### PR TITLE
Guard against races in Simulator deletion

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		AA56963A1B9FB7C800A2918F /* DVTiPhoneSimulatorRemoteClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA5696391B9FB7C800A2918F /* DVTiPhoneSimulatorRemoteClient.framework */; };
 		AA74B9991BB014A200C1E59C /* FBSimulatorError.h in Headers */ = {isa = PBXBuildFile; fileRef = AA74B9971BB014A200C1E59C /* FBSimulatorError.h */; settings = {ASSET_TAGS = (); }; };
 		AA74B99A1BB014A200C1E59C /* FBSimulatorError.m in Sources */ = {isa = PBXBuildFile; fileRef = AA74B9981BB014A200C1E59C /* FBSimulatorError.m */; settings = {ASSET_TAGS = (); }; };
+		AA74B99C1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA74B99B1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m */; settings = {ASSET_TAGS = (); }; };
 		AA819DB71B9FB40D002F58CA /* FBSimulatorControl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E291A4B50E500000001 /* FBSimulatorControl.framework */; };
 		AA8DFB101BAC76B60076A6C2 /* FBSimulatorControlNotificationAssertion.m in Sources */ = {isa = PBXBuildFile; fileRef = AA8DFB0D1BAC76B60076A6C2 /* FBSimulatorControlNotificationAssertion.m */; settings = {ASSET_TAGS = (); }; };
 		AA8DFB111BAC76B60076A6C2 /* FBSimulatorSessionStateAssertion.m in Sources */ = {isa = PBXBuildFile; fileRef = AA8DFB0F1BAC76B60076A6C2 /* FBSimulatorSessionStateAssertion.m */; settings = {ASSET_TAGS = (); }; };
@@ -788,6 +789,7 @@
 		AA5696391B9FB7C800A2918F /* DVTiPhoneSimulatorRemoteClient.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DVTiPhoneSimulatorRemoteClient.framework; path = ../../../../Applications/xcode7_beta6.app/Contents/SharedFrameworks/DVTiPhoneSimulatorRemoteClient.framework; sourceTree = "<group>"; };
 		AA74B9971BB014A200C1E59C /* FBSimulatorError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorError.h; sourceTree = "<group>"; };
 		AA74B9981BB014A200C1E59C /* FBSimulatorError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorError.m; sourceTree = "<group>"; };
+		AA74B99B1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorPoolAllocationTests.m; sourceTree = "<group>"; };
 		AA819DB21B9FB40D002F58CA /* FBSimulatorControlTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FBSimulatorControlTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA819E0B1B9FB427002F58CA /* FBSimulatorControlTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "FBSimulatorControlTests-Info.plist"; sourceTree = "<group>"; };
 		AA8DFB0C1BAC76B60076A6C2 /* FBSimulatorControlNotificationAssertion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorControlNotificationAssertion.h; sourceTree = "<group>"; };
@@ -1565,6 +1567,7 @@
 				AA51E4911BA1CA3C0053141E /* FBSimulatorControlApplicationLaunchTests.m */,
 				AA51E4921BA1CA3C0053141E /* FBSimulatorControlConfigurationTests.m */,
 				AA51E4931BA1CA3C0053141E /* FBSimulatorControlSimulatorLaunchTests.m */,
+				AA74B99B1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m */,
 				AA51E4941BA1CA3C0053141E /* FBSimulatorPoolTests.m */,
 				AA51E4951BA1CA3C0053141E /* FBSimulatorStateTests.m */,
 			);
@@ -1853,6 +1856,7 @@
 				AA51E49E1BA1CA3C0053141E /* FBSimulatorStateTests.m in Sources */,
 				AA51E49C1BA1CA3C0053141E /* FBSimulatorControlSimulatorLaunchTests.m in Sources */,
 				AA51E49D1BA1CA3C0053141E /* FBSimulatorPoolTests.m in Sources */,
+				AA74B99C1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m in Sources */,
 				AA51E4991BA1CA3C0053141E /* FBSimulatorApplicationTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FBSimulatorControl/Management/FBSimulatorPool.m
+++ b/FBSimulatorControl/Management/FBSimulatorPool.m
@@ -221,12 +221,12 @@
   // Deleting the device from the set can still leave it around for a few seconds.
   // in order to prevent racing with methods that may reallocate the newly-deleted device, we should wait for the device to no longer be present in the set.
   BOOL wasRemovedFromDeviceSet = [NSRunLoop.currentRunLoop spinRunLoopWithTimeout:30 untilTrue:^ BOOL {
-    NSSet *udidSet = [self.allPooledSimulators valueForKey:@"udid"];
+    NSOrderedSet *udidSet = [self.allPooledSimulators valueForKey:@"udid"];
     return ![udidSet containsObject:udid];
   }];
 
   if (!wasRemovedFromDeviceSet) {
-    return [[[FBSimulatorError describe:@"Simulator should have been removed from set but wasn't "] inSimulator:simulator] failBool:error];
+    return [[[FBSimulatorError describeFormat:@"Simulator with UDID %@ should have been removed from set but wasn't.", udid] inSimulator:simulator] failBool:error];
   }
 
   return YES;

--- a/FBSimulatorControlTests/Tests/FBSimulatorPoolAllocationTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorPoolAllocationTests.m
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <FBSimulatorControl/FBSimulatorControl.h>
+#import <FBSimulatorControl/FBSimulatorControl+Private.h>
+#import <FBSimulatorControl/FBSimulatorPool.h>
+#import <FBSimulatorControl/FBSimulatorControlConfiguration.h>
+#import <FBSimulatorControl/FBSimulatorApplication.h>
+#import <FBSimulatorControl/FBSimulator.h>
+#import <FBSimulatorControl/FBSimulatorConfiguration.h>
+
+@interface FBSimulatorPoolAllocationTests : XCTestCase
+
+@end
+
+@implementation FBSimulatorPoolAllocationTests
+
+#pragma mark Tests
+
+- (void)testReallocatesAndErasesFreedDevice
+{
+  FBSimulatorControlConfiguration *controlConfiguration = [FBSimulatorControlConfiguration
+    configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
+    bucket:0
+    options:FBSimulatorManagementOptionsEraseOnFree];
+
+  FBSimulatorControl *control = [[FBSimulatorControl alloc] initWithConfiguration:controlConfiguration];
+
+  NSError *error = nil;
+  FBSimulatorConfiguration *simulatorConfiguration = FBSimulatorConfiguration.iPhone5;
+  FBSimulator *simulator = [control.simulatorPool allocateSimulatorWithConfiguration:simulatorConfiguration error:&error];
+  XCTAssertNotNil(simulator);
+  XCTAssertNil(error);
+
+  NSString *simulatorUUID = simulator.udid;
+  [self addTemporaryFileToSimulator:simulator];
+
+  XCTAssertTrue([control.simulatorPool freeSimulator:simulator error:nil]);
+  XCTAssertNil(error);
+
+  simulator = [control.simulatorPool allocateSimulatorWithConfiguration:simulatorConfiguration error:&error];
+  XCTAssertNotNil(simulator);
+  XCTAssertNil(error);
+  XCTAssertEqualObjects(simulatorUUID, simulator.udid);
+  [self assertTemporaryFileForSimulator:simulator exists:NO];
+
+  XCTAssertTrue([control.simulatorPool freeSimulator:simulator error:nil]);
+  XCTAssertNil(error);
+}
+
+- (void)testDoesNotReallocateDeletedDevice
+{
+  FBSimulatorControlConfiguration *controlConfiguration = [FBSimulatorControlConfiguration
+    configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
+    bucket:0
+    options:FBSimulatorManagementOptionsDeleteOnFree];
+
+  FBSimulatorControl *control = [[FBSimulatorControl alloc] initWithConfiguration:controlConfiguration];
+
+  NSError *error = nil;
+  FBSimulatorConfiguration *simulatorConfiguration = FBSimulatorConfiguration.iPhone5;
+  FBSimulator *simulator = [control.simulatorPool allocateSimulatorWithConfiguration:simulatorConfiguration error:&error];
+  XCTAssertNotNil(simulator);
+  XCTAssertNil(error);
+
+  NSString *simulatorUUID = simulator.udid;
+
+  XCTAssertTrue([control.simulatorPool freeSimulator:simulator error:nil]);
+  XCTAssertNil(error);
+
+  simulator = [control.simulatorPool allocateSimulatorWithConfiguration:simulatorConfiguration error:&error];
+  XCTAssertNotNil(simulator);
+  XCTAssertNil(error);
+  XCTAssertNotEqualObjects(simulatorUUID, simulator.udid);
+
+  XCTAssertTrue([control.simulatorPool freeSimulator:simulator error:nil]);
+  XCTAssertNil(error);
+}
+
+- (void)testRemovesDeletedDeviceFromSet
+{
+  FBSimulatorControlConfiguration *controlConfiguration = [FBSimulatorControlConfiguration
+    configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
+    bucket:0
+    options:FBSimulatorManagementOptionsDeleteOnFree];
+
+  FBSimulatorControl *control = [[FBSimulatorControl alloc] initWithConfiguration:controlConfiguration];
+
+  NSError *error = nil;
+  FBSimulatorConfiguration *simulatorConfiguration = FBSimulatorConfiguration.iPhone5;
+  FBSimulator *simulator = [control.simulatorPool allocateSimulatorWithConfiguration:simulatorConfiguration error:&error];
+  XCTAssertNotNil(simulator);
+  XCTAssertNil(error);
+
+  NSString *simulatorUUID = simulator.udid;
+
+  XCTAssertTrue([control.simulatorPool freeSimulator:simulator error:nil]);
+  XCTAssertNil(error);
+
+  NSOrderedSet *uuidSet = [control.simulatorPool.allPooledSimulators valueForKey:@"udid"];
+  XCTAssertFalse([uuidSet containsObject:simulatorUUID]);
+}
+
+#pragma mark Helpers
+
+- (NSString *)temporaryFilePathForSimulator:(FBSimulator *)simulator
+{
+  return [[simulator.dataDirectory stringByAppendingPathComponent:@"something_temp"] stringByAppendingPathExtension:@"txt"];
+}
+
+- (void)addTemporaryFileToSimulator:(FBSimulator *)simulator
+{
+  XCTAssertTrue([@"Hi there I'm a file" writeToFile:[self temporaryFilePathForSimulator:simulator] atomically:YES encoding:NSUTF8StringEncoding error:nil]);
+}
+
+- (void)assertTemporaryFileForSimulator:(FBSimulator *)simulator exists:(BOOL)exists
+{
+  XCTAssertEqual([NSFileManager.defaultManager fileExistsAtPath:[self temporaryFilePathForSimulator:simulator]], exists);
+}
+
+@end


### PR DESCRIPTION
When running allocation/deletion repeatedly, it's possible to expose what looks to be [`-[SimDeviceSet deleteDevice:error:]`](https://github.com/facebook/FBSimulatorControl/blob/master/PrivateHeaders/CoreSimulator/SimDeviceSet.h#L37) returning too early. 

I've managed to reproduce frequent failure of the new `-[FBSimulatorPoolAllocationTests testRemovesDeletedDeviceFromSet]` test, which can also be exposed in the startup path of `FBSimulatorControl`.

Instead of relying on the `SimDeviceSet` API doing the right thing, we can block on the existence of the newly-deleted Simulator in the DeviceSet and fail if this times out.