### PR TITLE
Add test for unexpected application termination notifications

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		AA74B99C1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA74B99B1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m */; settings = {ASSET_TAGS = (); }; };
 		AA74B99E1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA74B99D1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m */; settings = {ASSET_TAGS = (); }; };
 		AA819DB71B9FB40D002F58CA /* FBSimulatorControl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E291A4B50E500000001 /* FBSimulatorControl.framework */; };
+		AA8DF8C01BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA8DF8BF1BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m */; settings = {ASSET_TAGS = (); }; };
 		AA8DFB101BAC76B60076A6C2 /* FBSimulatorControlNotificationAssertion.m in Sources */ = {isa = PBXBuildFile; fileRef = AA8DFB0D1BAC76B60076A6C2 /* FBSimulatorControlNotificationAssertion.m */; settings = {ASSET_TAGS = (); }; };
 		AA8DFB111BAC76B60076A6C2 /* FBSimulatorSessionStateAssertion.m in Sources */ = {isa = PBXBuildFile; fileRef = AA8DFB0F1BAC76B60076A6C2 /* FBSimulatorSessionStateAssertion.m */; settings = {ASSET_TAGS = (); }; };
 		AAC083751B9FB88B00451648 /* CoreSimulator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E29B6970A5500000000 /* CoreSimulator.framework */; };
@@ -794,6 +795,7 @@
 		AA74B99D1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBProcessLaunchConfigurationTests.m; sourceTree = "<group>"; };
 		AA819DB21B9FB40D002F58CA /* FBSimulatorControlTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FBSimulatorControlTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA819E0B1B9FB427002F58CA /* FBSimulatorControlTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "FBSimulatorControlTests-Info.plist"; sourceTree = "<group>"; };
+		AA8DF8BF1BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorSessionLifecycleTests.m; sourceTree = "<group>"; };
 		AA8DFB0C1BAC76B60076A6C2 /* FBSimulatorControlNotificationAssertion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorControlNotificationAssertion.h; sourceTree = "<group>"; };
 		AA8DFB0D1BAC76B60076A6C2 /* FBSimulatorControlNotificationAssertion.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorControlNotificationAssertion.m; sourceTree = "<group>"; };
 		AA8DFB0E1BAC76B60076A6C2 /* FBSimulatorSessionStateAssertion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorSessionStateAssertion.h; sourceTree = "<group>"; };
@@ -1572,6 +1574,7 @@
 				AA51E4931BA1CA3C0053141E /* FBSimulatorControlSimulatorLaunchTests.m */,
 				AA74B99B1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m */,
 				AA51E4941BA1CA3C0053141E /* FBSimulatorPoolTests.m */,
+				AA8DF8BF1BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m */,
 				AA51E4951BA1CA3C0053141E /* FBSimulatorStateTests.m */,
 			);
 			path = Tests;
@@ -1853,6 +1856,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA51E49A1BA1CA3C0053141E /* FBSimulatorControlApplicationLaunchTests.m in Sources */,
+				AA8DF8C01BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m in Sources */,
 				AA51E49B1BA1CA3C0053141E /* FBSimulatorControlConfigurationTests.m in Sources */,
 				AA8DFB111BAC76B60076A6C2 /* FBSimulatorSessionStateAssertion.m in Sources */,
 				AA74B99E1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m in Sources */,

--- a/FBSimulatorControl/Management/FBSimulatorPool.m
+++ b/FBSimulatorControl/Management/FBSimulatorPool.m
@@ -29,6 +29,8 @@
 #import <CoreSimulator/SimDeviceType.h>
 #import <CoreSimulator/SimRuntime.h>
 
+static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
+
 @implementation FBSimulatorPool
 
 #pragma mark - Initializers
@@ -186,7 +188,7 @@
 
 - (BOOL)waitForDevice:(SimDevice *)device toChangeToState:(FBSimulatorState)simulatorState withError:(NSError **)error
 {
-  BOOL didChangeState = [NSRunLoop.currentRunLoop spinRunLoopWithTimeout:30 untilTrue:^ BOOL {
+  BOOL didChangeState = [NSRunLoop.currentRunLoop spinRunLoopWithTimeout:FBSimulatorPoolDefaultWait untilTrue:^ BOOL {
     return [FBSimulator simulatorStateFromStateString:device.stateString] == simulatorState;
   }];
   if (!didChangeState) {
@@ -220,7 +222,7 @@
 
   // Deleting the device from the set can still leave it around for a few seconds.
   // in order to prevent racing with methods that may reallocate the newly-deleted device, we should wait for the device to no longer be present in the set.
-  BOOL wasRemovedFromDeviceSet = [NSRunLoop.currentRunLoop spinRunLoopWithTimeout:30 untilTrue:^ BOOL {
+  BOOL wasRemovedFromDeviceSet = [NSRunLoop.currentRunLoop spinRunLoopWithTimeout:FBSimulatorPoolDefaultWait untilTrue:^ BOOL {
     NSOrderedSet *udidSet = [self.allPooledSimulators valueForKey:@"udid"];
     return ![udidSet containsObject:udid];
   }];

--- a/FBSimulatorControl/Utility/NSRunLoop+SimulatorControlAdditions.h
+++ b/FBSimulatorControl/Utility/NSRunLoop+SimulatorControlAdditions.h
@@ -15,10 +15,10 @@
 @interface NSRunLoop (SimulatorControlAdditions)
 
 /**
- Spins the Run Loop until `untilTrue` returns YES or a timeout is reached
+ Spins the Run Loop until `untilTrue` returns YES or a timeout is reached.
 
- @oaram timeout the Timeout in Seconds
- @param untilTrue the condition to meet
+ @oaram timeout the Timeout in Seconds.
+ @param untilTrue the condition to meet.
  @returns YES if the condition was met, NO if the timeout was reached first.
  */
 - (BOOL)spinRunLoopWithTimeout:(NSTimeInterval)timeout untilTrue:( BOOL (^)(void) )untilTrue;

--- a/FBSimulatorControl/Utility/NSRunLoop+SimulatorControlAdditions.m
+++ b/FBSimulatorControl/Utility/NSRunLoop+SimulatorControlAdditions.m
@@ -19,8 +19,8 @@
       if ([date timeIntervalSinceNow] < 0) {
         return NO;
       }
-      // Wait for 1s
-      [self runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1]];
+      // Wait for 100ms
+      [self runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
     }
   }
   return YES;

--- a/FBSimulatorControlTests/Tests/FBSimulatorSessionLifecycleTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorSessionLifecycleTests.m
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <FBSimulatorControl/FBProcessLaunchConfiguration.h>
+#import <FBSimulatorControl/FBSimulator.h>
+#import <FBSimulatorControl/FBSimulatorApplication.h>
+#import <FBSimulatorControl/FBSimulatorConfiguration.h>
+#import <FBSimulatorControl/FBSimulatorControl.h>
+#import <FBSimulatorControl/FBSimulatorControl+Private.h>
+#import <FBSimulatorControl/FBSimulatorControlConfiguration.h>
+#import <FBSimulatorControl/FBSimulatorProcess.h>
+#import <FBSimulatorControl/FBSimulatorSession.h>
+#import <FBSimulatorControl/FBSimulatorSessionInteraction.h>
+#import <FBSimulatorControl/FBSimulatorSessionLifecycle.h>
+#import <FBSimulatorControl/FBSimulatorSessionState.h>
+#import <FBSimulatorControl/FBSimulatorSessionState+Queries.h>
+#import <FBSimulatorControl/NSRunLoop+SimulatorControlAdditions.h>
+
+@interface FBSimulatorSessionLifecycleTests : XCTestCase
+
+@property (nonatomic, strong) FBSimulatorControl *control;
+
+@end
+
+@implementation FBSimulatorSessionLifecycleTests
+
+- (void)setUp
+{
+  FBSimulatorManagementOptions options =
+  FBSimulatorManagementOptionsDeleteManagedSimulatorsOnFirstStart |
+  FBSimulatorManagementOptionsKillUnmanagedSimulatorsOnFirstStart |
+  FBSimulatorManagementOptionsDeleteOnFree;
+
+  FBSimulatorControlConfiguration *configuration = [FBSimulatorControlConfiguration
+    configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
+    namePrefix:nil
+    bucket:0
+    options:options];
+
+  self.control = [[FBSimulatorControl alloc] initWithConfiguration:configuration];
+}
+
+- (void)testNotifiedByUnexpectedApplicationTermination
+{
+  NSError *error = nil;
+  FBSimulatorSession *session = [self.control createSessionForSimulatorConfiguration:FBSimulatorConfiguration.iPhone5 error:&error];
+
+  FBApplicationLaunchConfiguration *appLaunch = [FBApplicationLaunchConfiguration
+    configurationWithApplication:[FBSimulatorApplication systemApplicationNamed:@"MobileSafari"]
+    arguments:@[]
+    environment:@{}];
+
+  BOOL success = [[[session.interact
+    bootSimulator]
+    launchApplication:appLaunch]
+    performInteractionWithError:&error];
+
+  XCTAssertTrue(success);
+  XCTAssertNil(error);
+
+  FBUserLaunchedProcess *process = [session.state processForApplication:appLaunch.application];
+  XCTAssertNotNil(process);
+  if (!process) {
+    // Need to guard against continuing the test in case the PID is 0 or -1 to avoid nuking the machine.
+    return;
+  }
+
+  __block BOOL notificationRecieved = NO;
+  __block BOOL wasUnexpected = NO;
+
+  id token = [NSNotificationCenter.defaultCenter
+    addObserverForName:FBSimulatorSessionApplicationProcessDidTerminateNotification
+    object:session
+    queue:NSOperationQueue.mainQueue
+    usingBlock:^(NSNotification *notification) {
+      notificationRecieved = YES;
+      wasUnexpected = ![notification.userInfo[FBSimulatorSessionExpectedKey] boolValue];
+    }];
+
+  XCTAssertEqual(kill((pid_t)process.processIdentifier, SIGKILL), 0);
+
+  BOOL didMeetConditionBeforeTimeout = [NSRunLoop.currentRunLoop spinRunLoopWithTimeout:10 untilTrue:^ BOOL {
+    return notificationRecieved == YES;
+  }];
+
+  XCTAssertTrue(didMeetConditionBeforeTimeout);
+  XCTAssertTrue(wasUnexpected);
+  [NSNotificationCenter.defaultCenter removeObserver:token];
+}
+
+@end

--- a/FBSimulatorControlTests/Tests/FBSimulatorSessionLifecycleTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorSessionLifecycleTests.m
@@ -94,6 +94,60 @@
   XCTAssertTrue(didMeetConditionBeforeTimeout);
   XCTAssertTrue(wasUnexpected);
   [NSNotificationCenter.defaultCenter removeObserver:token];
+
+  XCTAssertFalse([session.state processForApplication:appLaunch.application]);
 }
+
+- (void)testNotifiedByExpectedApplicationTermination
+{
+  NSError *error = nil;
+  FBSimulatorSession *session = [self.control createSessionForSimulatorConfiguration:FBSimulatorConfiguration.iPhone5 error:&error];
+
+  FBApplicationLaunchConfiguration *appLaunch = [FBApplicationLaunchConfiguration
+    configurationWithApplication:[FBSimulatorApplication systemApplicationNamed:@"MobileSafari"]
+    arguments:@[]
+    environment:@{}];
+
+  BOOL success = [[[session.interact
+    bootSimulator]
+    launchApplication:appLaunch]
+    performInteractionWithError:&error];
+
+  XCTAssertTrue(success);
+  XCTAssertNil(error);
+
+  FBUserLaunchedProcess *process = [session.state processForApplication:appLaunch.application];
+  XCTAssertNotNil(process);
+  if (!process) {
+    // Need to guard against continuing the test in case the PID is 0 or -1 to avoid nuking the machine.
+    return;
+  }
+
+  __block BOOL notificationRecieved = NO;
+  __block BOOL wasExpected = NO;
+
+  id token = [NSNotificationCenter.defaultCenter
+    addObserverForName:FBSimulatorSessionApplicationProcessDidTerminateNotification
+    object:session
+    queue:NSOperationQueue.mainQueue
+    usingBlock:^(NSNotification *notification) {
+      notificationRecieved = YES;
+      wasExpected = [notification.userInfo[FBSimulatorSessionExpectedKey] boolValue];
+    }];
+
+  XCTAssertTrue([[session.interact killApplication:appLaunch.application] performInteractionWithError:&error]);
+  XCTAssertNil(error);
+
+  BOOL didMeetConditionBeforeTimeout = [NSRunLoop.currentRunLoop spinRunLoopWithTimeout:10 untilTrue:^ BOOL {
+    return notificationRecieved == YES;
+  }];
+
+  XCTAssertTrue(didMeetConditionBeforeTimeout);
+  XCTAssertTrue(wasExpected);
+  [NSNotificationCenter.defaultCenter removeObserver:token];
+
+  XCTAssertFalse([session.state processForApplication:appLaunch.application]);
+}
+
 
 @end


### PR DESCRIPTION
In #10 @arpadzalan was looking for a way to assert that some process dies in order to terminate the test. This adds a test for an unexpected Application Notification.