### PR TITLE
Add Window Tiling

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		3705DB1E45CFC79099240134 /* libPods-FBSimulatorControlTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C0269E5758A83CA9C72EC922 /* libPods-FBSimulatorControlTests.a */; };
+		AA377CF81BB3EC9C0058E26E /* FBSimulatorWindowHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = AA377CF61BB3EC9C0058E26E /* FBSimulatorWindowHelpers.h */; settings = {ASSET_TAGS = (); }; };
+		AA377CF91BB3EC9C0058E26E /* FBSimulatorWindowHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = AA377CF71BB3EC9C0058E26E /* FBSimulatorWindowHelpers.m */; settings = {ASSET_TAGS = (); }; };
 		AA4877121BAC74B9007F7D23 /* FBProcessLaunchConfiguration+Helpers.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4876C41BAC74B9007F7D23 /* FBProcessLaunchConfiguration+Helpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA4877131BAC74B9007F7D23 /* FBProcessLaunchConfiguration+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = AA4876C51BAC74B9007F7D23 /* FBProcessLaunchConfiguration+Helpers.m */; settings = {ASSET_TAGS = (); }; };
 		AA4877141BAC74B9007F7D23 /* FBProcessLaunchConfiguration+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4876C61BAC74B9007F7D23 /* FBProcessLaunchConfiguration+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -106,6 +108,11 @@
 		AAC083791B9FBACB00451648 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E2976B173B900000000 /* Cocoa.framework */; };
 		AAC2411C1BB30CB30054570C /* FBSimulatorPredicates.h in Headers */ = {isa = PBXBuildFile; fileRef = AAC2411A1BB30CB30054570C /* FBSimulatorPredicates.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AAC2411D1BB30CB30054570C /* FBSimulatorPredicates.m in Sources */ = {isa = PBXBuildFile; fileRef = AAC2411B1BB30CB30054570C /* FBSimulatorPredicates.m */; settings = {ASSET_TAGS = (); }; };
+		AAC241211BB311200054570C /* FBSimulatorWindowTiler.h in Headers */ = {isa = PBXBuildFile; fileRef = AAC2411F1BB311200054570C /* FBSimulatorWindowTiler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AAC241221BB311200054570C /* FBSimulatorWindowTiler.m in Sources */ = {isa = PBXBuildFile; fileRef = AAC241201BB311200054570C /* FBSimulatorWindowTiler.m */; settings = {ASSET_TAGS = (); }; };
+		AAC241241BB3113F0054570C /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAC241231BB3113F0054570C /* AppKit.framework */; };
+		AAC241261BB311690054570C /* ApplicationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAC241251BB311690054570C /* ApplicationServices.framework */; };
+		AAC241281BB311970054570C /* FBSimulatorWindowTilingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AAC241271BB311970054570C /* FBSimulatorWindowTilingTests.m */; settings = {ASSET_TAGS = (); }; };
 		E7A30F041AC72D1E00000000 /* DVTiPhoneSimulatorRemoteClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E291AC72D1E00000000 /* DVTiPhoneSimulatorRemoteClient.framework */; };
 		E7A30F0476B173B900000000 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E2976B173B900000000 /* Cocoa.framework */; };
 		E7A30F04A6018C7A00000000 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E29A6018C7A00000000 /* CoreGraphics.framework */; };
@@ -148,6 +155,8 @@
 		1DD70E29A6018C7A00000000 /* CoreGraphics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		1DD70E29B67B6FA500000000 /* DVTFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = DVTFoundation.framework; path = ../SharedFrameworks/DVTFoundation.framework; sourceTree = DEVELOPER_DIR; };
 		1DD70E29B6970A5500000000 /* CoreSimulator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = CoreSimulator.framework; path = Library/PrivateFrameworks/CoreSimulator.framework; sourceTree = DEVELOPER_DIR; };
+		AA377CF61BB3EC9C0058E26E /* FBSimulatorWindowHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorWindowHelpers.h; sourceTree = "<group>"; };
+		AA377CF71BB3EC9C0058E26E /* FBSimulatorWindowHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorWindowHelpers.m; sourceTree = "<group>"; };
 		AA4876491BAC7399007F7D23 /* FBSimulatorControl-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "FBSimulatorControl-Info.plist"; sourceTree = "<group>"; };
 		AA4876C41BAC74B9007F7D23 /* FBProcessLaunchConfiguration+Helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FBProcessLaunchConfiguration+Helpers.h"; sourceTree = "<group>"; };
 		AA4876C51BAC74B9007F7D23 /* FBProcessLaunchConfiguration+Helpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "FBProcessLaunchConfiguration+Helpers.m"; sourceTree = "<group>"; };
@@ -812,6 +821,11 @@
 		AA8DFB0F1BAC76B60076A6C2 /* FBSimulatorSessionStateAssertion.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorSessionStateAssertion.m; sourceTree = "<group>"; };
 		AAC2411A1BB30CB30054570C /* FBSimulatorPredicates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorPredicates.h; sourceTree = "<group>"; };
 		AAC2411B1BB30CB30054570C /* FBSimulatorPredicates.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorPredicates.m; sourceTree = "<group>"; };
+		AAC2411F1BB311200054570C /* FBSimulatorWindowTiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorWindowTiler.h; sourceTree = "<group>"; };
+		AAC241201BB311200054570C /* FBSimulatorWindowTiler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorWindowTiler.m; sourceTree = "<group>"; };
+		AAC241231BB3113F0054570C /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
+		AAC241251BB311690054570C /* ApplicationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ApplicationServices.framework; path = System/Library/Frameworks/ApplicationServices.framework; sourceTree = SDKROOT; };
+		AAC241271BB311970054570C /* FBSimulatorWindowTilingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorWindowTilingTests.m; sourceTree = "<group>"; };
 		C0269E5758A83CA9C72EC922 /* libPods-FBSimulatorControlTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-FBSimulatorControlTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE0BECC2D4331B5F6BD6224D /* Pods-FBSimulatorControlTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FBSimulatorControlTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-FBSimulatorControlTests/Pods-FBSimulatorControlTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -821,6 +835,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
+				AAC241261BB311690054570C /* ApplicationServices.framework in Frameworks */,
+				AAC241241BB3113F0054570C /* AppKit.framework in Frameworks */,
 				E7A30F0476B173B900000000 /* Cocoa.framework in Frameworks */,
 				E7A30F04A6018C7A00000000 /* CoreGraphics.framework in Frameworks */,
 				E7A30F04B67B6FA500000000 /* DVTFoundation.framework in Frameworks */,
@@ -1594,6 +1610,7 @@
 				AA8DF8BF1BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m */,
 				AA51E4951BA1CA3C0053141E /* FBSimulatorStateTests.m */,
 				AA7EA4041BB309C30065DC52 /* FBSimulatorTests.m */,
+				AAC241271BB311970054570C /* FBSimulatorWindowTilingTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -1618,6 +1635,7 @@
 				AA4876E91BAC74B9007F7D23 /* Notifications */,
 				AA4876EE1BAC74B9007F7D23 /* Session */,
 				AA4877021BAC74B9007F7D23 /* Tasks */,
+				AAC2411E1BB311200054570C /* Tiling */,
 				AA48770D1BAC74B9007F7D23 /* Utility */,
 			);
 			path = FBSimulatorControl;
@@ -1634,9 +1652,22 @@
 			path = Utilities;
 			sourceTree = "<group>";
 		};
+		AAC2411E1BB311200054570C /* Tiling */ = {
+			isa = PBXGroup;
+			children = (
+				AA377CF61BB3EC9C0058E26E /* FBSimulatorWindowHelpers.h */,
+				AA377CF71BB3EC9C0058E26E /* FBSimulatorWindowHelpers.m */,
+				AAC2411F1BB311200054570C /* FBSimulatorWindowTiler.h */,
+				AAC241201BB311200054570C /* FBSimulatorWindowTiler.m */,
+			);
+			path = Tiling;
+			sourceTree = "<group>";
+		};
 		B401C97968022A5500000000 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				AAC241251BB311690054570C /* ApplicationServices.framework */,
+				AAC241231BB3113F0054570C /* AppKit.framework */,
 				AA5696391B9FB7C800A2918F /* DVTiPhoneSimulatorRemoteClient.framework */,
 				AA5696371B9FB7B500A2918F /* DVTFoundation.framework */,
 				1DD70E2976B173B900000000 /* Cocoa.framework */,
@@ -1688,6 +1719,7 @@
 				AA48772D1BAC74B9007F7D23 /* FBSimulatorPool+Private.h in Headers */,
 				AA48774A1BAC74B9007F7D23 /* FBSimulatorSessionStateGenerator.h in Headers */,
 				AA4877331BAC74B9007F7D23 /* FBSimulatorProcess.h in Headers */,
+				AA377CF81BB3EC9C0058E26E /* FBSimulatorWindowHelpers.h in Headers */,
 				AA4877481BAC74B9007F7D23 /* FBSimulatorSessionState.h in Headers */,
 				AA4877431BAC74B9007F7D23 /* FBSimulatorSessionLifecycle.h in Headers */,
 				AA4877541BAC74B9007F7D23 /* FBTerminationHandle.h in Headers */,
@@ -1700,6 +1732,7 @@
 				AA48772A1BAC74B9007F7D23 /* FBSimulatorInteraction+Private.h in Headers */,
 				AA48772E1BAC74B9007F7D23 /* FBSimulatorPool.h in Headers */,
 				AA4877151BAC74B9007F7D23 /* FBProcessLaunchConfiguration.h in Headers */,
+				AAC241211BB311200054570C /* FBSimulatorWindowTiler.h in Headers */,
 				AA4877401BAC74B9007F7D23 /* FBSimulatorSessionInteraction+Private.h in Headers */,
 				AA4877231BAC74B9007F7D23 /* FBSimulator+Queries.h in Headers */,
 				AA48772B1BAC74B9007F7D23 /* FBSimulatorInteraction.h in Headers */,
@@ -1861,6 +1894,7 @@
 				AA4877181BAC74B9007F7D23 /* FBSimulatorConfiguration+Convenience.m in Sources */,
 				AA48771A1BAC74B9007F7D23 /* FBSimulatorConfiguration+CoreSimulator.m in Sources */,
 				AA4877131BAC74B9007F7D23 /* FBProcessLaunchConfiguration+Helpers.m in Sources */,
+				AAC241221BB311200054570C /* FBSimulatorWindowTiler.m in Sources */,
 				AA4877421BAC74B9007F7D23 /* FBSimulatorSessionInteraction.m in Sources */,
 				AA4877471BAC74B9007F7D23 /* FBSimulatorSessionState+Queries.m in Sources */,
 				AA4877161BAC74B9007F7D23 /* FBProcessLaunchConfiguration.m in Sources */,
@@ -1868,6 +1902,7 @@
 				AA4877211BAC74B9007F7D23 /* FBSimulatorControlStaticConfiguration.m in Sources */,
 				AA4877381BAC74B9007F7D23 /* FBDispatchSourceNotifier.m in Sources */,
 				AA4877531BAC74B9007F7D23 /* FBTaskExecutor.m in Sources */,
+				AA377CF91BB3EC9C0058E26E /* FBSimulatorWindowHelpers.m in Sources */,
 				AA4877571BAC74B9007F7D23 /* FBSimulatorLogger.m in Sources */,
 				AA4877491BAC74B9007F7D23 /* FBSimulatorSessionState.m in Sources */,
 				AA4877261BAC74B9007F7D23 /* FBSimulator.m in Sources */,
@@ -1883,6 +1918,7 @@
 				AA51E49B1BA1CA3C0053141E /* FBSimulatorControlConfigurationTests.m in Sources */,
 				AA8DFB111BAC76B60076A6C2 /* FBSimulatorSessionStateAssertion.m in Sources */,
 				AA74B99E1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m in Sources */,
+				AAC241281BB311970054570C /* FBSimulatorWindowTilingTests.m in Sources */,
 				AA8DFB101BAC76B60076A6C2 /* FBSimulatorControlNotificationAssertion.m in Sources */,
 				AA51E49E1BA1CA3C0053141E /* FBSimulatorStateTests.m in Sources */,
 				AA51E49C1BA1CA3C0053141E /* FBSimulatorControlSimulatorLaunchTests.m in Sources */,

--- a/FBSimulatorControl/Session/FBSimulatorSessionInteraction.h
+++ b/FBSimulatorControl/Session/FBSimulatorSessionInteraction.h
@@ -37,6 +37,11 @@
 - (instancetype)bootSimulator;
 
 /**
+ Tiles the Simulator in the first available position on the Display.
+ */
+- (instancetype)tileSimulator;
+
+/**
  Installs the given Application.
  */
 - (instancetype)installApplication:(FBSimulatorApplication *)application;

--- a/FBSimulatorControl/Session/FBSimulatorSessionInteraction.m
+++ b/FBSimulatorControl/Session/FBSimulatorSessionInteraction.m
@@ -25,6 +25,7 @@
 #import "FBSimulatorSessionLifecycle.h"
 #import "FBSimulatorSessionState+Queries.h"
 #import "FBSimulatorSessionState.h"
+#import "FBSimulatorWindowTiler.h"
 #import "FBTaskExecutor.h"
 
 NSTimeInterval const FBSimulatorInteractionDefaultTimeout = 30;
@@ -71,6 +72,20 @@ NSTimeInterval const FBSimulatorInteractionDefaultTimeout = 30;
 
     [lifecycle simulator:simulator didStartWithProcessIdentifier:task.processIdentifier terminationHandle:task];
 
+    return YES;
+  }];
+}
+
+- (instancetype)tileSimulator
+{
+  FBSimulator *simulator = self.session.simulator;
+
+  return [self interact:^ BOOL (NSError **error) {
+    FBSimulatorWindowTiler *tiler = [FBSimulatorWindowTiler withSimulator:simulator];
+    NSError *innerError = nil;
+    if (CGRectIsNull([tiler placeInForegroundWithError:&innerError])) {
+      return [FBSimulatorError failWithError:innerError errorOut:error];
+    }
     return YES;
   }];
 }

--- a/FBSimulatorControl/Tiling/FBSimulatorWindowHelpers.h
+++ b/FBSimulatorControl/Tiling/FBSimulatorWindowHelpers.h
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
+
+@class FBSimulator;
+
+@interface FBSimulatorWindowHelpers : NSObject
+
+/**
+ Creates and returns an NSArray<CGRect> of the bounds of all Simulators except the provided Simulator.
+
+ @param the simulator to exclude from the bounds fetch
+ @return an NSArray<CGRect> of these bounds.
+ */
++ (NSArray *)obtainBoundsOfOtherSimulators:(FBSimulator *)simulator;
+
+/**
+ Creates and returns an NSArray<NSDictionary> of Simulator.app Windows that belong to the Ordered Set of Simulator.
+ The Dictionary contains Windows in format from 'Quartz Window Services'
+
+ @param simulator the Simulators to find Windows For.
+ @return array an Array of the windows that could be found for the provided Simulators.
+ */
++ (NSArray *)windowsForSimulators:(NSOrderedSet *)simulators;
+
+/**
+ Returns the CGDirectDisplayID for the provided Simulator.
+
+ @param simulator the Simulators to find the DisplayID For.
+ @param cropRect an outparam for the Cropping Rectangle in Screen Bounds.
+ @param screenSize the size of the Screen containing the Simulator.
+ @return the Display ID of the Simulator or 0 if it could not be found.
+ */
++ (CGDirectDisplayID)displayIDForSimulator:(FBSimulator *)simulator cropRect:(CGRect *)cropRect screenSize:(CGSize *)screenSize;
+
+@end

--- a/FBSimulatorControl/Tiling/FBSimulatorWindowHelpers.m
+++ b/FBSimulatorControl/Tiling/FBSimulatorWindowHelpers.m
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBSimulatorWindowHelpers.h"
+
+#import "FBSimulator.h"
+#import "FBSimulatorPredicates.h"
+#import "FBSimulatorPool.h"
+
+// See https://github.com/appium/screen_recording/pull/6
+extern void CGSInitialize(void);
+static void EnsureCGIsInitialized(void)
+{
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    CGSInitialize();
+  });
+}
+
+@implementation FBSimulatorWindowHelpers
+
++ (NSArray *)obtainBoundsOfOtherSimulators:(FBSimulator *)simulator
+{
+  NSPredicate *predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[
+    [FBSimulatorPredicates launched],
+    [NSCompoundPredicate notPredicateWithSubpredicate:[FBSimulatorPredicates only:simulator]],
+  ]];
+  NSOrderedSet *simulators = [simulator.pool.allSimulators filteredOrderedSetUsingPredicate:predicate];
+  NSArray *windows = [self windowsForSimulators:simulators];
+
+  NSMutableArray *boundsValues = [NSMutableArray array];
+  for (NSDictionary *window in windows) {
+    NSDictionary *boundsDictionary = window[(NSString *)kCGWindowBounds];
+    CGRect windowBounds = CGRectZero;
+    if (!CGRectMakeWithDictionaryRepresentation((CFDictionaryRef) boundsDictionary, &windowBounds)) {
+      continue;
+    }
+    [boundsValues addObject:[NSValue valueWithRect:windowBounds]];
+  }
+  return [boundsValues copy];
+}
+
++ (NSArray *)windowsForSimulators:(NSOrderedSet *)simulators
+{
+  NSArray *windows = CFBridgingRelease(CGWindowListCopyWindowInfo(kCGWindowListOptionAll, kCGNullWindowID));
+
+  // Filtering by PID first will knock out all non-Simulator processes.
+  NSOrderedSet *pids = [simulators valueForKey:@"processIdentifier"];
+  NSPredicate *pidPredicate = [NSPredicate predicateWithBlock:^ BOOL (NSDictionary *window, NSDictionary *_) {
+    NSNumber *processIdentifier = window[(NSString *)kCGWindowOwnerPID];
+    return [pids containsObject:processIdentifier];
+  }];
+  // Each Simulator Process appears to have multiple Windows, with strange bounds.
+  // We just care about the named one, which is the Simulator.app window with the Simulator's canvas.
+  NSPredicate *namePredicate = [NSPredicate predicateWithBlock:^ BOOL (NSDictionary *window, NSDictionary *_) {
+    NSString *windowName = window[(NSString *)kCGWindowName];
+    return windowName.length > 0;
+  }];
+  NSPredicate *predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[
+    pidPredicate,
+    namePredicate
+  ]];
+
+  return [windows filteredArrayUsingPredicate:predicate];
+}
+
++ (CGDirectDisplayID)displayIDForSimulator:(FBSimulator *)simulator cropRect:(CGRect *)cropRect screenSize:(CGSize *)screenSize
+{
+  EnsureCGIsInitialized();
+
+  NSDictionary *window = [[self windowsForSimulators:[NSOrderedSet orderedSetWithObject:simulator]] firstObject];
+  if (!window) {
+    return 0;
+  }
+
+  NSDictionary *boundsDictionary = window[(NSString *)kCGWindowBounds];
+  CGRect windowBounds = CGRectZero;
+  if (!CGRectMakeWithDictionaryRepresentation((CFDictionaryRef) boundsDictionary, &windowBounds)) {
+    return 0;
+  }
+
+  CGDirectDisplayID displayID = 0;
+  CGGetDisplaysWithRect(windowBounds, 1, &displayID, NULL);
+  CGRect displayBounds = CGDisplayBounds(displayID);
+
+  if (cropRect) {
+    CGRect displayBounds = CGDisplayBounds(displayID);
+    *cropRect = CGRectMake(
+      CGRectGetMinX(windowBounds) - CGRectGetMinX(displayBounds),
+      CGRectGetMaxY(displayBounds) - CGRectGetHeight(windowBounds),
+      CGRectGetWidth(windowBounds),
+      CGRectGetHeight(windowBounds)
+    );
+  }
+  if (screenSize) {
+    *screenSize = CGDisplayScreenSize(displayID);
+  }
+
+  return displayID;
+}
+
+@end

--- a/FBSimulatorControl/Tiling/FBSimulatorWindowTiler.h
+++ b/FBSimulatorControl/Tiling/FBSimulatorWindowTiler.h
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Cocoa/Cocoa.h>
+
+@class FBSimulator;
+
+/**
+ A class responsible for tiling Simulator Windows and bringing them to the foreground
+ */
+@interface FBSimulatorWindowTiler : NSObject
+
+/**
+ Creates and returns a new Window Tiler for the provided Simulator
+ 
+ @param simulator the Simulator to position.
+ @return a new FBWindowTiler instance.
+ */
++ (instancetype)withSimulator:(FBSimulator *)simulator;
+
+/**
+ Moves the Simuator into the foreground in the first available position that is not occluded by any other Simulator
+ If the Window is too small then to contain this, as well as other Simulators, the position is undefined
+ 
+ @param error an error out for any error that occurred.
+ @return a CGRect representing the final position of the Window. CGRectNull if an error occured.
+ */
+- (CGRect)placeInForegroundWithError:(NSError **)error;
+
+@end

--- a/FBSimulatorControl/Tiling/FBSimulatorWindowTiler.m
+++ b/FBSimulatorControl/Tiling/FBSimulatorWindowTiler.m
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBSimulatorWindowTiler.h"
+
+#import "FBSimulator.h"
+#import "FBSimulatorError.h"
+#import "FBSimulatorPool.h"
+#import "FBSimulatorPredicates.h"
+#import "FBSimulatorWindowHelpers.h"
+
+static inline NSRange FBHorizontalOcclusionRange(CGRect rect)
+{
+  rect = CGRectIntegral(rect);
+  return NSMakeRange(
+    (NSUInteger) CGRectGetMinX(rect),
+    (NSUInteger) (CGRectGetMaxX(rect) - CGRectGetMinX(rect))
+  );
+}
+
+@interface FBWindowOcclusionArea : NSObject
+
+@property (nonatomic, assign, readwrite) CGSize size;
+@property (nonatomic, strong, readwrite) NSArray *contents;
+
+@end
+
+@implementation FBWindowOcclusionArea
+
++ (instancetype)ofSize:(CGSize)size contents:(NSArray *)contents
+{
+  FBWindowOcclusionArea *area = [FBWindowOcclusionArea new];
+  area.size = size;
+  area.contents = contents;
+  return area;
+}
+
+- (CGRect)bestFittingRectangleOfSize:(CGSize)size
+{
+  // Only checks the X-Axis
+  NSMutableIndexSet *xOccluded = [NSMutableIndexSet indexSet];
+  for (NSValue *contentRectValue in self.contents) {
+    [xOccluded addIndexesInRange:FBHorizontalOcclusionRange(contentRectValue.rectValue)];
+  }
+
+  CGRect rect = { CGPointZero, size };
+  while ([xOccluded containsIndexesInRange:FBHorizontalOcclusionRange(rect)]) {
+    rect.origin.x += CGRectGetWidth(rect);
+  }
+  return rect;
+}
+
+@end
+
+@interface FBSimulatorWindowTiler ()
+
+@property (nonatomic, strong, readwrite) FBSimulator *simulator;
+
+@end
+
+@implementation FBSimulatorWindowTiler
+
++ (instancetype)withSimulator:(FBSimulator *)simulator
+{
+  FBSimulatorWindowTiler *tiler = [FBSimulatorWindowTiler new];
+  tiler.simulator = simulator;
+  return tiler;
+}
+
+- (CGRect)placeInForegroundWithError:(NSError **)error
+{
+  if (!AXIsProcessTrusted()) {
+    return [[FBSimulatorError describe:@"Current process is untrusted"] failRect:error];
+  }
+  if (self.simulator.processIdentifier < 1) {
+    return [[[FBSimulatorError describe:@"Cannot find Window ID"] inSimulator:self.simulator] failRect:error];
+  }
+
+  AXUIElementRef applicationElement = AXUIElementCreateApplication(self.simulator.processIdentifier);
+  if (!applicationElement) {
+    return [[[FBSimulatorError describe:@"Could not get an Application Element for process"] inSimulator:self.simulator] failRect:error];
+  }
+
+  // Get the Window
+  AXUIElementRef windowElement = NULL;
+  if (AXUIElementCopyAttributeValue(applicationElement, (CFStringRef) NSAccessibilityFocusedWindowAttribute, (CFTypeRef *) &windowElement) != kAXErrorSuccess) {
+    return [[[FBSimulatorError describe:@"Could not get the Window Element for the forground Simulator"] inSimulator:self.simulator] failRect:error];
+  }
+
+  // Get the size of the window
+  CGSize size = CGSizeZero;
+  AXValueRef sizeValue = NULL;
+  if (AXUIElementCopyAttributeValue(windowElement, (CFStringRef) NSAccessibilitySizeAttribute, (CFTypeRef *) &sizeValue) != kAXErrorSuccess) {
+    return [[[FBSimulatorError describe:@"Could not get the size of the Window element"] inSimulator:self.simulator] failRect:error];
+  }
+  if (!AXValueGetValue(sizeValue, kAXValueCGSizeType, (void *) &size)) {
+    return [[[FBSimulatorError describe:@"Could not extract the Size struct from the value"] inSimulator:self.simulator] failRect:error];
+  }
+
+  // Position at the appropriate position.
+  NSError *innerError = nil;
+  CGRect frame = [self bestFittingRectangeOfSize:size withError:&innerError];
+  if (CGRectIsNull(frame)) {
+    return [[[[FBSimulatorError describe:@"Could not find the best fit for the tiled window"] inSimulator:self.simulator] causedBy:innerError] failRect:error];
+  }
+
+  // Only the position needs to be set as the Size of the Window is fixed.
+  AXValueRef positionValue = AXValueCreate(kAXValueCGPointType, (void *) &(frame.origin));
+  if (AXUIElementSetAttributeValue(windowElement, (CFStringRef) NSAccessibilityPositionAttribute, (CFTypeRef *) positionValue) != kAXErrorSuccess) {
+    return [[[FBSimulatorError describe:@"Could not set the position for the Window element"] inSimulator:self.simulator] failRect:error];
+  }
+
+  // Bring to the front
+  if (AXUIElementSetAttributeValue(applicationElement, (CFStringRef) NSAccessibilityFrontmostAttribute, kCFBooleanTrue) != kAXErrorSuccess) {
+    return [[[FBSimulatorError describe:@"Could not make Simulator Application frontmost"] inSimulator:self.simulator] failRect:error];
+  }
+
+  return frame;
+}
+
+- (CGRect)bestFittingRectangeOfSize:(CGSize)size withError:(NSError **)error
+{
+  CGSize displaySize = CGSizeZero;
+  if (![FBSimulatorWindowHelpers displayIDForSimulator:self.simulator cropRect:NULL screenSize:&displaySize]) {
+    return [[FBSimulatorError describe:@"Could not get the Screen Bounds"] failRect:error];
+  }
+
+  NSArray *otherWindowsBounds = [FBSimulatorWindowHelpers obtainBoundsOfOtherSimulators:self.simulator];
+  FBWindowOcclusionArea *area = [FBWindowOcclusionArea ofSize:displaySize contents:otherWindowsBounds];
+  return [area bestFittingRectangleOfSize:size];
+}
+
+@end

--- a/FBSimulatorControl/Utility/FBSimulatorError.h
+++ b/FBSimulatorControl/Utility/FBSimulatorError.h
@@ -39,6 +39,7 @@ extern NSString *const FBSimulatorControlErrorDomain;
  For returning early from failing conditions.
  */
 - (BOOL)failBool:(NSError **)error;
+- (CGRect)failRect:(NSError **)error;
 - (id)fail:(NSError **)error;
 
 /**

--- a/FBSimulatorControl/Utility/FBSimulatorError.m
+++ b/FBSimulatorControl/Utility/FBSimulatorError.m
@@ -83,6 +83,14 @@ NSString *const FBSimulatorControlErrorDomain = @"com.facebook.FBSimulatorContro
   return NO;
 }
 
+- (CGRect)failRect:(NSError **)error
+{
+  if (error) {
+    *error = [self build];
+  }
+  return CGRectNull;
+}
+
 - (id)fail:(NSError **)error
 {
   if (error) {

--- a/FBSimulatorControlTests/Tests/FBSimulatorWindowTilingTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorWindowTilingTests.m
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+#import <AppKit/AppKit.h>
+
+#import <FBSimulatorControl/FBSimulator+Queries.h>
+#import <FBSimulatorControl/FBSimulator.h>
+#import <FBSimulatorControl/FBSimulatorApplication.h>
+#import <FBSimulatorControl/FBSimulatorConfiguration.h>
+#import <FBSimulatorControl/FBSimulatorControl+Private.h>
+#import <FBSimulatorControl/FBSimulatorControl.h>
+#import <FBSimulatorControl/FBSimulatorControlConfiguration.h>
+#import <FBSimulatorControl/FBSimulatorPool.h>
+#import <FBSimulatorControl/FBSimulatorSession.h>
+#import <FBSimulatorControl/FBSimulatorSessionInteraction.h>
+#import <FBSimulatorControl/FBSimulatorSessionLifecycle.h>
+#import <FBSimulatorControl/FBSimulatorSessionState+Queries.h>
+#import <FBSimulatorControl/FBSimulatorSessionState.h>
+#import <FBSimulatorControl/FBSimulatorWindowTiler.h>
+
+@interface FBSimulatorWindowTilingTests : XCTestCase
+
+@property (nonatomic, strong) FBSimulatorControl *control;
+
+@end
+
+@implementation FBSimulatorWindowTilingTests
+
+- (void)setUp
+{
+  FBSimulatorManagementOptions options =
+  FBSimulatorManagementOptionsDeleteManagedSimulatorsOnFirstStart |
+  FBSimulatorManagementOptionsKillUnmanagedSimulatorsOnFirstStart |
+  FBSimulatorManagementOptionsDeleteOnFree;
+
+  FBSimulatorControlConfiguration *configuration = [FBSimulatorControlConfiguration
+    configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
+    namePrefix:nil
+    bucket:0
+    options:options];
+
+  self.control = [[FBSimulatorControl alloc] initWithConfiguration:configuration];
+}
+
+- (void)testTilesSingleiPhoneSimulatorInTopLeft
+{
+  // Approval is required externally to the Test Runner. Without approval, the tests can't run
+  if (!AXIsProcessTrusted()) {
+    NSLog(@"%@ can't run as the host process isn't trusted", NSStringFromSelector(_cmd));
+    return;
+  }
+
+  NSError *error = nil;
+  FBSimulatorSession *session = [self.control createSessionForSimulatorConfiguration:FBSimulatorConfiguration.iPhone5 error:&error];
+  XCTAssertNotNil(session);
+  XCTAssertNil(error);
+
+  BOOL success = [[session.interact
+    bootSimulator]
+    performInteractionWithError:&error];
+  XCTAssertTrue(success);
+  XCTAssertNil(error);
+
+  FBSimulatorWindowTiler *tiler = [FBSimulatorWindowTiler withSimulator:session.simulator];
+  CGRect position = [tiler placeInForegroundWithError:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(CGRectGetMinX(position), 0);
+  XCTAssertEqual(CGRectGetMinX(position), 0);
+}
+
+- (void)disabled_testTilesMultipleiPhones5Horizontally
+{
+  // Approval is required externally to the Test Runner. Without approval, the tests can't run
+  if (!AXIsProcessTrusted()) {
+    NSLog(@"%@ can't run as the host process isn't trusted", NSStringFromSelector(_cmd));
+    return;
+  }
+
+  FBSimulatorConfiguration *configuration = FBSimulatorConfiguration.iPhone5.scale50Percent;
+  CGFloat scaleFactor = NSScreen.mainScreen.backingScaleFactor;
+
+  NSError *error = nil;
+  FBSimulatorSession *firstSession = [self.control createSessionForSimulatorConfiguration:configuration error:&error];
+  XCTAssertNotNil(firstSession);
+  XCTAssertNil(error);
+
+  BOOL success = [[firstSession.interact
+    bootSimulator]
+    performInteractionWithError:&error];
+  XCTAssertTrue(success);
+  XCTAssertNil(error);
+
+  FBSimulatorWindowTiler *tiler = [FBSimulatorWindowTiler withSimulator:firstSession.simulator];
+  CGRect position = [tiler placeInForegroundWithError:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(CGRectGetMinX(position), 0);
+  XCTAssertEqual(CGRectGetMinY(position), 0);
+
+  FBSimulatorSession *secondSession = [self.control createSessionForSimulatorConfiguration:configuration error:&error];
+  XCTAssertNotNil(secondSession);
+  XCTAssertNil(error);
+
+  success = [[secondSession.interact
+    bootSimulator]
+    performInteractionWithError:&error];
+  XCTAssertTrue(success);
+  XCTAssertNil(error);
+
+  tiler = [FBSimulatorWindowTiler withSimulator:secondSession.simulator];
+  position = [tiler placeInForegroundWithError:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(CGRectGetMinX(position), 320 / scaleFactor);
+  XCTAssertEqual(CGRectGetMinY(position), 0);
+
+  FBSimulatorSession *thirdSession = [self.control createSessionForSimulatorConfiguration:configuration error:&error];
+  XCTAssertNotNil(thirdSession);
+  XCTAssertNil(error);
+
+  success = [[thirdSession.interact
+    bootSimulator]
+    performInteractionWithError:&error];
+  XCTAssertTrue(success);
+  XCTAssertNil(error);
+
+  tiler = [FBSimulatorWindowTiler withSimulator:thirdSession.simulator];
+  position = [tiler placeInForegroundWithError:&error];
+  XCTAssertNil(error);
+  XCTAssertEqual(CGRectGetMinX(position), 640 / scaleFactor);
+  XCTAssertEqual(CGRectGetMinY(position), 0);
+}
+
+@end


### PR DESCRIPTION
Using the Mac OS X Accessibility APIs, it's possible to tile the windows so that they are in the foreground and do not overlap each other. This makes observing the windows in an automated fashion substantially easier.

Adds a test to this effect.

- [x] Figure out how to find the best non-occluded fit in a display
- [x] How to get this running on Travis-CI given that approval for accessibility is required.
- [x] Fix Build-Break
- [x] Tile in an `FBSimulatorSessionInteraction`
- [x] `CFTypeRef`s require releasing.