### PR TITLE
Managed & Unmanaged FBSimulator

### DIFF
--- a/FBSimulatorControl/Management/FBSimulator+Private.h
+++ b/FBSimulatorControl/Management/FBSimulator+Private.h
@@ -9,12 +9,21 @@
 
 #import <FBSimulatorControl/FBSimulator.h>
 
+@class FBSimulatorControlConfiguration;
+
 @interface FBSimulator ()
 
 @property (nonatomic, strong, readwrite) SimDevice *device;
 @property (nonatomic, weak, readwrite) FBSimulatorPool *pool;
+@property (nonatomic, assign, readwrite) NSInteger processIdentifier;
+
++ (instancetype)inflateFromSimDevice:(SimDevice *)simDevice configuration:(FBSimulatorControlConfiguration *)configuration;
+
+@end
+
+@interface FBManagedSimulator ()
+
 @property (nonatomic, assign, readwrite) NSInteger bucketID;
 @property (nonatomic, assign, readwrite) NSInteger offset;
-@property (nonatomic, assign, readwrite) NSInteger processIdentifier;
 
 @end

--- a/FBSimulatorControl/Management/FBSimulator.h
+++ b/FBSimulatorControl/Management/FBSimulator.h
@@ -14,7 +14,7 @@
 @class SimDevice;
 
 /**
- The Default timeout for waits
+ The Default timeout for waits.
  */
 extern NSTimeInterval const FBSimulatorDefaultTimeout;
 
@@ -32,14 +32,9 @@ typedef NS_ENUM(NSInteger, FBSimulatorState) {
 };
 
 /**
- Wraps SimDevice, with additional information about the device.
+ Defines the High-Level Properties and Methods that exist on any Simulator returned from `FBSimulatorPool`.
  */
 @interface FBSimulator : NSObject
-
-/**
- Whether the Simulator is Allocated.
- */
-@property (nonatomic, assign, readonly, getter=isAllocated) BOOL allocated;
 
 /**
  The Underlying SimDevice.
@@ -50,17 +45,6 @@ typedef NS_ENUM(NSInteger, FBSimulatorState) {
  The Pool to which the Simulator Belongs.
  */
 @property (nonatomic, weak, readonly) FBSimulatorPool *pool;
-
-/**
- The Bucket ID of the allocated device. Bucket IDs are used to segregate a range of devices, so that multiple
- processes can use Simulators, without colliding
- */
-@property (nonatomic, assign, readonly) NSInteger bucketID;
-
-/**
- The Offset represents the position in the pool of this device. Multiple devices of the same type can be allocated in the same pool.
- */
-@property (nonatomic, assign, readonly) NSInteger offset;
 
 /**
  The Name of the allocated device.
@@ -76,11 +60,6 @@ typedef NS_ENUM(NSInteger, FBSimulatorState) {
  The State of the allocated device.
  */
 @property (nonatomic, assign, readonly) FBSimulatorState state;
-
-/**
- The Application that the Simulator should be launched with.
- */
-@property (nonatomic, copy, readonly) FBSimulatorApplication *simulatorApplication;
 
 /**
  The Process Identifier of the Simulator. -1 if it is not running
@@ -99,12 +78,9 @@ typedef NS_ENUM(NSInteger, FBSimulatorState) {
 @property (nonatomic, copy, readonly) NSString *launchdBootstrapPath;
 
 /**
- Calls `freeSimulator:error:` on this device's pool, with the reciever as the first argument
-
- @param error an error out for any error that occured.
- @returns YES if the freeing of the device was successful, NO otherwise.
+ The Application that the Simulator should be launched with.
  */
-- (BOOL)freeFromPoolWithError:(NSError **)error;
+@property (nonatomic, copy, readonly) FBSimulatorApplication *simulatorApplication;
 
 /**
  Synchronously waits on the provided state.
@@ -132,5 +108,37 @@ typedef NS_ENUM(NSInteger, FBSimulatorState) {
  Convenience method for obtaining SimulatorState from a String.
  */
 + (FBSimulatorState)simulatorStateFromStateString:(NSString *)stateString;
+
+@end
+
+/**
+ Defines the Additional Properties and Methods that exist on a 'Managed' Simulator.
+ A Managed Simulator is one that has Allocation and Freeing semantics.
+ */
+@interface FBManagedSimulator : FBSimulator
+
+/**
+ Whether the Simulator is Allocated.
+ */
+@property (nonatomic, assign, readonly, getter=isAllocated) BOOL allocated;
+
+/**
+ The Bucket ID of the allocated device. Bucket IDs are used to segregate a range of devices, so that multiple
+ processes can use Simulators, without colliding
+ */
+@property (nonatomic, assign, readonly) NSInteger bucketID;
+
+/**
+ The Offset represents the position in the pool of this device. Multiple devices of the same type can be allocated in the same pool.
+ */
+@property (nonatomic, assign, readonly) NSInteger offset;
+
+/**
+ Calls `freeSimulator:error:` on this device's pool, with the reciever as the first argument
+
+ @param error an error out for any error that occured.
+ @returns YES if the freeing of the device was successful, NO otherwise.
+ */
+- (BOOL)freeFromPoolWithError:(NSError **)error;
 
 @end

--- a/FBSimulatorControl/Management/FBSimulatorControl.m
+++ b/FBSimulatorControl/Management/FBSimulatorControl.m
@@ -72,7 +72,7 @@
     return [FBSimulatorError failWithError:innerError description:@"Failed to meet first run preconditions" errorOut:error];
   }
 
-  FBSimulator *simulator = [self.simulatorPool
+  FBManagedSimulator *simulator = [self.simulatorPool
     allocateSimulatorWithConfiguration:simulatorConfiguration
     error:&innerError];
 

--- a/FBSimulatorControl/Management/FBSimulatorPool+Private.h
+++ b/FBSimulatorControl/Management/FBSimulatorPool+Private.h
@@ -14,7 +14,7 @@
 @property (nonatomic, copy, readwrite) FBSimulatorControlConfiguration *configuration;
 
 @property (nonatomic, strong, readwrite) SimDeviceSet *deviceSet;
-@property (nonatomic, strong, readwrite) NSMutableOrderedSet *allocatedWorkingSet;
+@property (nonatomic, strong, readwrite) NSMutableOrderedSet *allocatedUDIDs;
 @property (nonatomic, strong, readwrite) NSRegularExpression *managedSimulatorPoolOffsetRegex;
 
 @end

--- a/FBSimulatorControl/Management/FBSimulatorPool.h
+++ b/FBSimulatorControl/Management/FBSimulatorPool.h
@@ -13,6 +13,7 @@
 @class FBSimulatorConfiguration;
 @class FBSimulatorControlConfiguration;
 @class FBSimulatorPool;
+@class FBManagedSimulator;
 @class SimDevice;
 @class SimDeviceSet;
 
@@ -38,47 +39,53 @@
 @property (nonatomic, copy, readonly) FBSimulatorControlConfiguration *configuration;
 
 /**
- An Array of the Simulators that this Pool is responsible for.
+ An Ordered Set of the Simulators that this Pool is responsible for.
  This includes allocated and un-allocated simulators.
  Ordering is based on name descending.
- Is an NSOrderedSet<FBSimulator>
+ Is an NSOrderedSet<FBManagedSimulator>
  */
 @property (nonatomic, copy, readonly) NSOrderedSet *allSimulatorsInPool;
 
 /**
- An Array of the Simulators that any posible Pool is responsible for.
+ An Ordered Set of the Simulators that any posible Pool is responsible for.
  This includes allocated and un-allocated simulators.
  Ordering is based on name descending.
- Is an NSOrderedSet<FBSimulator>
+ Is an NSOrderedSet<FBManagedSimulator>
  */
 @property (nonatomic, copy, readonly) NSOrderedSet *allPooledSimulators;
 
 /**
- An Array of the Simulators that this Pool has allocated.
+ An Ordered Set of the Simulators that this Pool has allocated.
  This includes only allocated simulators.
  Ordering is based on the most recently allocated simulator descending.
- Is an NSOrderedSet<FBSimulator>
+ Is an NSOrderedSet<FBManagedSimulator>
  */
 @property (nonatomic, copy, readonly) NSOrderedSet *allocatedSimulators;
 
 /**
- An Array of the Simulators that this Pool has allocated.
+ An Ordered Set of the Simulators that this Pool has allocated.
  This includes only allocated simulators.
  Ordering is based on name descending.
- Is an NSOrderedSet<FBSimulator>
+ Is an NSOrderedSet<FBManagedSimulator>
  */
 @property (nonatomic, copy, readonly) NSOrderedSet *unallocatedSimulators;
 
 /**
- An Array of the Simulators that no Pool is responsible for.
- Is an NSArray<SimDevice>
+ An Ordered Set of all the Simulators for the Device Set.
+ Is an NSOrderedSet<FBSimulator>
  */
-@property (nonatomic, copy, readonly) NSArray *unmanagedSimulators;
+@property (nonatomic, copy, readonly) NSOrderedSet *allSimulators;
+
+/**
+ An Ordered Set of the Simulators that no Pool is responsible for.
+ Is an NSOrderedSet<FBSimulator>
+ */
+@property (nonatomic, copy, readonly) NSOrderedSet *unmanagedSimulators;
 
 /**
  Returns a device matching the UDID, if one exists.
  */
-- (SimDevice *)deviceWithUDID:(NSString *)udidString;
+- (FBSimulator *)simulatorWithUDID:(NSString *)udidString;
 
 /**
  Returns a Device for the given parameters. Will create devices where necessary.
@@ -89,7 +96,7 @@
  @param error an error out for any error that occured.
  @returns a device if one could be found or created, nil if an error occured.
  */
-- (FBSimulator *)allocateSimulatorWithConfiguration:(FBSimulatorConfiguration *)configuration error:(NSError **)error;
+- (FBManagedSimulator *)allocateSimulatorWithConfiguration:(FBSimulatorConfiguration *)configuration error:(NSError **)error;
 
 /**
  Marks a device that was previously returned from `allocateDeviceWithName:sdkVersion:error:` as free.
@@ -99,7 +106,7 @@
  @param error an error out for any error that occured.
  @returns YES if the freeing of the device was successful, NO otherwise.
  */
-- (BOOL)freeSimulator:(FBSimulator *)device error:(NSError **)error;
+- (BOOL)freeSimulator:(FBManagedSimulator *)simulator error:(NSError **)error;
 
 /**
  Kills all of the Simulators that this Pool is responsible for.
@@ -174,7 +181,7 @@
  @param deviceType the Device Type of the Device to search for. Must not be nil.
  @return The Allocated device created by FBSimulatorPool.
  */
-- (FBSimulator *)allocatedSimulatorWithDeviceType:(NSString *)deviceType;
+- (FBManagedSimulator *)allocatedSimulatorWithDeviceType:(NSString *)deviceType;
 
 @end
 

--- a/FBSimulatorControl/Session/FBSimulatorSession+Private.h
+++ b/FBSimulatorControl/Session/FBSimulatorSession+Private.h
@@ -15,7 +15,7 @@
 
 @interface FBSimulatorSession ()
 
-@property (nonatomic, strong, readwrite) FBSimulator *simulator;
+@property (nonatomic, strong, readwrite) FBManagedSimulator *simulator;
 @property (nonatomic, strong, readwrite) FBSimulatorSessionLifecycle *lifecycle;
 
 @end

--- a/FBSimulatorControl/Session/FBSimulatorSession.h
+++ b/FBSimulatorControl/Session/FBSimulatorSession.h
@@ -9,7 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class FBSimulator;
+@class FBManagedSimulator;
 @class FBSimulatorSessionInteraction;
 @class FBSimulatorSessionState;
 
@@ -25,12 +25,12 @@
  @param simulator the Simulator to manage the session for.
  @returns a new `FBSimulatorSession`.
  */
-+ (instancetype)sessionWithSimulator:(FBSimulator *)simulator;
++ (instancetype)sessionWithSimulator:(FBManagedSimulator *)simulator;
 
 /**
  The Simulator for this session
  */
-@property (nonatomic, strong, readonly) FBSimulator *simulator;
+@property (nonatomic, strong, readonly) FBManagedSimulator *simulator;
 
 /**
  Returns the Session Information for the reciever.

--- a/FBSimulatorControl/Session/FBSimulatorSession.m
+++ b/FBSimulatorControl/Session/FBSimulatorSession.m
@@ -24,14 +24,14 @@
 
 #pragma mark - Initializers
 
-+ (instancetype)sessionWithSimulator:(FBSimulator *)simulator
++ (instancetype)sessionWithSimulator:(FBManagedSimulator *)simulator
 {
   NSParameterAssert(simulator);
 
   return [[FBSimulatorSession alloc] initWithSimulator:simulator];
 }
 
-- (instancetype)initWithSimulator:(FBSimulator *)simulator
+- (instancetype)initWithSimulator:(FBManagedSimulator *)simulator
 {
   self = [super init];
   if (!self) {

--- a/FBSimulatorControlTests/Tests/FBSimulatorPoolAllocationTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorPoolAllocationTests.m
@@ -38,7 +38,7 @@
 
   NSError *error = nil;
   FBSimulatorConfiguration *simulatorConfiguration = FBSimulatorConfiguration.iPhone5;
-  FBSimulator *simulator = [control.simulatorPool allocateSimulatorWithConfiguration:simulatorConfiguration error:&error];
+  FBManagedSimulator *simulator = [control.simulatorPool allocateSimulatorWithConfiguration:simulatorConfiguration error:&error];
   XCTAssertNotNil(simulator);
   XCTAssertNil(error);
 
@@ -70,7 +70,7 @@
 
   NSError *error = nil;
   FBSimulatorConfiguration *simulatorConfiguration = FBSimulatorConfiguration.iPhone5;
-  FBSimulator *simulator = [control.simulatorPool allocateSimulatorWithConfiguration:simulatorConfiguration error:&error];
+  FBManagedSimulator *simulator = [control.simulatorPool allocateSimulatorWithConfiguration:simulatorConfiguration error:&error];
   XCTAssertNotNil(simulator);
   XCTAssertNil(error);
 
@@ -100,7 +100,7 @@
 
   NSError *error = nil;
   FBSimulatorConfiguration *simulatorConfiguration = FBSimulatorConfiguration.iPhone5;
-  FBSimulator *simulator = [control.simulatorPool allocateSimulatorWithConfiguration:simulatorConfiguration error:&error];
+  FBManagedSimulator *simulator = [control.simulatorPool allocateSimulatorWithConfiguration:simulatorConfiguration error:&error];
   XCTAssertNotNil(simulator);
   XCTAssertNil(error);
 

--- a/FBSimulatorControlTests/Tests/FBSimulatorPoolTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorPoolTests.m
@@ -76,7 +76,7 @@
   for (NSString *deviceName in deviceNames) {
     FBSimulator *simulator = lookup[deviceName];
     XCTAssertNotNil(simulator, @"Expected there is a existing device named %@", deviceName);
-    [self.pool.allocatedWorkingSet addObject:simulator];
+    [self.pool.allocatedUDIDs addObject:simulator.udid];
   }
 }
 
@@ -141,25 +141,25 @@
   XCTAssertEqual([devices[0] state], FBSimulatorStateBooted);
   XCTAssertEqual([devices[0] bucketID], 1);
   XCTAssertEqual([devices[0] offset], 0);
-  XCTAssertEqual([devices[0] pool], self.pool);
+  XCTAssertNil([devices[0] pool]);
 
   XCTAssertEqualObjects([devices[1] name], @"E2E_1_0_iPhone 5_9.0");
   XCTAssertEqual([devices[1] state], FBSimulatorStateCreating);
   XCTAssertEqual([devices[1] bucketID], 1);
   XCTAssertEqual([devices[1] offset], 0);
-  XCTAssertEqual([devices[1] pool], self.pool);
+  XCTAssertNil([devices[1] pool]);
 
   XCTAssertEqualObjects([devices[2] name], @"E2E_1_1_iPhone 5_9.0");
   XCTAssertEqual([devices[2] state], FBSimulatorStateShutdown);
   XCTAssertEqual([devices[2] bucketID], 1);
   XCTAssertEqual([devices[2] offset], 1);
-  XCTAssertEqual([devices[2] pool], self.pool);
+  XCTAssertNil([devices[2] pool]);
 
   XCTAssertEqualObjects([devices[3] name], @"E2E_1_2_iPhone 5_9.0");
   XCTAssertEqual([devices[3] state], FBSimulatorStateBooted);
   XCTAssertEqual([devices[3] bucketID], 1);
   XCTAssertEqual([devices[3] offset], 2);
-  XCTAssertEqual([devices[3] pool], self.pool);
+  XCTAssertNil([devices[3] pool],);
 
   XCTAssertEqualObjects([devices[4] name], @"E2E_2_0_iPad 1_9.0");
   XCTAssertEqual([devices[4] state], FBSimulatorStateBooted);
@@ -187,7 +187,7 @@
     @{@"name" : @"E2E_2_0_iPad 1_9.0"}
   ]];
 
-  NSArray *devices = self.pool.unmanagedSimulators;
+  NSOrderedSet *devices = self.pool.unmanagedSimulators;
   XCTAssertEqual(devices.count, 2);
   XCTAssertEqualObjects([devices[0] name], @"iPad 3");
   XCTAssertEqualObjects([devices[1] name], @"iPhone 6S");


### PR DESCRIPTION
Extracts out `FBSimulator` simulator behavior to allow all Simulators to be wrapped with the `FBSimulator` conveniences that are relevant, regardless of whether they are managed or unmanaged.

A Concreted subclass `FBManagedSimulator` deals with allocation/freeing of these Simulators. This improves a lot of the inflation of `SimDevice` to `FBSimulator` and means that `FBSimulatorPool` spends a lot less time dealing with heterogeneous objects.

This also means that expensive information about a simulator (for example the construction of processes that have been created through `launchd_sim`) can be done lazily and will apply to any simulator, not just 'managed' ones.