### PR TITLE
Add inference of Simulator Process Identifiers

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -92,6 +92,8 @@
 		AA74B99A1BB014A200C1E59C /* FBSimulatorError.m in Sources */ = {isa = PBXBuildFile; fileRef = AA74B9981BB014A200C1E59C /* FBSimulatorError.m */; settings = {ASSET_TAGS = (); }; };
 		AA74B99C1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA74B99B1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m */; settings = {ASSET_TAGS = (); }; };
 		AA74B99E1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA74B99D1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m */; settings = {ASSET_TAGS = (); }; };
+		AA7EA4061BB309C30065DC52 /* FBSimulatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA7EA4041BB309C30065DC52 /* FBSimulatorTests.m */; settings = {ASSET_TAGS = (); }; };
+		AA7EA4071BB309C30065DC52 /* FBTaskExecutorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA7EA4051BB309C30065DC52 /* FBTaskExecutorTests.m */; settings = {ASSET_TAGS = (); }; };
 		AA819DB71B9FB40D002F58CA /* FBSimulatorControl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E291A4B50E500000001 /* FBSimulatorControl.framework */; };
 		AA8DF8C01BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA8DF8BF1BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m */; settings = {ASSET_TAGS = (); }; };
 		AA8DF8C91BB18B3700CC0411 /* FBInteraction.h in Headers */ = {isa = PBXBuildFile; fileRef = AA8DF8C61BB18B3700CC0411 /* FBInteraction.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -796,6 +798,8 @@
 		AA74B9981BB014A200C1E59C /* FBSimulatorError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorError.m; sourceTree = "<group>"; };
 		AA74B99B1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorPoolAllocationTests.m; sourceTree = "<group>"; };
 		AA74B99D1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBProcessLaunchConfigurationTests.m; sourceTree = "<group>"; };
+		AA7EA4041BB309C30065DC52 /* FBSimulatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorTests.m; sourceTree = "<group>"; };
+		AA7EA4051BB309C30065DC52 /* FBTaskExecutorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBTaskExecutorTests.m; sourceTree = "<group>"; };
 		AA819DB21B9FB40D002F58CA /* FBSimulatorControlTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FBSimulatorControlTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA819E0B1B9FB427002F58CA /* FBSimulatorControlTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "FBSimulatorControlTests-Info.plist"; sourceTree = "<group>"; };
 		AA8DF8BF1BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorSessionLifecycleTests.m; sourceTree = "<group>"; };
@@ -1585,6 +1589,8 @@
 				AA51E4941BA1CA3C0053141E /* FBSimulatorPoolTests.m */,
 				AA8DF8BF1BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m */,
 				AA51E4951BA1CA3C0053141E /* FBSimulatorStateTests.m */,
+				AA7EA4041BB309C30065DC52 /* FBSimulatorTests.m */,
+				AA7EA4051BB309C30065DC52 /* FBTaskExecutorTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -1875,6 +1881,8 @@
 				AA8DFB101BAC76B60076A6C2 /* FBSimulatorControlNotificationAssertion.m in Sources */,
 				AA51E49E1BA1CA3C0053141E /* FBSimulatorStateTests.m in Sources */,
 				AA51E49C1BA1CA3C0053141E /* FBSimulatorControlSimulatorLaunchTests.m in Sources */,
+				AA7EA4061BB309C30065DC52 /* FBSimulatorTests.m in Sources */,
+				AA7EA4071BB309C30065DC52 /* FBTaskExecutorTests.m in Sources */,
 				AA51E49D1BA1CA3C0053141E /* FBSimulatorPoolTests.m in Sources */,
 				AA74B99C1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m in Sources */,
 				AA51E4991BA1CA3C0053141E /* FBSimulatorApplicationTests.m in Sources */,

--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -93,7 +93,6 @@
 		AA74B99C1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA74B99B1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m */; settings = {ASSET_TAGS = (); }; };
 		AA74B99E1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA74B99D1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m */; settings = {ASSET_TAGS = (); }; };
 		AA7EA4061BB309C30065DC52 /* FBSimulatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA7EA4041BB309C30065DC52 /* FBSimulatorTests.m */; settings = {ASSET_TAGS = (); }; };
-		AA7EA4071BB309C30065DC52 /* FBTaskExecutorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA7EA4051BB309C30065DC52 /* FBTaskExecutorTests.m */; settings = {ASSET_TAGS = (); }; };
 		AA819DB71B9FB40D002F58CA /* FBSimulatorControl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E291A4B50E500000001 /* FBSimulatorControl.framework */; };
 		AA8DF8C01BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA8DF8BF1BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m */; settings = {ASSET_TAGS = (); }; };
 		AA8DF8C91BB18B3700CC0411 /* FBInteraction.h in Headers */ = {isa = PBXBuildFile; fileRef = AA8DF8C61BB18B3700CC0411 /* FBInteraction.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -799,7 +798,6 @@
 		AA74B99B1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorPoolAllocationTests.m; sourceTree = "<group>"; };
 		AA74B99D1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBProcessLaunchConfigurationTests.m; sourceTree = "<group>"; };
 		AA7EA4041BB309C30065DC52 /* FBSimulatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorTests.m; sourceTree = "<group>"; };
-		AA7EA4051BB309C30065DC52 /* FBTaskExecutorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBTaskExecutorTests.m; sourceTree = "<group>"; };
 		AA819DB21B9FB40D002F58CA /* FBSimulatorControlTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FBSimulatorControlTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA819E0B1B9FB427002F58CA /* FBSimulatorControlTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "FBSimulatorControlTests-Info.plist"; sourceTree = "<group>"; };
 		AA8DF8BF1BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorSessionLifecycleTests.m; sourceTree = "<group>"; };
@@ -1590,7 +1588,6 @@
 				AA8DF8BF1BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m */,
 				AA51E4951BA1CA3C0053141E /* FBSimulatorStateTests.m */,
 				AA7EA4041BB309C30065DC52 /* FBSimulatorTests.m */,
-				AA7EA4051BB309C30065DC52 /* FBTaskExecutorTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -1882,7 +1879,6 @@
 				AA51E49E1BA1CA3C0053141E /* FBSimulatorStateTests.m in Sources */,
 				AA51E49C1BA1CA3C0053141E /* FBSimulatorControlSimulatorLaunchTests.m in Sources */,
 				AA7EA4061BB309C30065DC52 /* FBSimulatorTests.m in Sources */,
-				AA7EA4071BB309C30065DC52 /* FBTaskExecutorTests.m in Sources */,
 				AA51E49D1BA1CA3C0053141E /* FBSimulatorPoolTests.m in Sources */,
 				AA74B99C1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m in Sources */,
 				AA51E4991BA1CA3C0053141E /* FBSimulatorApplicationTests.m in Sources */,

--- a/FBSimulatorControl/Management/FBSimulator+Queries.h
+++ b/FBSimulatorControl/Management/FBSimulator+Queries.h
@@ -18,12 +18,6 @@
 - (BOOL)hasActiveLaunchdSim;
 
 /**
- Returns the Process Identifier of the running launchd_sim for this Simulator>
- nil if there is no running launchd_sim
- */
-- (NSNumber *)launchdSimProcessIdentifier;
-
-/**
  Returns an NSArray<id<FBSimulatorProcess>> of the subprocesses of launchd_sim.
  */
 - (NSArray *)launchedProcesses;

--- a/FBSimulatorControl/Management/FBSimulator+Queries.m
+++ b/FBSimulatorControl/Management/FBSimulator+Queries.m
@@ -16,37 +16,18 @@
 
 - (BOOL)hasActiveLaunchdSim
 {
-  return self.launchdSimProcessIdentifier != nil;
-}
-
-- (NSNumber *)launchdSimProcessIdentifier
-{
-  NSString *bootstrapPath = self.launchdBootstrapPath;
-  if (!bootstrapPath) {
-    return NO;
-  }
-
-  NSInteger processIdentifier = [[[[FBTaskExecutor.sharedInstance
-    taskWithLaunchPath:@"/usr/bin/pgrep" arguments:@[@"-f", bootstrapPath]]
-    startSynchronouslyWithTimeout:5]
-    stdOut]
-    integerValue];
-
-  if (processIdentifier < 2) {
-    return nil;
-  }
-  return @(processIdentifier);
+  return self.launchdSimProcessIdentifier > 1;
 }
 
 - (NSArray *)launchedProcesses
 {
-  NSNumber *launchdSimProcessIdentifier = self.launchdSimProcessIdentifier;
-  if (!launchdSimProcessIdentifier) {
+  NSInteger launchdSimProcessIdentifier = self.launchdSimProcessIdentifier;
+  if (launchdSimProcessIdentifier < 1) {
     return @[];
   }
 
   NSString *allProcesses = [[[FBTaskExecutor.sharedInstance
-    taskWithLaunchPath:@"/usr/bin/pgrep" arguments:@[@"-lfP", [launchdSimProcessIdentifier stringValue]]]
+    taskWithLaunchPath:@"/usr/bin/pgrep" arguments:@[@"-lfP", [@(launchdSimProcessIdentifier) stringValue]]]
     startSynchronouslyWithTimeout:10]
     stdOut];
 

--- a/FBSimulatorControl/Management/FBSimulator.h
+++ b/FBSimulatorControl/Management/FBSimulator.h
@@ -79,6 +79,11 @@ typedef NS_ENUM(NSInteger, FBSimulatorState) {
 @property (nonatomic, copy, readonly) NSString *launchdBootstrapPath;
 
 /**
+ The Process Identifier of the Simulator's launchd_sim. -1 if it is not running
+ */
+@property (nonatomic, assign, readonly) NSInteger launchdSimProcessIdentifier;
+
+/**
  The Application that the Simulator should be launched with.
  */
 @property (nonatomic, copy, readonly) FBSimulatorApplication *simulatorApplication;

--- a/FBSimulatorControl/Session/FBSimulatorSessionLifecycle.m
+++ b/FBSimulatorControl/Session/FBSimulatorSessionLifecycle.m
@@ -80,7 +80,6 @@ NSString *const FBSimulatorSessionExpectedKey = @"expected";
 {
   NSParameterAssert(terminationHandle);
   NSParameterAssert(self.simulatorTerminationHandle == nil);
-  NSParameterAssert(simulator.processIdentifier == -1);
   NSParameterAssert(simulator == self.session.simulator);
 
   if (self.currentState.lifecycle == FBSimulatorSessionLifecycleStateNotStarted) {
@@ -111,7 +110,6 @@ NSString *const FBSimulatorSessionExpectedKey = @"expected";
 
 - (void)clearSimulatorState:(FBSimulator *)simulator
 {
-  NSParameterAssert(simulator.processIdentifier != -1);
   NSParameterAssert(simulator == self.session.simulator);
   NSParameterAssert(self.currentState.lifecycle == FBSimulatorSessionLifecycleStateStarted);
 

--- a/FBSimulatorControlTests/Tests/FBSimulatorControlSimulatorLaunchTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorControlSimulatorLaunchTests.m
@@ -29,12 +29,6 @@
 
 #import "FBSimulatorControlNotificationAssertion.h"
 
-/**
- A suite of tests that confirm that it's possible to boot emulators.
- Doesn't test the booting of Agents/Applications (yet).
- We could probably get this to boot Safari on the Simulator as well.
- sysctl(3) can confirm the process ids of the Simulators are correct.
- */
 @interface FBSimulatorControlSimulatorLaunchTests : XCTestCase
 
 @property (nonatomic, strong) FBSimulatorControl *control;

--- a/FBSimulatorControlTests/Tests/FBSimulatorTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorTests.m
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <FBSimulatorControl/FBProcessLaunchConfiguration.h>
+#import <FBSimulatorControl/FBSimulator.h>
+#import <FBSimulatorControl/FBSimulator+Private.h>
+#import <FBSimulatorControl/FBSimulatorApplication.h>
+#import <FBSimulatorControl/FBSimulatorConfiguration.h>
+#import <FBSimulatorControl/FBSimulatorControl+Private.h>
+#import <FBSimulatorControl/FBSimulatorControl.h>
+#import <FBSimulatorControl/FBSimulatorControlConfiguration.h>
+#import <FBSimulatorControl/FBSimulatorPool.h>
+#import <FBSimulatorControl/FBSimulatorSession.h>
+#import <FBSimulatorControl/FBSimulatorSessionInteraction.h>
+#import <FBSimulatorControl/FBSimulatorSessionLifecycle.h>
+#import <FBSimulatorControl/FBSimulatorSessionState+Queries.h>
+#import <FBSimulatorControl/FBSimulatorSessionState.h>
+
+@interface FBSimulatorTests : XCTestCase
+
+@property (nonatomic, strong) FBSimulatorControl *control;
+
+@end
+
+@implementation FBSimulatorTests
+
+- (void)setUp
+{
+  FBSimulatorManagementOptions options =
+    FBSimulatorManagementOptionsDeleteManagedSimulatorsOnFirstStart |
+    FBSimulatorManagementOptionsKillUnmanagedSimulatorsOnFirstStart |
+    FBSimulatorManagementOptionsDeleteOnFree;
+
+  FBSimulatorControlConfiguration *configuration = [FBSimulatorControlConfiguration
+    configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
+    namePrefix:nil
+    bucket:0
+    options:options];
+
+  self.control = [[FBSimulatorControl alloc] initWithConfiguration:configuration];
+}
+
+- (void)testCanInferProcessIdentiferAppropriately
+{
+  NSError *error = nil;
+  FBSimulatorSession *session = [self.control createSessionForSimulatorConfiguration:FBSimulatorConfiguration.iPhone5 error:&error];
+
+  BOOL success = [[session.interact
+    bootSimulator]
+    performInteractionWithError:&error];
+
+  XCTAssertTrue(success);
+  XCTAssertNil(error);
+
+  NSInteger expected = session.simulator.processIdentifier;
+  session.simulator.processIdentifier = -1;
+  NSInteger actual = session.simulator.processIdentifier;
+  XCTAssertEqual(expected, actual);
+}
+
+@end

--- a/FBSimulatorControlTests/Tests/FBSimulatorTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorTests.m
@@ -61,6 +61,7 @@
   XCTAssertNil(error);
 
   NSInteger expected = session.simulator.processIdentifier;
+  XCTAssertTrue(expected > 1);
   session.simulator.processIdentifier = -1;
   NSInteger actual = session.simulator.processIdentifier;
   XCTAssertEqual(expected, actual);


### PR DESCRIPTION
The Process Identifier of a `FBSimulator` can be inferred from the arguments of the launched Simulator process. This allows `FBSimulatorControl` to use the PID to find the Windows of Simulator Applications that *haven't* been launched by the *current `FBSimulatorControl` process*.

Also added a test to confirm this.