### PR TITLE
Add Scale to Simulator Configuration

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -15,8 +15,8 @@
 		AA4877161BAC74B9007F7D23 /* FBProcessLaunchConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = AA4876C81BAC74B9007F7D23 /* FBProcessLaunchConfiguration.m */; settings = {ASSET_TAGS = (); }; };
 		AA4877171BAC74B9007F7D23 /* FBSimulatorConfiguration+Convenience.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4876C91BAC74B9007F7D23 /* FBSimulatorConfiguration+Convenience.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA4877181BAC74B9007F7D23 /* FBSimulatorConfiguration+Convenience.m in Sources */ = {isa = PBXBuildFile; fileRef = AA4876CA1BAC74B9007F7D23 /* FBSimulatorConfiguration+Convenience.m */; settings = {ASSET_TAGS = (); }; };
-		AA4877191BAC74B9007F7D23 /* FBSimulatorConfiguration+DTMobile.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4876CB1BAC74B9007F7D23 /* FBSimulatorConfiguration+DTMobile.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AA48771A1BAC74B9007F7D23 /* FBSimulatorConfiguration+DTMobile.m in Sources */ = {isa = PBXBuildFile; fileRef = AA4876CC1BAC74B9007F7D23 /* FBSimulatorConfiguration+DTMobile.m */; settings = {ASSET_TAGS = (); }; };
+		AA4877191BAC74B9007F7D23 /* FBSimulatorConfiguration+CoreSimulator.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4876CB1BAC74B9007F7D23 /* FBSimulatorConfiguration+CoreSimulator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA48771A1BAC74B9007F7D23 /* FBSimulatorConfiguration+CoreSimulator.m in Sources */ = {isa = PBXBuildFile; fileRef = AA4876CC1BAC74B9007F7D23 /* FBSimulatorConfiguration+CoreSimulator.m */; settings = {ASSET_TAGS = (); }; };
 		AA48771B1BAC74B9007F7D23 /* FBSimulatorConfiguration+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4876CD1BAC74B9007F7D23 /* FBSimulatorConfiguration+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA48771C1BAC74B9007F7D23 /* FBSimulatorConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4876CE1BAC74B9007F7D23 /* FBSimulatorConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA48771D1BAC74B9007F7D23 /* FBSimulatorConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = AA4876CF1BAC74B9007F7D23 /* FBSimulatorConfiguration.m */; settings = {ASSET_TAGS = (); }; };
@@ -153,8 +153,8 @@
 		AA4876C81BAC74B9007F7D23 /* FBProcessLaunchConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBProcessLaunchConfiguration.m; sourceTree = "<group>"; };
 		AA4876C91BAC74B9007F7D23 /* FBSimulatorConfiguration+Convenience.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FBSimulatorConfiguration+Convenience.h"; sourceTree = "<group>"; };
 		AA4876CA1BAC74B9007F7D23 /* FBSimulatorConfiguration+Convenience.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "FBSimulatorConfiguration+Convenience.m"; sourceTree = "<group>"; };
-		AA4876CB1BAC74B9007F7D23 /* FBSimulatorConfiguration+DTMobile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FBSimulatorConfiguration+DTMobile.h"; sourceTree = "<group>"; };
-		AA4876CC1BAC74B9007F7D23 /* FBSimulatorConfiguration+DTMobile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "FBSimulatorConfiguration+DTMobile.m"; sourceTree = "<group>"; };
+		AA4876CB1BAC74B9007F7D23 /* FBSimulatorConfiguration+CoreSimulator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FBSimulatorConfiguration+CoreSimulator.h"; sourceTree = "<group>"; };
+		AA4876CC1BAC74B9007F7D23 /* FBSimulatorConfiguration+CoreSimulator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "FBSimulatorConfiguration+CoreSimulator.m"; sourceTree = "<group>"; };
 		AA4876CD1BAC74B9007F7D23 /* FBSimulatorConfiguration+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FBSimulatorConfiguration+Private.h"; sourceTree = "<group>"; };
 		AA4876CE1BAC74B9007F7D23 /* FBSimulatorConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorConfiguration.h; sourceTree = "<group>"; };
 		AA4876CF1BAC74B9007F7D23 /* FBSimulatorConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorConfiguration.m; sourceTree = "<group>"; };
@@ -860,8 +860,8 @@
 				AA4876C81BAC74B9007F7D23 /* FBProcessLaunchConfiguration.m */,
 				AA4876C91BAC74B9007F7D23 /* FBSimulatorConfiguration+Convenience.h */,
 				AA4876CA1BAC74B9007F7D23 /* FBSimulatorConfiguration+Convenience.m */,
-				AA4876CB1BAC74B9007F7D23 /* FBSimulatorConfiguration+DTMobile.h */,
-				AA4876CC1BAC74B9007F7D23 /* FBSimulatorConfiguration+DTMobile.m */,
+				AA4876CB1BAC74B9007F7D23 /* FBSimulatorConfiguration+CoreSimulator.h */,
+				AA4876CC1BAC74B9007F7D23 /* FBSimulatorConfiguration+CoreSimulator.m */,
 				AA4876CD1BAC74B9007F7D23 /* FBSimulatorConfiguration+Private.h */,
 				AA4876CE1BAC74B9007F7D23 /* FBSimulatorConfiguration.h */,
 				AA4876CF1BAC74B9007F7D23 /* FBSimulatorConfiguration.m */,
@@ -1700,7 +1700,7 @@
 				AA4877521BAC74B9007F7D23 /* FBTaskExecutor.h in Headers */,
 				AA4877561BAC74B9007F7D23 /* FBSimulatorLogger.h in Headers */,
 				AA4877351BAC74B9007F7D23 /* FBCoreSimulatorNotifier.h in Headers */,
-				AA4877191BAC74B9007F7D23 /* FBSimulatorConfiguration+DTMobile.h in Headers */,
+				AA4877191BAC74B9007F7D23 /* FBSimulatorConfiguration+CoreSimulator.h in Headers */,
 				AA48773B1BAC74B9007F7D23 /* FBSimulatorSession+Private.h in Headers */,
 				AA48771C1BAC74B9007F7D23 /* FBSimulatorConfiguration.h in Headers */,
 				AA4877141BAC74B9007F7D23 /* FBProcessLaunchConfiguration+Private.h in Headers */,
@@ -1848,7 +1848,7 @@
 				AA4877441BAC74B9007F7D23 /* FBSimulatorSessionLifecycle.m in Sources */,
 				AA8DF8CA1BB18B3700CC0411 /* FBInteraction.m in Sources */,
 				AA4877181BAC74B9007F7D23 /* FBSimulatorConfiguration+Convenience.m in Sources */,
-				AA48771A1BAC74B9007F7D23 /* FBSimulatorConfiguration+DTMobile.m in Sources */,
+				AA48771A1BAC74B9007F7D23 /* FBSimulatorConfiguration+CoreSimulator.m in Sources */,
 				AA4877131BAC74B9007F7D23 /* FBProcessLaunchConfiguration+Helpers.m in Sources */,
 				AA4877421BAC74B9007F7D23 /* FBSimulatorSessionInteraction.m in Sources */,
 				AA4877471BAC74B9007F7D23 /* FBSimulatorSessionState+Queries.m in Sources */,

--- a/FBSimulatorControl/Configuration/FBSimulatorConfiguration+Convenience.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorConfiguration+Convenience.m
@@ -9,7 +9,7 @@
 
 #import "FBSimulatorConfiguration+Convenience.h"
 
-#import "FBSimulatorConfiguration+DTMobile.h"
+#import "FBSimulatorConfiguration+CoreSimulator.h"
 
 #import <CoreSimulator/SimRuntime.h>
 

--- a/FBSimulatorControl/Configuration/FBSimulatorConfiguration+CoreSimulator.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorConfiguration+CoreSimulator.h
@@ -13,9 +13,9 @@
 @class SimRuntime;
 
 /**
- Adapting FBSimulatorConfiguration to DTMobile
+ Adapting FBSimulatorConfiguration to CoreSimulator.
  */
-@interface FBSimulatorConfiguration (DTMobile)
+@interface FBSimulatorConfiguration (CoreSimulator)
 
 /**
  The SimRuntime for the current configuration.
@@ -28,6 +28,28 @@
  Will return nil, if the runtime is unavailable
  */
 @property (nonatomic, strong, readonly) SimDeviceType *deviceType;
+
+/**
+ The Defaults override for the Device-Specific scale key in NSUserDefaults.
+ See 'defaults read com.apple.iphonesimulator'
+ */
+@property (nonatomic, copy, readonly) NSString *lastScaleKey;
+
+/**
+ The Command Line switch to override the Device-Specific scale of a directly-launched the Simulator.
+ See 'defaults read com.apple.iphonesimulator'
+ */
+@property (nonatomic, copy, readonly) NSString *lastScaleCommandLineSwitch;
+
+/**
+ Returns a new Configuration, for the specific SimRuntime.
+ */
+- (instancetype)withRuntime:(SimRuntime *)runtime;
+
+/**
+ Returns a new Configuration, for the specific DeviceType.
+ */
+- (instancetype)withDeviceType:(SimDeviceType *)deviceType;
 
 /**
  Returns an NSDictionary<FBSimulatorConfiguration, SimRuntime> for the available runtimes.

--- a/FBSimulatorControl/Configuration/FBSimulatorConfiguration+CoreSimulator.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorConfiguration+CoreSimulator.m
@@ -50,7 +50,7 @@
 
 - (NSString *)lastScaleCommandLineSwitch
 {
-  return [NSString stringWithFormat:@"-\"%@\"", self.lastScaleKey];
+  return [NSString stringWithFormat:@"-%@", self.lastScaleKey];
 }
 
 - (instancetype)withRuntime:(SimRuntime *)runtime

--- a/FBSimulatorControl/Configuration/FBSimulatorConfiguration+CoreSimulator.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorConfiguration+CoreSimulator.m
@@ -7,14 +7,14 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import "FBSimulatorConfiguration+DTMobile.h"
+#import "FBSimulatorConfiguration+CoreSimulator.h"
 
 #import "FBSimulatorConfiguration+Private.h"
 
 #import <CoreSimulator/SimDeviceType.h>
 #import <CoreSimulator/SimRuntime.h>
 
-@implementation FBSimulatorConfiguration (DTMobile)
+@implementation FBSimulatorConfiguration (CoreSimulator)
 
 - (SimRuntime *)runtime
 {
@@ -38,6 +38,29 @@
     }
   }
   return nil;
+}
+
+- (NSString *)lastScaleKey
+{
+  return [NSString stringWithFormat:
+    @"SimulatorWindowLastScale-%@",
+    self.deviceType.identifier
+  ];
+}
+
+- (NSString *)lastScaleCommandLineSwitch
+{
+  return [NSString stringWithFormat:@"-\"%@\"", self.lastScaleKey];
+}
+
+- (instancetype)withRuntime:(SimRuntime *)runtime
+{
+  return [self iOS:runtime.versionString];
+}
+
+- (instancetype)withDeviceType:(SimDeviceType *)deviceType
+{
+  return [self named:deviceType.name];
 }
 
 + (NSDictionary *)configurationsToAvailableRuntimes

--- a/FBSimulatorControl/Configuration/FBSimulatorConfiguration+Private.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorConfiguration+Private.h
@@ -69,10 +69,29 @@
 @interface FBSimulatorConfigurationOSVersion_9_0 : NSObject<FBSimulatorConfigurationOSVersion>
 @end
 
+@protocol FBSimulatorConfigurationScale <NSObject>
+
+- (NSString *)scaleString;
+
+@end
+
+@interface FBSimulatorConfigurationScale_25 : NSObject<FBSimulatorConfigurationScale>
+@end
+
+@interface FBSimulatorConfigurationScale_50 : NSObject<FBSimulatorConfigurationScale>
+@end
+
+@interface FBSimulatorConfigurationScale_75 : NSObject<FBSimulatorConfigurationScale>
+@end
+
+@interface FBSimulatorConfigurationScale_100 : NSObject<FBSimulatorConfigurationScale>
+@end
+
 @interface FBSimulatorConfiguration ()
 
 @property (nonatomic, strong, readwrite) id<FBSimulatorConfigurationNamedDevice> namedDevice;
 @property (nonatomic, strong, readwrite) id<FBSimulatorConfigurationOSVersion> osVersion;
+@property (nonatomic, strong, readwrite) id<FBSimulatorConfigurationScale> scale;
 @property (nonatomic, strong, readwrite) NSLocale *locale;
 
 @end

--- a/FBSimulatorControl/Configuration/FBSimulatorConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorConfiguration.h
@@ -22,6 +22,8 @@
  */
 @interface FBSimulatorConfiguration : NSObject<NSCopying>
 
+#pragma mark Properties
+
 /**
  The Name of the Device to Simulate. Must not be nil.
  */
@@ -38,10 +40,17 @@
 @property (nonatomic, strong, readonly) NSLocale *locale;
 
 /**
+ A String representing the Scale at which to launch the Simulator.
+ */
+@property (nonatomic, copy, readonly) NSString *scaleString;
+
+/**
  Returns the Default Configuration.
  The OS Version is derived from the SDK Version.
  */
 + (instancetype)defaultConfiguration;
+
+#pragma mark Devices
 
 /**
  An iPhone 4s.
@@ -104,6 +113,8 @@
 + (instancetype)named:(NSString *)deviceType;
 - (instancetype)named:(NSString *)deviceType;
 
+#pragma mark OS Versions
+
 /**
  iOS 7.1
  */
@@ -146,10 +157,34 @@
 + (instancetype)iOS:(NSString *)version;
 
 /**
-  iOS Device with the given OS version.
-  Will return nil, if no OS with the given name could be found.
+ iOS Device with the given OS version.
+ Will return nil, if no OS with the given name could be found.
  */
 - (instancetype)iOS:(NSString *)version;
+
+#pragma mark Device Scale
+
+/**
+ Launch at 25% Scale.
+ */
+- (instancetype)scale25Percent;
+
+/**
+ Launch at 50% Scale.
+ */
+- (instancetype)scale50Percent;
+
+/**
+ Launch at 75% Scale.
+ */
+- (instancetype)scale75Percent;
+
+/**
+ Launch at 100% Scale.
+ */
+- (instancetype)scale100Percent;
+
+#pragma mark Locale
 
 /**
  A new configuration with the provided locale

--- a/FBSimulatorControl/Configuration/FBSimulatorConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorConfiguration.m
@@ -156,6 +156,42 @@
 
 @end
 
+@implementation FBSimulatorConfigurationScale_25
+
+- (NSString *)scaleString
+{
+  return @"0.25";
+}
+
+@end
+
+@implementation FBSimulatorConfigurationScale_50
+
+- (NSString *)scaleString
+{
+  return @"0.50";
+}
+
+@end
+
+@implementation FBSimulatorConfigurationScale_75
+
+- (NSString *)scaleString
+{
+  return @"0.75";
+}
+
+@end
+
+@implementation FBSimulatorConfigurationScale_100
+
+- (NSString *)scaleString
+{
+  return @"1.00";
+}
+
+@end
+
 @implementation FBSimulatorConfiguration
 
 - (instancetype)copyWithZone:(NSZone *)zone
@@ -164,6 +200,7 @@
   configuration.namedDevice = self.namedDevice;
   configuration.osVersion = self.osVersion;
   configuration.locale = self.locale;
+  configuration.scale = self.scale;
   return configuration;
 }
 
@@ -177,6 +214,7 @@
     configuration = [FBSimulatorConfiguration new];
     configuration.namedDevice = [FBSimulatorConfigurationNamedDevice_iPhone5 new];
     configuration.osVersion = self.class.nameToOSVersion[sdkVersion];
+    configuration.scale = [FBSimulatorConfigurationScale_50 new];
     NSCAssert(configuration.osVersion, @"Could not get a simulator OS for SDK %@", sdkVersion);
   });
   return configuration;
@@ -194,11 +232,16 @@
   return self.osVersion.osVersion;
 }
 
+- (NSString *)scaleString
+{
+  return self.scale.scaleString;
+}
+
 #pragma mark NSObject
 
 - (NSUInteger)hash
 {
-  return self.deviceName.hash | self.osVersionString.hash | self.locale.hash;
+  return self.deviceName.hash | self.osVersionString.hash | self.locale.hash | self.scaleString.hash;
 }
 
 - (BOOL)isEqual:(FBSimulatorConfiguration *)object
@@ -207,18 +250,20 @@
     return NO;
   }
 
-  return [self.deviceName isEqual:object.deviceName] &&
-         [self.osVersionString isEqual:object.osVersionString] &&
+  return [self.deviceName isEqualToString:object.deviceName] &&
+         [self.osVersionString isEqualToString:object.osVersionString] &&
+         [self.scaleString isEqualToString:object.scaleString] &&
          ((self.locale == nil && object.locale == nil) || [self.locale isEqual:object.locale]);
 }
 
 - (NSString *)description
 {
   return [NSString stringWithFormat:
-    @"Simulator '%@' | OS Version '%@' | Locale '%@'",
+    @"Simulator '%@' | OS Version '%@' | Locale '%@' | Scale '%@'",
     self.deviceName,
     self.osVersionString,
-    self.locale
+    self.locale,
+    self.scaleString
   ];
 }
 
@@ -369,6 +414,28 @@
   return [self updateOSVersion:self.class.nameToOSVersion[version]];
 }
 
+#pragma mark Scale
+
+- (instancetype)scale25Percent
+{
+  return [self updateScale:[FBSimulatorConfigurationScale_25 new]];
+}
+
+- (instancetype)scale50Percent
+{
+  return [self updateScale:[FBSimulatorConfigurationScale_50 new]];
+}
+
+- (instancetype)scale75Percent
+{
+  return [self updateScale:[FBSimulatorConfigurationScale_75 new]];
+}
+
+- (instancetype)scale100Percent
+{
+  return [self updateScale:[FBSimulatorConfigurationScale_100 new]];
+}
+
 - (instancetype)withLocale:(NSLocale *)locale
 {
   FBSimulatorConfiguration *configuration = [self copy];
@@ -460,6 +527,16 @@
   }
   FBSimulatorConfiguration *configuration = [self copy];
   configuration.osVersion = osVersion;
+  return configuration;
+}
+
+- (instancetype)updateScale:(id<FBSimulatorConfigurationScale>)scale
+{
+  if (!scale) {
+    return nil;
+  }
+  FBSimulatorConfiguration *configuration = [self copy];
+  configuration.scale = scale;
   return configuration;
 }
 

--- a/FBSimulatorControl/Management/FBSimulator+Private.h
+++ b/FBSimulatorControl/Management/FBSimulator+Private.h
@@ -10,6 +10,7 @@
 #import <FBSimulatorControl/FBSimulator.h>
 
 @class FBSimulatorControlConfiguration;
+@class FBSimulatorConfiguration;
 
 @interface FBSimulator ()
 
@@ -25,5 +26,6 @@
 
 @property (nonatomic, assign, readwrite) NSInteger bucketID;
 @property (nonatomic, assign, readwrite) NSInteger offset;
+@property (nonatomic, copy, readwrite) FBSimulatorConfiguration *configuration;
 
 @end

--- a/FBSimulatorControl/Management/FBSimulator.h
+++ b/FBSimulatorControl/Management/FBSimulator.h
@@ -10,6 +10,7 @@
 #import <Foundation/Foundation.h>
 
 @class FBSimulatorApplication;
+@class FBSimulatorConfiguration;
 @class FBSimulatorPool;
 @class SimDevice;
 
@@ -132,6 +133,11 @@ typedef NS_ENUM(NSInteger, FBSimulatorState) {
  The Offset represents the position in the pool of this device. Multiple devices of the same type can be allocated in the same pool.
  */
 @property (nonatomic, assign, readonly) NSInteger offset;
+
+/**
+ The Configuration that this Simulator was created and will be launched with.
+ */
+@property (nonatomic, copy, readonly) FBSimulatorConfiguration *configuration;
 
 /**
  Calls `freeSimulator:error:` on this device's pool, with the reciever as the first argument

--- a/FBSimulatorControl/Management/FBSimulatorPool.m
+++ b/FBSimulatorControl/Management/FBSimulatorPool.m
@@ -13,7 +13,7 @@
 #import "FBCoreSimulatorNotifier.h"
 #import "FBSimulator+Private.h"
 #import "FBSimulatorApplication.h"
-#import "FBSimulatorConfiguration+DTMobile.h"
+#import "FBSimulatorConfiguration+CoreSimulator.h"
 #import "FBSimulatorConfiguration.h"
 #import "FBSimulatorControl.h"
 #import "FBSimulatorControlConfiguration.h"
@@ -114,9 +114,9 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
   return nil;
 }
 
-- (FBSimulator *)allocateSimulatorWithConfiguration:(FBSimulatorConfiguration *)configuration error:(NSError **)error
+- (FBManagedSimulator *)allocateSimulatorWithConfiguration:(FBSimulatorConfiguration *)configuration error:(NSError **)error
 {
-  FBSimulator *simulator = [self findOrCreateSimulatorWithConfiguration:configuration error:error];
+  FBManagedSimulator *simulator = [self findOrCreateSimulatorWithConfiguration:configuration error:error];
   if (!simulator) {
     return nil;
   }
@@ -339,16 +339,16 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
   return [self waitForSimulator:simulator toChangeToState:FBSimulatorStateShutdown withError:error];
 }
 
-- (FBSimulator *)findOrCreateSimulatorWithConfiguration:(FBSimulatorConfiguration *)configuration error:(NSError **)error
+- (FBManagedSimulator *)findOrCreateSimulatorWithConfiguration:(FBSimulatorConfiguration *)configuration error:(NSError **)error
 {
   return [self findSimulatorWithConfiguration:configuration]
       ?: [self createSimulatorWithConfiguration:configuration error:error];
 }
 
-- (FBSimulator *)findSimulatorWithConfiguration:(FBSimulatorConfiguration *)configuration
+- (FBManagedSimulator *)findSimulatorWithConfiguration:(FBSimulatorConfiguration *)configuration
 {
   NSString *deviceName = [self targetNameForConfiguration:configuration];
-  for (FBSimulator *simulator in self.unallocatedSimulators) {
+  for (FBManagedSimulator *simulator in self.unallocatedSimulators) {
     if ([simulator.name isEqualToString:deviceName]) {
       return simulator;
     }
@@ -356,7 +356,7 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
   return nil;
 }
 
-- (FBSimulator *)createSimulatorWithConfiguration:(FBSimulatorConfiguration *)configuration error:(NSError **)error
+- (FBManagedSimulator *)createSimulatorWithConfiguration:(FBSimulatorConfiguration *)configuration error:(NSError **)error
 {
   NSString *targetName = [self targetNameForConfiguration:configuration];
   SimDeviceType *targetType = configuration.deviceType;
@@ -367,7 +367,8 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
   if (!device) {
     return [[[FBSimulatorError describeFormat:@"Failed to create a simulator with the name %@", targetName] causedBy:innerError] fail:error];
   }
-  FBSimulator *simulator = [FBSimulatorPool keySimulatorsByUDID:self.allSimulatorsInPool][device.UDID.UUIDString];
+  FBManagedSimulator *simulator = [FBSimulatorPool keySimulatorsByUDID:self.allSimulatorsInPool][device.UDID.UUIDString];
+  simulator.configuration = configuration;
   NSAssert(simulator, @"Expected simulator with name %@ to be inflated into pool", targetName);
   return simulator;
 }

--- a/FBSimulatorControl/Session/FBSimulatorSessionInteraction.m
+++ b/FBSimulatorControl/Session/FBSimulatorSessionInteraction.m
@@ -15,6 +15,8 @@
 #import "FBSimulator.h"
 #import "FBSimulatorApplication.h"
 #import "FBSimulatorControl.h"
+#import "FBSimulatorConfiguration.h"
+#import "FBSimulatorConfiguration+CoreSimulator.h"
 #import "FBSimulatorError.h"
 #import "FBSimulatorPool.h"
 #import "FBSimulatorSession+Private.h"
@@ -40,13 +42,19 @@ NSTimeInterval const FBSimulatorInteractionDefaultTimeout = 30;
 
 - (instancetype)bootSimulator
 {
-  FBSimulator *simulator = self.session.simulator;
+  FBManagedSimulator *simulator = self.session.simulator;
   FBSimulatorSessionLifecycle *lifecycle = self.session.lifecycle;
 
   return [self interact:^ BOOL (NSError **error) {
+    NSArray *arguments = @[@"--args",
+      @"-CurrentDeviceUDID", simulator.udid,
+      @"-ConnectHardwareKeyboard", @"0",
+      simulator.configuration.lastScaleCommandLineSwitch, simulator.configuration.scaleString
+    ];
+
     id<FBTask> task = [FBTaskExecutor.sharedInstance
       taskWithLaunchPath:simulator.simulatorApplication.binary.path
-      arguments:@[@"--args", @"-CurrentDeviceUDID", simulator.udid, @"-ConnectHardwareKeyboard", @"0"]];
+      arguments:arguments];
 
     [lifecycle simulatorWillStart:simulator];
     [task startAsynchronously];


### PR DESCRIPTION
When launching Simulators, it can be useful to set the scale to a more appropriate one depending on the desktop resolution of the machine launching the Simulator. 

This PR adds this into the configuration, with a default value and the necessary plumbing to fix this value via the Command Line to Simulator.app.