### PR TITLE
Composable NSPredicates for finding Simulators

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -94,6 +94,8 @@
 		AA74B99E1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA74B99D1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m */; settings = {ASSET_TAGS = (); }; };
 		AA7EA4061BB309C30065DC52 /* FBSimulatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA7EA4041BB309C30065DC52 /* FBSimulatorTests.m */; settings = {ASSET_TAGS = (); }; };
 		AA7EA4071BB309C30065DC52 /* FBTaskExecutorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA7EA4051BB309C30065DC52 /* FBTaskExecutorTests.m */; settings = {ASSET_TAGS = (); }; };
+		AA7EA40A1BB30AB60065DC52 /* FBSimulatorPredicates.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7EA4081BB30AB60065DC52 /* FBSimulatorPredicates.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA7EA40B1BB30AB60065DC52 /* FBSimulatorPredicates.m in Sources */ = {isa = PBXBuildFile; fileRef = AA7EA4091BB30AB60065DC52 /* FBSimulatorPredicates.m */; settings = {ASSET_TAGS = (); }; };
 		AA819DB71B9FB40D002F58CA /* FBSimulatorControl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E291A4B50E500000001 /* FBSimulatorControl.framework */; };
 		AA8DF8C01BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA8DF8BF1BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m */; settings = {ASSET_TAGS = (); }; };
 		AA8DF8C91BB18B3700CC0411 /* FBInteraction.h in Headers */ = {isa = PBXBuildFile; fileRef = AA8DF8C61BB18B3700CC0411 /* FBInteraction.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -800,6 +802,8 @@
 		AA74B99D1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBProcessLaunchConfigurationTests.m; sourceTree = "<group>"; };
 		AA7EA4041BB309C30065DC52 /* FBSimulatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorTests.m; sourceTree = "<group>"; };
 		AA7EA4051BB309C30065DC52 /* FBTaskExecutorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBTaskExecutorTests.m; sourceTree = "<group>"; };
+		AA7EA4081BB30AB60065DC52 /* FBSimulatorPredicates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorPredicates.h; sourceTree = "<group>"; };
+		AA7EA4091BB30AB60065DC52 /* FBSimulatorPredicates.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorPredicates.m; sourceTree = "<group>"; };
 		AA819DB21B9FB40D002F58CA /* FBSimulatorControlTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FBSimulatorControlTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA819E0B1B9FB427002F58CA /* FBSimulatorControlTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "FBSimulatorControlTests-Info.plist"; sourceTree = "<group>"; };
 		AA8DF8BF1BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorSessionLifecycleTests.m; sourceTree = "<group>"; };
@@ -880,20 +884,22 @@
 		AA4876D41BAC74B9007F7D23 /* Management */ = {
 			isa = PBXGroup;
 			children = (
+				AA4876D81BAC74B9007F7D23 /* FBSimulator.h */,
+				AA4876D91BAC74B9007F7D23 /* FBSimulator.m */,
 				AA4876D51BAC74B9007F7D23 /* FBSimulator+Private.h */,
 				AA4876D61BAC74B9007F7D23 /* FBSimulator+Queries.h */,
 				AA4876D71BAC74B9007F7D23 /* FBSimulator+Queries.m */,
-				AA4876D81BAC74B9007F7D23 /* FBSimulator.h */,
-				AA4876D91BAC74B9007F7D23 /* FBSimulator.m */,
-				AA4876DA1BAC74B9007F7D23 /* FBSimulatorControl+Private.h */,
 				AA4876DB1BAC74B9007F7D23 /* FBSimulatorControl.h */,
 				AA4876DC1BAC74B9007F7D23 /* FBSimulatorControl.m */,
-				AA4876DD1BAC74B9007F7D23 /* FBSimulatorInteraction+Private.h */,
+				AA4876DA1BAC74B9007F7D23 /* FBSimulatorControl+Private.h */,
 				AA4876DE1BAC74B9007F7D23 /* FBSimulatorInteraction.h */,
 				AA4876DF1BAC74B9007F7D23 /* FBSimulatorInteraction.m */,
-				AA4876E01BAC74B9007F7D23 /* FBSimulatorPool+Private.h */,
+				AA4876DD1BAC74B9007F7D23 /* FBSimulatorInteraction+Private.h */,
 				AA4876E11BAC74B9007F7D23 /* FBSimulatorPool.h */,
 				AA4876E21BAC74B9007F7D23 /* FBSimulatorPool.m */,
+				AA4876E01BAC74B9007F7D23 /* FBSimulatorPool+Private.h */,
+				AA7EA4081BB30AB60065DC52 /* FBSimulatorPredicates.h */,
+				AA7EA4091BB30AB60065DC52 /* FBSimulatorPredicates.m */,
 			);
 			path = Management;
 			sourceTree = "<group>";
@@ -1715,6 +1721,7 @@
 				AA4877221BAC74B9007F7D23 /* FBSimulator+Private.h in Headers */,
 				AA4877201BAC74B9007F7D23 /* FBSimulatorControlStaticConfiguration.h in Headers */,
 				AA4877511BAC74B9007F7D23 /* FBTaskExecutor+Private.h in Headers */,
+				AA7EA40A1BB30AB60065DC52 /* FBSimulatorPredicates.h in Headers */,
 				AA4877371BAC74B9007F7D23 /* FBDispatchSourceNotifier.h in Headers */,
 				AA4877281BAC74B9007F7D23 /* FBSimulatorControl.h in Headers */,
 				AA8DF8C91BB18B3700CC0411 /* FBInteraction.h in Headers */,
@@ -1834,6 +1841,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				AA7EA40B1BB30AB60065DC52 /* FBSimulatorPredicates.m in Sources */,
 				AA74B99A1BB014A200C1E59C /* FBSimulatorError.m in Sources */,
 				AA48773A1BAC74B9007F7D23 /* FBSimulatorSession+Convenience.m in Sources */,
 				AA4877341BAC74B9007F7D23 /* FBSimulatorProcess.m in Sources */,

--- a/FBSimulatorControl/Management/FBSimulatorPool.h
+++ b/FBSimulatorControl/Management/FBSimulatorPool.h
@@ -39,48 +39,12 @@
 @property (nonatomic, copy, readonly) FBSimulatorControlConfiguration *configuration;
 
 /**
- An Ordered Set of the Simulators that this Pool is responsible for.
- This includes allocated and un-allocated simulators.
+ An Ordered Set of the Simulators for the DeviceSet.
+ This includes allocated and un-allocated simulators, as well as managed and unmanaged simulators.
  Ordering is based on name descending.
- Is an NSOrderedSet<FBManagedSimulator>
- */
-@property (nonatomic, copy, readonly) NSOrderedSet *allSimulatorsInPool;
-
-/**
- An Ordered Set of the Simulators that any posible Pool is responsible for.
- This includes allocated and un-allocated simulators.
- Ordering is based on name descending.
- Is an NSOrderedSet<FBManagedSimulator>
- */
-@property (nonatomic, copy, readonly) NSOrderedSet *allPooledSimulators;
-
-/**
- An Ordered Set of the Simulators that this Pool has allocated.
- This includes only allocated simulators.
- Ordering is based on the most recently allocated simulator descending.
- Is an NSOrderedSet<FBManagedSimulator>
- */
-@property (nonatomic, copy, readonly) NSOrderedSet *allocatedSimulators;
-
-/**
- An Ordered Set of the Simulators that this Pool has allocated.
- This includes only allocated simulators.
- Ordering is based on name descending.
- Is an NSOrderedSet<FBManagedSimulator>
- */
-@property (nonatomic, copy, readonly) NSOrderedSet *unallocatedSimulators;
-
-/**
- An Ordered Set of all the Simulators for the Device Set.
  Is an NSOrderedSet<FBSimulator>
  */
 @property (nonatomic, copy, readonly) NSOrderedSet *allSimulators;
-
-/**
- An Ordered Set of the Simulators that no Pool is responsible for.
- Is an NSOrderedSet<FBSimulator>
- */
-@property (nonatomic, copy, readonly) NSOrderedSet *unmanagedSimulators;
 
 /**
  Returns a device matching the UDID, if one exists.
@@ -160,9 +124,9 @@
 @end
 
 /**
- Some Fetchers for bridging the Old Way with the New
+ Fetchers for Specific and Groups of Simulators
  */
-@interface FBSimulatorPool (Fetching)
+@interface FBSimulatorPool (Fetchers)
 
 /**
  Finds the Device UDID for the given device name and SDK version combination.
@@ -182,6 +146,55 @@
  @return The Allocated device created by FBSimulatorPool.
  */
 - (FBManagedSimulator *)allocatedSimulatorWithDeviceType:(NSString *)deviceType;
+
+/**
+ An Ordered Set of the Simulators that this Pool is responsible for.
+ This includes allocated and un-allocated simulators.
+ Ordering is based on name descending.
+ Is an NSOrderedSet<FBManagedSimulator>
+ */
+@property (nonatomic, copy, readonly) NSOrderedSet *allSimulatorsInPool;
+
+/**
+ An Ordered Set of the Simulators that any posible Pool is responsible for.
+ This includes allocated and un-allocated simulators.
+ Ordering is based on name descending.
+ Is an NSOrderedSet<FBManagedSimulator>
+ */
+@property (nonatomic, copy, readonly) NSOrderedSet *allPooledSimulators;
+
+/**
+ An Ordered Set of the Simulators that this Pool has allocated.
+ This includes only allocated simulators.
+ Is an NSOrderedSet<FBManagedSimulator>
+ */
+@property (nonatomic, copy, readonly) NSOrderedSet *allocatedSimulators;
+
+/**
+ An Ordered Set of the Simulators that this Pool has allocated.
+ This includes only allocated simulators.
+ Ordering is based on name descending.
+ Is an NSOrderedSet<FBManagedSimulator>
+ */
+@property (nonatomic, copy, readonly) NSOrderedSet *unallocatedSimulators;
+
+/**
+ An Ordered Set of all the Simulators for the Device Set.
+ Is an NSOrderedSet<FBSimulator>
+ */
+@property (nonatomic, copy, readonly) NSOrderedSet *allSimulators;
+
+/**
+ An Ordered Set of the Simulators that no Pool is responsible for.
+ Is an NSOrderedSet<FBSimulator>
+ */
+@property (nonatomic, copy, readonly) NSOrderedSet *unmanagedSimulators;
+
+/**
+ An Ordered Set of the Simulators that have been launched by any pool, or not by FBSimulatorControl at all.
+ Is an NSOrderedSet<FBSimulator>
+ */
+@property (nonatomic, copy, readonly) NSOrderedSet *launchedSimulators;
 
 @end
 

--- a/FBSimulatorControl/Management/FBSimulatorPredicates.h
+++ b/FBSimulatorControl/Management/FBSimulatorPredicates.h
@@ -10,6 +10,7 @@
 #import <Foundation/Foundation.h>
 
 @class FBSimulatorPool;
+@class FBSimulator;
 
 /**
  Predicates for filtering the sets of available Simulators.
@@ -46,5 +47,10 @@
  Predicate for Simulators that are launched.
  */
 + (NSPredicate *)launched;
+
+/**
+ Predicate for only the provided Simulator.
+ */
++ (NSPredicate *)only:(FBSimulator *)simulator;
 
 @end

--- a/FBSimulatorControl/Management/FBSimulatorPredicates.h
+++ b/FBSimulatorControl/Management/FBSimulatorPredicates.h
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class FBSimulatorPool;
+
+/**
+ Predicates for filtering the sets of available Simulators.
+ NSCompoundPredicate can be used to compose Predicates.
+ */
+@interface FBSimulatorPredicates : NSObject
+
+/**
+ Predicate for Simulators that are managed by any Pool.
+ */
++ (NSPredicate *)managed;
+
+/**
+ Predicate for Simulators that are managed by a specific Pool.
+ */
++ (NSPredicate *)managedByPool:(FBSimulatorPool *)pool;
+
+/**
+ Predicate for Simulators that are allocated in a specific Pool.
+ */
++ (NSPredicate *)allocatedByPool:(FBSimulatorPool *)pool;
+
+/**
+ Predicate for Simulators that are managed by a pool but not allocated.
+ */
++ (NSPredicate *)unallocatedByPool:(FBSimulatorPool *)pool;
+
+/**
+ Predicate for Simulators that are not managed by any Pool.
+ */
++ (NSPredicate *)unmanaged;
+
+/**
+ Predicate for Simulators that are launched.
+ */
++ (NSPredicate *)launched;
+
+@end

--- a/FBSimulatorControl/Management/FBSimulatorPredicates.m
+++ b/FBSimulatorControl/Management/FBSimulatorPredicates.m
@@ -60,4 +60,11 @@
   }];
 }
 
++ (NSPredicate *)only:(FBSimulator *)simulator
+{
+  return [NSPredicate predicateWithBlock:^ BOOL (FBSimulator *candidate, NSDictionary* _) {
+    return simulator.udid && [candidate.udid isEqual:simulator.udid];
+  }];
+}
+
 @end

--- a/FBSimulatorControl/Management/FBSimulatorPredicates.m
+++ b/FBSimulatorControl/Management/FBSimulatorPredicates.m
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBSimulatorPredicates.h"
+
+#import "FBSimulator.h"
+#import "FBSimulatorControlConfiguration.h"
+#import "FBSimulatorPool.h"
+#import "FBSimulatorPool+Private.h"
+
+@implementation FBSimulatorPredicates
+
++ (NSPredicate *)managed
+{
+  return [NSPredicate predicateWithBlock:^ BOOL (FBSimulator *simulator, NSDictionary* _) {
+    return [simulator isKindOfClass:FBManagedSimulator.class];
+  }];
+}
+
++ (NSPredicate *)managedByPool:(FBSimulatorPool *)pool
+{
+  return [NSCompoundPredicate andPredicateWithSubpredicates:@[
+    self.managed,
+    [NSPredicate predicateWithBlock:^ BOOL (FBManagedSimulator *simulator, NSDictionary* _) {
+      return pool.configuration.bucketID == simulator.bucketID;
+    }]
+  ]];
+}
+
++ (NSPredicate *)allocatedByPool:(FBSimulatorPool *)pool
+{
+  return [NSPredicate predicateWithBlock:^ BOOL (FBSimulator *simulator, NSDictionary* _) {
+    return [pool.allocatedUDIDs containsObject:simulator.udid];
+  }];
+}
+
++ (NSPredicate *)unallocatedByPool:(FBSimulatorPool *)pool
+{
+  return [NSCompoundPredicate andPredicateWithSubpredicates:@[
+    [self managedByPool:pool],
+    [NSCompoundPredicate notPredicateWithSubpredicate:[self allocatedByPool:pool]],
+  ]];
+}
+
++ (NSPredicate *)unmanaged
+{
+  return [NSCompoundPredicate notPredicateWithSubpredicate:self.managed];
+}
+
++ (NSPredicate *)launched
+{
+  return [NSPredicate predicateWithBlock:^ BOOL (FBSimulator *simulator, NSDictionary* _) {
+    return simulator.processIdentifier > 1 || simulator.launchdSimProcessIdentifier > 1;
+  }];
+}
+
+@end


### PR DESCRIPTION
Extracts out the filtering of the `allSimulators` property of `FBSimulatorPool` into discrete `NSPredicate` objects in the `FBSimulatorPredicates` object. Thanks to `NSCompoundPredicate` it should become easier to define more complex filtering of Simulators.

By using #25 it should be possible to get a collection of Process Identifiers of *any* `FBSimulatorControl` launched Simulator, regardless of the process that it was launched from.
