### PR TITLE
Extract Interactions to base class

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -88,11 +88,13 @@
 		AA51E49E1BA1CA3C0053141E /* FBSimulatorStateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA51E4951BA1CA3C0053141E /* FBSimulatorStateTests.m */; settings = {ASSET_TAGS = (); }; };
 		AA5696381B9FB7B500A2918F /* DVTFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA5696371B9FB7B500A2918F /* DVTFoundation.framework */; };
 		AA56963A1B9FB7C800A2918F /* DVTiPhoneSimulatorRemoteClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA5696391B9FB7C800A2918F /* DVTiPhoneSimulatorRemoteClient.framework */; };
-		AA74B9991BB014A200C1E59C /* FBSimulatorError.h in Headers */ = {isa = PBXBuildFile; fileRef = AA74B9971BB014A200C1E59C /* FBSimulatorError.h */; settings = {ASSET_TAGS = (); }; };
+		AA74B9991BB014A200C1E59C /* FBSimulatorError.h in Headers */ = {isa = PBXBuildFile; fileRef = AA74B9971BB014A200C1E59C /* FBSimulatorError.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA74B99A1BB014A200C1E59C /* FBSimulatorError.m in Sources */ = {isa = PBXBuildFile; fileRef = AA74B9981BB014A200C1E59C /* FBSimulatorError.m */; settings = {ASSET_TAGS = (); }; };
 		AA74B99C1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA74B99B1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m */; settings = {ASSET_TAGS = (); }; };
 		AA74B99E1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA74B99D1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m */; settings = {ASSET_TAGS = (); }; };
 		AA819DB71B9FB40D002F58CA /* FBSimulatorControl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E291A4B50E500000001 /* FBSimulatorControl.framework */; };
+		AA8DF8C31BB1842600CC0411 /* FBInteraction.h in Headers */ = {isa = PBXBuildFile; fileRef = AA8DF8C11BB1842600CC0411 /* FBInteraction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA8DF8C41BB1842600CC0411 /* FBInteraction.m in Sources */ = {isa = PBXBuildFile; fileRef = AA8DF8C21BB1842600CC0411 /* FBInteraction.m */; settings = {ASSET_TAGS = (); }; };
 		AA8DFB101BAC76B60076A6C2 /* FBSimulatorControlNotificationAssertion.m in Sources */ = {isa = PBXBuildFile; fileRef = AA8DFB0D1BAC76B60076A6C2 /* FBSimulatorControlNotificationAssertion.m */; settings = {ASSET_TAGS = (); }; };
 		AA8DFB111BAC76B60076A6C2 /* FBSimulatorSessionStateAssertion.m in Sources */ = {isa = PBXBuildFile; fileRef = AA8DFB0F1BAC76B60076A6C2 /* FBSimulatorSessionStateAssertion.m */; settings = {ASSET_TAGS = (); }; };
 		AAC083751B9FB88B00451648 /* CoreSimulator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E29B6970A5500000000 /* CoreSimulator.framework */; };
@@ -794,6 +796,9 @@
 		AA74B99D1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBProcessLaunchConfigurationTests.m; sourceTree = "<group>"; };
 		AA819DB21B9FB40D002F58CA /* FBSimulatorControlTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FBSimulatorControlTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA819E0B1B9FB427002F58CA /* FBSimulatorControlTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "FBSimulatorControlTests-Info.plist"; sourceTree = "<group>"; };
+		AA8DF8C11BB1842600CC0411 /* FBInteraction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBInteraction.h; sourceTree = "<group>"; };
+		AA8DF8C21BB1842600CC0411 /* FBInteraction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBInteraction.m; sourceTree = "<group>"; };
+		AA8DF8C51BB1847100CC0411 /* FBInteraction+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FBInteraction+Private.h"; sourceTree = "<group>"; };
 		AA8DFB0C1BAC76B60076A6C2 /* FBSimulatorControlNotificationAssertion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorControlNotificationAssertion.h; sourceTree = "<group>"; };
 		AA8DFB0D1BAC76B60076A6C2 /* FBSimulatorControlNotificationAssertion.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorControlNotificationAssertion.m; sourceTree = "<group>"; };
 		AA8DFB0E1BAC76B60076A6C2 /* FBSimulatorSessionStateAssertion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorSessionStateAssertion.h; sourceTree = "<group>"; };
@@ -955,6 +960,9 @@
 		AA48770D1BAC74B9007F7D23 /* Utility */ = {
 			isa = PBXGroup;
 			children = (
+				AA8DF8C11BB1842600CC0411 /* FBInteraction.h */,
+				AA8DF8C21BB1842600CC0411 /* FBInteraction.m */,
+				AA8DF8C51BB1847100CC0411 /* FBInteraction+Private.h */,
 				AA74B9971BB014A200C1E59C /* FBSimulatorError.h */,
 				AA74B9981BB014A200C1E59C /* FBSimulatorError.m */,
 				AA48770E1BAC74B9007F7D23 /* FBSimulatorLogger.h */,
@@ -1661,7 +1669,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA4877271BAC74B9007F7D23 /* FBSimulatorControl+Private.h in Headers */,
-				AA74B9991BB014A200C1E59C /* FBSimulatorError.h in Headers */,
 				AA48771E1BAC74B9007F7D23 /* FBSimulatorControlConfiguration.h in Headers */,
 				AA48774C1BAC74B9007F7D23 /* FBTask+Private.h in Headers */,
 				AA48773E1BAC74B9007F7D23 /* FBSimulatorSessionInteraction+Diagnostics.h in Headers */,
@@ -1701,6 +1708,8 @@
 				AA4877371BAC74B9007F7D23 /* FBDispatchSourceNotifier.h in Headers */,
 				AA4877281BAC74B9007F7D23 /* FBSimulatorControl.h in Headers */,
 				AA4877121BAC74B9007F7D23 /* FBProcessLaunchConfiguration+Helpers.h in Headers */,
+				AA8DF8C31BB1842600CC0411 /* FBInteraction.h in Headers */,
+				AA74B9991BB014A200C1E59C /* FBSimulatorError.h in Headers */,
 				AA4877251BAC74B9007F7D23 /* FBSimulator.h in Headers */,
 				AA4877451BAC74B9007F7D23 /* FBSimulatorSessionState+Private.h in Headers */,
 			);
@@ -1832,6 +1841,7 @@
 				AA4877501BAC74B9007F7D23 /* FBTaskExecutor+Convenience.m in Sources */,
 				AA4877551BAC74B9007F7D23 /* FBTerminationHandle.m in Sources */,
 				AA4877441BAC74B9007F7D23 /* FBSimulatorSessionLifecycle.m in Sources */,
+				AA8DF8C41BB1842600CC0411 /* FBInteraction.m in Sources */,
 				AA4877181BAC74B9007F7D23 /* FBSimulatorConfiguration+Convenience.m in Sources */,
 				AA48771A1BAC74B9007F7D23 /* FBSimulatorConfiguration+DTMobile.m in Sources */,
 				AA4877131BAC74B9007F7D23 /* FBProcessLaunchConfiguration+Helpers.m in Sources */,

--- a/FBSimulatorControl/Management/FBSimulatorInteraction+Private.h
+++ b/FBSimulatorControl/Management/FBSimulatorInteraction+Private.h
@@ -12,16 +12,5 @@
 @interface FBSimulatorInteraction ()
 
 @property (nonatomic, strong) FBSimulator *simulator;
-@property (nonatomic, strong) NSMutableArray *interactions;
-
-+ (id<FBSimulatorInteraction>)chainInteractions:(NSArray *)interactions;
-
-@end
-
-@interface FBSimulatorInteraction_Block : NSObject<FBSimulatorInteraction>
-
-@property (nonatomic, copy) BOOL (^block)(NSError **error);
-
-+ (id<FBSimulatorInteraction>)interactionWithBlock:( BOOL(^)(NSError **error) )block;
 
 @end

--- a/FBSimulatorControl/Management/FBSimulatorInteraction.h
+++ b/FBSimulatorControl/Management/FBSimulatorInteraction.h
@@ -9,6 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import <FBSimulatorControl/FBInteraction.h>
 #import <FBSimulatorControl/FBSimulator.h>
 
 @class FBSimulator;
@@ -16,24 +17,9 @@
 @class FBSimulatorConfiguration;
 
 /**
- Represents a failable transaction involving a Simulator.
- */
-@protocol FBSimulatorInteraction<NSObject>
-
-/**
- Perform the given interaction.
-
- @param error an errorOut if any ocurred.
- @returns YES if the interaction succeeded, NO otherwise.
- */
-- (BOOL)performInteractionWithError:(NSError **)error;
-
-@end
-
-/**
  Pre-session interactions used pre-launch of a Simulator
  */
-@interface FBSimulatorInteraction : NSObject <FBSimulatorInteraction>
+@interface FBSimulatorInteraction : FBInteraction
 
 /**
  Returns a new Interaction for the provided Simulator.

--- a/FBSimulatorControl/Session/FBSimulatorSessionInteraction+Private.h
+++ b/FBSimulatorControl/Session/FBSimulatorSessionInteraction+Private.h
@@ -15,13 +15,7 @@ extern NSTimeInterval const FBSimulatorInteractionDefaultTimeout;
 
 @interface FBSimulatorSessionInteraction ()
 
-@property (nonatomic, strong) NSMutableArray *interactions;
 @property (nonatomic, strong) FBSimulatorSession *session;
-
-/**
- Chains an interaction using the provided block
- */
-- (instancetype)interact:(BOOL (^)(NSError **))block;
 
 /**
  Chains an interaction on an application process, for the given application.

--- a/FBSimulatorControl/Session/FBSimulatorSessionInteraction.h
+++ b/FBSimulatorControl/Session/FBSimulatorSessionInteraction.h
@@ -9,7 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <FBSimulatorControl/FBSimulatorInteraction.h>
+#import <FBSimulatorControl/FBInteraction.h>
 
 @class FBAgentLaunchConfiguration;
 @class FBApplicationLaunchConfiguration;
@@ -24,7 +24,7 @@
  Successive applications of interactions will occur in the order that they are sequenced.
  Interactions have no effect until `performInteractionWithError:` is called.
  */
-@interface FBSimulatorSessionInteraction : NSObject <FBSimulatorInteraction>
+@interface FBSimulatorSessionInteraction : FBInteraction
 
 /**
  Creates a new instance of the Interaction Builder.
@@ -65,11 +65,6 @@
  Launches the provided Agent.
  */
 - (instancetype)killAgent:(FBSimulatorBinary *)agent;
-
-/**
- Retries the last chained interaction by `retries`, if it fails.
- */
-- (instancetype)retry:(NSUInteger)retries;
 
 /**
  Opens the provided URL on the Device

--- a/FBSimulatorControl/Utility/FBInteraction+Private.h
+++ b/FBSimulatorControl/Utility/FBInteraction+Private.h
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <FBSimulatorControl/FBInteraction.h>
+
+@interface FBInteraction ()
+
+/**
+ The NSMutableArray<id<FBInteraction>> to chain together.
+ */
+@property (nonatomic, strong) NSMutableArray *interactions;
+
+/**
+ Chains an interaction using the provided block
+ */
+- (instancetype)interact:(BOOL (^)(NSError **))block;
+
+/**
+ Takes an NSArray<id<FBInteraction>> and returns an id<FBInteracton>.
+ */
++ (id<FBInteraction>)chainInteractions:(NSArray *)interactions;
+
+@end
+
+/**
+ Implementation of id<FBInteraction> using a block
+ */
+@interface FBInteraction_Block : NSObject<FBInteraction>
+
+@property (nonatomic, copy) BOOL (^block)(NSError **error);
+
++ (id<FBInteraction>)interactionWithBlock:( BOOL(^)(NSError **error) )block;
+
+@end

--- a/FBSimulatorControl/Utility/FBInteraction.h
+++ b/FBSimulatorControl/Utility/FBInteraction.h
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <FBSimulatorControl/FBInteraction.h>
+
+/**
+ Represents a failable transaction involving a Simulator.
+ */
+@protocol FBInteraction <NSObject>
+
+/**
+ Perform the given interaction.
+
+ @param error an errorOut if any ocurred.
+ @returns YES if the interaction succeeded, NO otherwise.
+ */
+- (BOOL)performInteractionWithError:(NSError **)error;
+
+@end
+
+/**
+ Pre-session interactions used pre-launch of a Simulator
+ */
+@interface FBInteraction : NSObject <FBInteraction>
+
+/**
+ Retries the last chained interaction by `retries`, if it fails.
+ */
+- (instancetype)retry:(NSUInteger)retries;
+
+@end

--- a/FBSimulatorControl/Utility/FBInteraction.m
+++ b/FBSimulatorControl/Utility/FBInteraction.m
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBInteraction.h"
+
+#import "FBInteraction+Private.h"
+#import "FBSimulatorError.h"
+
+@implementation FBInteraction
+
+- (instancetype)init
+{
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  _interactions = [NSMutableArray array];
+  return self;
+}
+
++ (id<FBInteraction>)chainInteractions:(NSArray *)interactions
+{
+  return [FBInteraction_Block interactionWithBlock:^ BOOL (NSError **error) {
+    for (id<FBInteraction> interaction in interactions) {
+      NSError *innerError = nil;
+      if (![interaction performInteractionWithError:&innerError]) {
+        return [FBSimulatorError failBoolWithError:innerError errorOut:error];
+      }
+    }
+    return YES;
+  }];
+}
+
+- (instancetype)interact:(BOOL (^)(NSError **error))block
+{
+  NSParameterAssert(block);
+  return [self addInteraction:[FBInteraction_Block interactionWithBlock:block]];
+}
+
+- (instancetype)addInteraction:(id<FBInteraction>)interaction
+{
+  [self.interactions addObject:interaction];
+  return self;
+}
+
+- (instancetype)retry:(NSUInteger)retries
+{
+  NSParameterAssert(self.interactions.count > 0);
+  NSParameterAssert(retries > 1);
+
+  NSUInteger interactionIndex = self.interactions.count - 1;
+  id<FBInteraction> interaction = self.interactions[interactionIndex];
+
+  id<FBInteraction> retryInteraction = [FBInteraction_Block interactionWithBlock:^ BOOL (NSError **error) {
+    NSError *innerError = nil;
+    for (NSUInteger index = 0; index < retries; index++) {
+      if ([interaction performInteractionWithError:&innerError]) {
+        return YES;
+      }
+    }
+    return [[[FBSimulatorError describeFormat:@"Failed interaction after %ld retries", retries] causedBy:innerError] failBool:error];
+  }];
+
+  [self.interactions replaceObjectAtIndex:interactionIndex withObject:retryInteraction];
+  return self;
+}
+
+- (id<FBInteraction>)build
+{
+  return [FBInteraction chainInteractions:[self.interactions copy]];
+}
+
+- (BOOL)performInteractionWithError:(NSError **)error
+{
+  return [[self build] performInteractionWithError:error];
+}
+
+@end
+
+@implementation FBInteraction_Block
+
++ (id<FBInteraction>)interactionWithBlock:( BOOL(^)(NSError **error) )block
+{
+  FBInteraction_Block *interaction = [self new];
+  interaction.block = block;
+  return interaction;
+}
+
+- (BOOL)performInteractionWithError:(NSError **)error
+{
+  NSError *innerError = nil;
+  BOOL success = self.block(&innerError);
+  if (!success && error) {
+    *error = innerError;
+  }
+  return success;
+}
+
+@end


### PR DESCRIPTION
`FBSimulatorInteraction` and `FBSimulatorSessionInteraction` have common behavior, but duplicate implementations of some methods. 

This PR extracts the common behaviour, also giving `FBSimulatorInteraction` retrying.