### PR TITLE
Configurable prefix for Pool-Managed Simulators

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		AA74B9991BB014A200C1E59C /* FBSimulatorError.h in Headers */ = {isa = PBXBuildFile; fileRef = AA74B9971BB014A200C1E59C /* FBSimulatorError.h */; settings = {ASSET_TAGS = (); }; };
 		AA74B99A1BB014A200C1E59C /* FBSimulatorError.m in Sources */ = {isa = PBXBuildFile; fileRef = AA74B9981BB014A200C1E59C /* FBSimulatorError.m */; settings = {ASSET_TAGS = (); }; };
 		AA74B99C1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA74B99B1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m */; settings = {ASSET_TAGS = (); }; };
+		AA74B99E1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA74B99D1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m */; settings = {ASSET_TAGS = (); }; };
 		AA819DB71B9FB40D002F58CA /* FBSimulatorControl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E291A4B50E500000001 /* FBSimulatorControl.framework */; };
 		AA8DFB101BAC76B60076A6C2 /* FBSimulatorControlNotificationAssertion.m in Sources */ = {isa = PBXBuildFile; fileRef = AA8DFB0D1BAC76B60076A6C2 /* FBSimulatorControlNotificationAssertion.m */; settings = {ASSET_TAGS = (); }; };
 		AA8DFB111BAC76B60076A6C2 /* FBSimulatorSessionStateAssertion.m in Sources */ = {isa = PBXBuildFile; fileRef = AA8DFB0F1BAC76B60076A6C2 /* FBSimulatorSessionStateAssertion.m */; settings = {ASSET_TAGS = (); }; };
@@ -790,6 +791,7 @@
 		AA74B9971BB014A200C1E59C /* FBSimulatorError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorError.h; sourceTree = "<group>"; };
 		AA74B9981BB014A200C1E59C /* FBSimulatorError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorError.m; sourceTree = "<group>"; };
 		AA74B99B1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorPoolAllocationTests.m; sourceTree = "<group>"; };
+		AA74B99D1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBProcessLaunchConfigurationTests.m; sourceTree = "<group>"; };
 		AA819DB21B9FB40D002F58CA /* FBSimulatorControlTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FBSimulatorControlTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA819E0B1B9FB427002F58CA /* FBSimulatorControlTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "FBSimulatorControlTests-Info.plist"; sourceTree = "<group>"; };
 		AA8DFB0C1BAC76B60076A6C2 /* FBSimulatorControlNotificationAssertion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorControlNotificationAssertion.h; sourceTree = "<group>"; };
@@ -1563,6 +1565,7 @@
 		AA51E48F1BA1CA3C0053141E /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				AA74B99D1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m */,
 				AA51E4901BA1CA3C0053141E /* FBSimulatorApplicationTests.m */,
 				AA51E4911BA1CA3C0053141E /* FBSimulatorControlApplicationLaunchTests.m */,
 				AA51E4921BA1CA3C0053141E /* FBSimulatorControlConfigurationTests.m */,
@@ -1852,6 +1855,7 @@
 				AA51E49A1BA1CA3C0053141E /* FBSimulatorControlApplicationLaunchTests.m in Sources */,
 				AA51E49B1BA1CA3C0053141E /* FBSimulatorControlConfigurationTests.m in Sources */,
 				AA8DFB111BAC76B60076A6C2 /* FBSimulatorSessionStateAssertion.m in Sources */,
+				AA74B99E1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m in Sources */,
 				AA8DFB101BAC76B60076A6C2 /* FBSimulatorControlNotificationAssertion.m in Sources */,
 				AA51E49E1BA1CA3C0053141E /* FBSimulatorStateTests.m in Sources */,
 				AA51E49C1BA1CA3C0053141E /* FBSimulatorControlSimulatorLaunchTests.m in Sources */,

--- a/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.h
@@ -11,6 +11,11 @@
 
 @class FBSimulatorApplication;
 
+/**
+ The default prefix for Pool-Managed Simulators
+ */
+extern NSString *const FBSimulatorControlConfigurationDefaultNamePrefix;
+
 typedef NS_OPTIONS(NSUInteger, FBSimulatorManagementOptions){
   FBSimulatorManagementOptionsDeleteManagedSimulatorsOnFirstStart = 1 << 0,
   FBSimulatorManagementOptionsKillUnmanagedSimulatorsOnFirstStart = 1 << 1,
@@ -27,16 +32,23 @@ typedef NS_OPTIONS(NSUInteger, FBSimulatorManagementOptions){
  Creates and returns a new Configuration with the provided parameters.
 
  @param simulatorApplication the FBSimulatorApplication for the Simulator.app.
+ @param namePrefix the String to prefix all `FBSimulatorControl` managed Simulators with. Will default to 'E2E' if nil.
  @param bucketID the Bucket of the launched Simulators. Multiple processes cannot share the same Bucket ID.
  @param options the options for Simulator Management.
  @returns a new Configuration Object with the arguments applied.
  */
-+ (instancetype)configurationWithSimulatorApplication:(FBSimulatorApplication *)simulatorApplication bucket:(NSInteger)bucketID options:(FBSimulatorManagementOptions)options;
++ (instancetype)configurationWithSimulatorApplication:(FBSimulatorApplication *)simulatorApplication namePrefix:(NSString *)namePrefix bucket:(NSInteger)bucketID options:(FBSimulatorManagementOptions)options;
 
 /**
  The FBSimulatorApplication for the Simulator.app.
  */
 @property (nonatomic, copy, readonly) FBSimulatorApplication *simulatorApplication;
+
+/**
+ The String to prefix all `FBSimulatorControl` Simulators with.
+ Simulators in the same Pool will share the same `namePrefix` and `bucketID`.
+ */
+@property (nonatomic, copy, readonly) NSString *namePrefix;
 
 /**
  The Bucket of the launched Simulators. Multiple processes cannot share the same Bucket ID.

--- a/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.m
@@ -11,9 +11,12 @@
 
 #import "FBSimulatorApplication.h"
 
+NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
+
 @interface FBSimulatorControlConfiguration ()
 
 @property (nonatomic, copy, readwrite) FBSimulatorApplication *simulatorApplication;
+@property (nonatomic, copy, readwrite) NSString *namePrefix;
 @property (nonatomic, assign, readwrite) NSInteger bucketID;
 @property (nonatomic, assign, readwrite) FBSimulatorManagementOptions options;
 
@@ -21,13 +24,14 @@
 
 @implementation FBSimulatorControlConfiguration
 
-+ (instancetype)configurationWithSimulatorApplication:(FBSimulatorApplication *)simulatorApplication bucket:(NSInteger)bucketID options:(FBSimulatorManagementOptions)options
++ (instancetype)configurationWithSimulatorApplication:(FBSimulatorApplication *)simulatorApplication namePrefix:(NSString *)namePrefix bucket:(NSInteger)bucketID options:(FBSimulatorManagementOptions)options
 {
   NSParameterAssert(simulatorApplication);
   NSParameterAssert(bucketID >= 0);
 
   FBSimulatorControlConfiguration *configuration = [self new];
   configuration.simulatorApplication = simulatorApplication;
+  configuration.namePrefix = namePrefix.length > 0 ? namePrefix : FBSimulatorControlConfigurationDefaultNamePrefix;
   configuration.bucketID = bucketID;
   configuration.options = options;
   return configuration;
@@ -37,13 +41,14 @@
 {
   return [self.class
     configurationWithSimulatorApplication:self.simulatorApplication
+    namePrefix:self.namePrefix
     bucket:self.bucketID
     options:self.options];
 }
 
 - (NSUInteger)hash
 {
-  return self.simulatorApplication.hash | self.bucketID | self.options;
+  return self.simulatorApplication.hash | self.namePrefix.hash | self.bucketID | self.options;
 }
 
 - (BOOL)isEqual:(FBSimulatorControlConfiguration *)object
@@ -52,15 +57,17 @@
     return NO;
   }
   return [self.simulatorApplication isEqual:object.simulatorApplication] &&
-  self.options == object.options &&
-  self.bucketID == object.bucketID;
+         [self.namePrefix isEqualToString:object.namePrefix] &&
+         self.bucketID == object.bucketID &&
+         self.options == object.options;
 }
 
 - (NSString *)description
 {
   return [NSString stringWithFormat:
-    @"Pool Config | Sim App %@ | Bucket Id %ld | Options %ld",
+    @"Pool Config | Sim App %@ | Prefix %@ | Bucket Id %ld | Options %ld",
     self.simulatorApplication,
+    self.namePrefix,
     self.bucketID,
     self.options
   ];

--- a/FBSimulatorControl/Management/FBSimulatorPool+Private.h
+++ b/FBSimulatorControl/Management/FBSimulatorPool+Private.h
@@ -13,7 +13,8 @@
 
 @property (nonatomic, copy, readwrite) FBSimulatorControlConfiguration *configuration;
 
-@property (nonatomic, strong) SimDeviceSet *deviceSet;
-@property (nonatomic, strong) NSMutableOrderedSet *allocatedWorkingSet;
+@property (nonatomic, strong, readwrite) SimDeviceSet *deviceSet;
+@property (nonatomic, strong, readwrite) NSMutableOrderedSet *allocatedWorkingSet;
+@property (nonatomic, strong, readwrite) NSRegularExpression *managedSimulatorPoolOffsetRegex;
 
 @end

--- a/FBSimulatorControlTests/Tests/FBProcessLaunchConfigurationTests.m
+++ b/FBSimulatorControlTests/Tests/FBProcessLaunchConfigurationTests.m
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <FBSimulatorControl/FBProcessLaunchConfiguration.h>
+#import <FBSimulatorControl/FBSimulatorApplication.h>
+
+@interface FBProcessLaunchConfigurationTests : XCTestCase
+
+@end
+
+@implementation FBProcessLaunchConfigurationTests
+
+- (void)testEqualityOfCopy
+{
+  FBSimulatorApplication *application = [[FBSimulatorApplication simulatorSystemApplications] firstObject];
+
+  FBApplicationLaunchConfiguration *appLaunchConfig = [FBApplicationLaunchConfiguration
+    configurationWithApplication:application
+    arguments:@[@"FOOBAR"]
+    environment:@{@"BING" : @"BAZ"}];
+  FBApplicationLaunchConfiguration *appLaunchConfigCopy = [appLaunchConfig copy];
+
+  XCTAssertEqualObjects(appLaunchConfig.application, appLaunchConfigCopy.application);
+  XCTAssertEqualObjects(appLaunchConfig.arguments, appLaunchConfigCopy.arguments);
+  XCTAssertEqualObjects(appLaunchConfig.environment, appLaunchConfigCopy.environment);
+  XCTAssertEqualObjects(appLaunchConfig, appLaunchConfigCopy);
+
+  FBAgentLaunchConfiguration *agentLaunchConfig = [FBAgentLaunchConfiguration
+    configurationWithBinary:application.binary
+    arguments:@[@"BINGBONG"]
+    environment:@{@"FIB" : @"BLE"}];
+  FBAgentLaunchConfiguration *agentLaunchConfigCopy = [agentLaunchConfig copy];
+
+  XCTAssertEqualObjects(agentLaunchConfig.agentBinary, agentLaunchConfigCopy.agentBinary);
+  XCTAssertEqualObjects(agentLaunchConfig.arguments, agentLaunchConfigCopy.arguments);
+  XCTAssertEqualObjects(agentLaunchConfig.environment, agentLaunchConfigCopy.environment);
+  XCTAssertEqualObjects(agentLaunchConfig, agentLaunchConfigCopy);
+}
+
+@end

--- a/FBSimulatorControlTests/Tests/FBSimulatorControlApplicationLaunchTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorControlApplicationLaunchTests.m
@@ -47,6 +47,7 @@
 
   FBSimulatorControlConfiguration *configuration = [FBSimulatorControlConfiguration
     configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
+    namePrefix:nil
     bucket:0
     options:options];
 

--- a/FBSimulatorControlTests/Tests/FBSimulatorControlConfigurationTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorControlConfigurationTests.m
@@ -11,13 +11,8 @@
 
 #import <OCMock/OCMock.h>
 
-#import <FBSimulatorControl/FBProcessLaunchConfiguration.h>
-#import <FBSimulatorControl/FBSimulator.h>
 #import <FBSimulatorControl/FBSimulatorApplication.h>
 #import <FBSimulatorControl/FBSimulatorControlConfiguration.h>
-#import <FBSimulatorControl/FBSimulatorPool.h>
-#import <CoreSimulator/SimDevice.h>
-#import <CoreSimulator/SimDeviceSet.h>
 
 @interface FBSimulatorControlConfigurationTests : XCTestCase
 
@@ -25,36 +20,22 @@
 
 @implementation FBSimulatorControlConfigurationTests
 
-- (void)testEquality
+- (void)testEqualityOfCopy
 {
   FBSimulatorApplication *application = [FBSimulatorApplication simulatorApplicationWithError:nil];
 
   FBSimulatorControlConfiguration *config = [FBSimulatorControlConfiguration
-    configurationWithSimulatorApplication:application bucket:1 options:FBSimulatorManagementOptionsDeleteManagedSimulatorsOnFirstStart];
+    configurationWithSimulatorApplication:application
+    namePrefix:@"TestEnv"
+    bucket:1
+    options:FBSimulatorManagementOptionsDeleteManagedSimulatorsOnFirstStart];
   FBSimulatorControlConfiguration *configCopy = [config copy];
 
   XCTAssertEqualObjects(config.simulatorApplication, configCopy.simulatorApplication);
+  XCTAssertEqualObjects(config.namePrefix, configCopy.namePrefix);
   XCTAssertEqual(config.bucketID, configCopy.bucketID);
   XCTAssertEqual(config.options, configCopy.options);
   XCTAssertEqualObjects(config, configCopy);
-
-  FBApplicationLaunchConfiguration *appLaunchConfig = [FBApplicationLaunchConfiguration
-    configurationWithApplication:application arguments:@[@"FOOBAR"] environment:@{@"BING" : @"BAZ"}];
-  FBApplicationLaunchConfiguration *appLaunchConfigCopy = [appLaunchConfig copy];
-
-  XCTAssertEqualObjects(appLaunchConfig.application, appLaunchConfigCopy.application);
-  XCTAssertEqualObjects(appLaunchConfig.arguments, appLaunchConfigCopy.arguments);
-  XCTAssertEqualObjects(appLaunchConfig.environment, appLaunchConfigCopy.environment);
-  XCTAssertEqualObjects(appLaunchConfig, appLaunchConfigCopy);
-
-  FBAgentLaunchConfiguration *agentLaunchConfig = [FBAgentLaunchConfiguration
-    configurationWithBinary:application.binary arguments:@[@"BINGBONG"] environment:@{@"FIB" : @"BLE"}];
-  FBAgentLaunchConfiguration *agentLaunchConfigCopy = [agentLaunchConfig copy];
-
-  XCTAssertEqualObjects(agentLaunchConfig.agentBinary, agentLaunchConfigCopy.agentBinary);
-  XCTAssertEqualObjects(agentLaunchConfig.arguments, agentLaunchConfigCopy.arguments);
-  XCTAssertEqualObjects(agentLaunchConfig.environment, agentLaunchConfigCopy.environment);
-  XCTAssertEqualObjects(agentLaunchConfig, agentLaunchConfigCopy);
 }
 
 @end

--- a/FBSimulatorControlTests/Tests/FBSimulatorControlSimulatorLaunchTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorControlSimulatorLaunchTests.m
@@ -53,6 +53,7 @@
 
   FBSimulatorControlConfiguration *configuration = [FBSimulatorControlConfiguration
     configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
+    namePrefix:nil
     bucket:0
     options:options];
 

--- a/FBSimulatorControlTests/Tests/FBSimulatorPoolAllocationTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorPoolAllocationTests.m
@@ -29,6 +29,7 @@
 {
   FBSimulatorControlConfiguration *controlConfiguration = [FBSimulatorControlConfiguration
     configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
+    namePrefix:nil
     bucket:0
     options:FBSimulatorManagementOptionsEraseOnFree];
 
@@ -60,6 +61,7 @@
 {
   FBSimulatorControlConfiguration *controlConfiguration = [FBSimulatorControlConfiguration
     configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
+    namePrefix:nil
     bucket:0
     options:FBSimulatorManagementOptionsDeleteOnFree];
 
@@ -89,6 +91,7 @@
 {
   FBSimulatorControlConfiguration *controlConfiguration = [FBSimulatorControlConfiguration
     configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
+    namePrefix:nil
     bucket:0
     options:FBSimulatorManagementOptionsDeleteOnFree];
 

--- a/FBSimulatorControlTests/Tests/FBSimulatorPoolTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorPoolTests.m
@@ -64,6 +64,7 @@
 
   FBSimulatorControlConfiguration *poolConfig = [FBSimulatorControlConfiguration
     configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
+    namePrefix:nil
     bucket:1
     options:0];
   self.pool = [FBSimulatorPool poolWithConfiguration:poolConfig deviceSet:(id)deviceSet];


### PR DESCRIPTION
Adds an additional property to `FBSimulatorControlConfiguration` to allow for prefixes other than `E2E`. A prefix *must* be non-empty for the meantime, until it is possible to work this out with a separately managed `SimDeviceSet`.