### PR TITLE
Increase runloop spin frequency

### DIFF
--- a/FBSimulatorControl/Management/FBSimulatorPool.m
+++ b/FBSimulatorControl/Management/FBSimulatorPool.m
@@ -29,6 +29,8 @@
 #import <CoreSimulator/SimDeviceType.h>
 #import <CoreSimulator/SimRuntime.h>
 
+static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
+
 @implementation FBSimulatorPool
 
 #pragma mark - Initializers
@@ -186,7 +188,7 @@
 
 - (BOOL)waitForDevice:(SimDevice *)device toChangeToState:(FBSimulatorState)simulatorState withError:(NSError **)error
 {
-  BOOL didChangeState = [NSRunLoop.currentRunLoop spinRunLoopWithTimeout:30 untilTrue:^ BOOL {
+  BOOL didChangeState = [NSRunLoop.currentRunLoop spinRunLoopWithTimeout:FBSimulatorPoolDefaultWait untilTrue:^ BOOL {
     return [FBSimulator simulatorStateFromStateString:device.stateString] == simulatorState;
   }];
   if (!didChangeState) {
@@ -220,7 +222,7 @@
 
   // Deleting the device from the set can still leave it around for a few seconds.
   // in order to prevent racing with methods that may reallocate the newly-deleted device, we should wait for the device to no longer be present in the set.
-  BOOL wasRemovedFromDeviceSet = [NSRunLoop.currentRunLoop spinRunLoopWithTimeout:30 untilTrue:^ BOOL {
+  BOOL wasRemovedFromDeviceSet = [NSRunLoop.currentRunLoop spinRunLoopWithTimeout:FBSimulatorPoolDefaultWait untilTrue:^ BOOL {
     NSOrderedSet *udidSet = [self.allPooledSimulators valueForKey:@"udid"];
     return ![udidSet containsObject:udid];
   }];

--- a/FBSimulatorControl/Utility/NSRunLoop+SimulatorControlAdditions.h
+++ b/FBSimulatorControl/Utility/NSRunLoop+SimulatorControlAdditions.h
@@ -15,10 +15,10 @@
 @interface NSRunLoop (SimulatorControlAdditions)
 
 /**
- Spins the Run Loop until `untilTrue` returns YES or a timeout is reached
+ Spins the Run Loop until `untilTrue` returns YES or a timeout is reached.
 
- @oaram timeout the Timeout in Seconds
- @param untilTrue the condition to meet
+ @oaram timeout the Timeout in Seconds.
+ @param untilTrue the condition to meet.
  @returns YES if the condition was met, NO if the timeout was reached first.
  */
 - (BOOL)spinRunLoopWithTimeout:(NSTimeInterval)timeout untilTrue:( BOOL (^)(void) )untilTrue;

--- a/FBSimulatorControl/Utility/NSRunLoop+SimulatorControlAdditions.m
+++ b/FBSimulatorControl/Utility/NSRunLoop+SimulatorControlAdditions.m
@@ -19,8 +19,8 @@
       if ([date timeIntervalSinceNow] < 0) {
         return NO;
       }
-      // Wait for 1s
-      [self runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1]];
+      // Wait for 100ms
+      [self runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
     }
   }
   return YES;


### PR DESCRIPTION
We probably waste a lot of time waiting on conditions that resolve very quickly. Instead of waiting for this every second we can still be prudent in terms of system resources (by not checking the condition continuously) but also resolve conditions faster by setting this to 100ms instead