### PR TITLE
Video Recording

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -102,6 +102,10 @@
 		AA8DF8CB1BB18B3700CC0411 /* FBInteraction+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = AA8DF8C81BB18B3700CC0411 /* FBInteraction+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA8DFB101BAC76B60076A6C2 /* FBSimulatorControlNotificationAssertion.m in Sources */ = {isa = PBXBuildFile; fileRef = AA8DFB0D1BAC76B60076A6C2 /* FBSimulatorControlNotificationAssertion.m */; settings = {ASSET_TAGS = (); }; };
 		AA8DFB111BAC76B60076A6C2 /* FBSimulatorSessionStateAssertion.m in Sources */ = {isa = PBXBuildFile; fileRef = AA8DFB0F1BAC76B60076A6C2 /* FBSimulatorSessionStateAssertion.m */; settings = {ASSET_TAGS = (); }; };
+		AAB4AC191BB586640046F6A1 /* FBSimulatorVideoRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB4AC171BB586640046F6A1 /* FBSimulatorVideoRecorder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AAB4AC1A1BB586640046F6A1 /* FBSimulatorVideoRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = AAB4AC181BB586640046F6A1 /* FBSimulatorVideoRecorder.m */; settings = {ASSET_TAGS = (); }; };
+		AAB4AC1C1BB586860046F6A1 /* FBSimulatorVideoRecorderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AAB4AC1B1BB586860046F6A1 /* FBSimulatorVideoRecorderTests.m */; settings = {ASSET_TAGS = (); }; };
+		AAB4AC1E1BB586930046F6A1 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAB4AC1D1BB586930046F6A1 /* AVFoundation.framework */; };
 		AAC083751B9FB88B00451648 /* CoreSimulator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E29B6970A5500000000 /* CoreSimulator.framework */; };
 		AAC083761B9FB89600451648 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E29A6018C7A00000000 /* CoreGraphics.framework */; };
 		AAC083781B9FBA7600451648 /* FBSimulatorControl.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1DD70E291A4B50E500000001 /* FBSimulatorControl.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -819,6 +823,10 @@
 		AA8DFB0D1BAC76B60076A6C2 /* FBSimulatorControlNotificationAssertion.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorControlNotificationAssertion.m; sourceTree = "<group>"; };
 		AA8DFB0E1BAC76B60076A6C2 /* FBSimulatorSessionStateAssertion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorSessionStateAssertion.h; sourceTree = "<group>"; };
 		AA8DFB0F1BAC76B60076A6C2 /* FBSimulatorSessionStateAssertion.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorSessionStateAssertion.m; sourceTree = "<group>"; };
+		AAB4AC171BB586640046F6A1 /* FBSimulatorVideoRecorder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorVideoRecorder.h; sourceTree = "<group>"; };
+		AAB4AC181BB586640046F6A1 /* FBSimulatorVideoRecorder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorVideoRecorder.m; sourceTree = "<group>"; };
+		AAB4AC1B1BB586860046F6A1 /* FBSimulatorVideoRecorderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorVideoRecorderTests.m; sourceTree = "<group>"; };
+		AAB4AC1D1BB586930046F6A1 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		AAC2411A1BB30CB30054570C /* FBSimulatorPredicates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorPredicates.h; sourceTree = "<group>"; };
 		AAC2411B1BB30CB30054570C /* FBSimulatorPredicates.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorPredicates.m; sourceTree = "<group>"; };
 		AAC2411F1BB311200054570C /* FBSimulatorWindowTiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorWindowTiler.h; sourceTree = "<group>"; };
@@ -835,6 +843,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
+				AAB4AC1E1BB586930046F6A1 /* AVFoundation.framework in Frameworks */,
 				AAC241261BB311690054570C /* ApplicationServices.framework in Frameworks */,
 				AAC241241BB3113F0054570C /* AppKit.framework in Frameworks */,
 				E7A30F0476B173B900000000 /* Cocoa.framework in Frameworks */,
@@ -1610,6 +1619,7 @@
 				AA8DF8BF1BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m */,
 				AA51E4951BA1CA3C0053141E /* FBSimulatorStateTests.m */,
 				AA7EA4041BB309C30065DC52 /* FBSimulatorTests.m */,
+				AAB4AC1B1BB586860046F6A1 /* FBSimulatorVideoRecorderTests.m */,
 				AAC241271BB311970054570C /* FBSimulatorWindowTilingTests.m */,
 			);
 			path = Tests;
@@ -1637,6 +1647,7 @@
 				AA4877021BAC74B9007F7D23 /* Tasks */,
 				AAC2411E1BB311200054570C /* Tiling */,
 				AA48770D1BAC74B9007F7D23 /* Utility */,
+				AAB4AC161BB586640046F6A1 /* Video */,
 			);
 			path = FBSimulatorControl;
 			sourceTree = "<group>";
@@ -1652,6 +1663,16 @@
 			path = Utilities;
 			sourceTree = "<group>";
 		};
+		AAB4AC161BB586640046F6A1 /* Video */ = {
+			isa = PBXGroup;
+			children = (
+				AAB4AC171BB586640046F6A1 /* FBSimulatorVideoRecorder.h */,
+				AAB4AC181BB586640046F6A1 /* FBSimulatorVideoRecorder.m */,
+			);
+			name = Video;
+			path = FBSimulatorControl/Video;
+			sourceTree = SOURCE_ROOT;
+		};
 		AAC2411E1BB311200054570C /* Tiling */ = {
 			isa = PBXGroup;
 			children = (
@@ -1666,6 +1687,7 @@
 		B401C97968022A5500000000 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				AAB4AC1D1BB586930046F6A1 /* AVFoundation.framework */,
 				AAC241251BB311690054570C /* ApplicationServices.framework */,
 				AAC241231BB3113F0054570C /* AppKit.framework */,
 				AA5696391B9FB7C800A2918F /* DVTiPhoneSimulatorRemoteClient.framework */,
@@ -1749,6 +1771,7 @@
 				AA48774F1BAC74B9007F7D23 /* FBTaskExecutor+Convenience.h in Headers */,
 				AA48771B1BAC74B9007F7D23 /* FBSimulatorConfiguration+Private.h in Headers */,
 				AA4877221BAC74B9007F7D23 /* FBSimulator+Private.h in Headers */,
+				AAB4AC191BB586640046F6A1 /* FBSimulatorVideoRecorder.h in Headers */,
 				AA4877201BAC74B9007F7D23 /* FBSimulatorControlStaticConfiguration.h in Headers */,
 				AA4877511BAC74B9007F7D23 /* FBTaskExecutor+Private.h in Headers */,
 				AAC2411C1BB30CB30054570C /* FBSimulatorPredicates.h in Headers */,
@@ -1905,6 +1928,7 @@
 				AA377CF91BB3EC9C0058E26E /* FBSimulatorWindowHelpers.m in Sources */,
 				AA4877571BAC74B9007F7D23 /* FBSimulatorLogger.m in Sources */,
 				AA4877491BAC74B9007F7D23 /* FBSimulatorSessionState.m in Sources */,
+				AAB4AC1A1BB586640046F6A1 /* FBSimulatorVideoRecorder.m in Sources */,
 				AA4877261BAC74B9007F7D23 /* FBSimulator.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1917,6 +1941,7 @@
 				AA8DF8C01BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m in Sources */,
 				AA51E49B1BA1CA3C0053141E /* FBSimulatorControlConfigurationTests.m in Sources */,
 				AA8DFB111BAC76B60076A6C2 /* FBSimulatorSessionStateAssertion.m in Sources */,
+				AAB4AC1C1BB586860046F6A1 /* FBSimulatorVideoRecorderTests.m in Sources */,
 				AA74B99E1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m in Sources */,
 				AAC241281BB311970054570C /* FBSimulatorWindowTilingTests.m in Sources */,
 				AA8DFB101BAC76B60076A6C2 /* FBSimulatorControlNotificationAssertion.m in Sources */,

--- a/FBSimulatorControl/Session/FBSimulatorSessionInteraction.h
+++ b/FBSimulatorControl/Session/FBSimulatorSessionInteraction.h
@@ -42,6 +42,11 @@
 - (instancetype)tileSimulator;
 
 /**
+ Records Video of the Simulator, until the Session is terminated.
+ */
+- (instancetype)recordVideo;
+
+/**
  Installs the given Application.
  */
 - (instancetype)installApplication:(FBSimulatorApplication *)application;

--- a/FBSimulatorControl/Video/FBSimulatorVideoRecorder.h
+++ b/FBSimulatorControl/Video/FBSimulatorVideoRecorder.h
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <FBSimulatorControl/FBTerminationHandle.h>
+#import <FBSimulatorControl/FBSimulatorLogger.h>
+
+@class FBSimulator;
+
+/**
+ A Class that Records Video for a given Simulator.
+
+ Helpful reference from:
+ - Apple Technical QA1740
+ - https://github.com/square/zapp/ZappVideoController.m
+ - https://github.com/appium/screen_recording
+ */
+@interface FBSimulatorVideoRecorder : NSObject <FBTerminationHandle>
+
+/**
+ Create a new FBSimulatorVideoRecorder for the provided Simulator.
+ 
+ @param simulator the Simulator to Record.
+ @param logger a logger to record interactions. May be nil.
+ @return a new Video Recorder instance.
+ */
++ (instancetype)forSimulator:(FBSimulator *)simulator logger:(id<FBSimulatorLogger>)logger;
+
+/**
+ Starts recording the Simulator to a File.
+ Will delete and overwrite any existing video for the given filePath.
+ 
+ @param filePath the File to Record into.
+ @param error the error out, for any error that occurred.
+ @returns YES if the recording started successfully, NO otherwise.
+ */
+- (BOOL)startRecordingToFilePath:(NSString *)filePath error:(NSError **)error;
+
+/**
+ Ends recording of the Simulator.
+ 
+ @param error the error out, for any error that occured.
+ @return the Path of the recorded movie if successful, NO otherwise.
+ */
+- (NSString *)stopRecordingWithError:(NSError **)error;
+
+@end

--- a/FBSimulatorControl/Video/FBSimulatorVideoRecorder.m
+++ b/FBSimulatorControl/Video/FBSimulatorVideoRecorder.m
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBSimulatorVideoRecorder.h"
+
+#import <CoreGraphics/CoreGraphics.h>
+#import <CoreMedia/CoreMedia.h>
+#import <AVFoundation/AVFoundation.h>
+
+#import "FBSimulator.h"
+#import "FBSimulatorError.h"
+#import "FBSimulatorWindowHelpers.h"
+#import "FBSimulatorWindowTiler.h"
+
+@interface FBSimulatorVideoRecorder () <AVCaptureFileOutputRecordingDelegate, AVCaptureFileOutputDelegate>
+
+@property (nonatomic, strong, readwrite) FBSimulator *simulator;
+@property (nonatomic, strong, readwrite) id<FBSimulatorLogger> logger;
+
+@property (nonatomic, copy, readwrite) NSString *filePath;
+@property (nonatomic, copy, readwrite) NSURL *fileURL;
+@property (nonatomic, strong, readwrite) AVCaptureSession *session;
+@property (nonatomic, strong, readwrite) AVCaptureMovieFileOutput *output;
+
+@end
+
+@implementation FBSimulatorVideoRecorder
+
++ (instancetype)forSimulator:(FBSimulator *)simulator logger:(id<FBSimulatorLogger>)logger
+{
+  FBSimulatorVideoRecorder *recorder = [self new];
+  recorder.simulator = simulator;
+  recorder.logger = logger;
+  return recorder;
+}
+
+- (BOOL)startRecordingToFilePath:(NSString *)filePath error:(NSError **)error
+{
+  if (self.session) {
+    return [[[FBSimulatorError describe:@"Cannot Start Recording twice"] inSimulator:self.simulator] failBool:error];
+  }
+
+  CGRect cropRect = CGRectZero;
+  CGDirectDisplayID displayID = [FBSimulatorWindowHelpers displayIDForSimulator:self.simulator cropRect:&cropRect screenSize:NULL];
+  if (!displayID) {
+    return [[[FBSimulatorError describe:@"Cannot obtain display ID for recording"] inSimulator:self.simulator] failBool:error];
+  }
+
+  NSError *innerError = nil;
+  if ([NSFileManager.defaultManager fileExistsAtPath:filePath] && ![NSFileManager.defaultManager removeItemAtPath:filePath error:&innerError]) {
+    return [[[FBSimulatorError describeFormat:@"Cannot remove existing video at '%@'", filePath] inSimulator:self.simulator] failBool:error];
+  }
+  self.filePath = filePath;
+  self.fileURL = [NSURL fileURLWithPath:filePath];
+
+  // Setup the Screen Capture Input
+  AVCaptureScreenInput *input = [[AVCaptureScreenInput alloc] initWithDisplayID:displayID];
+  if (!input) {
+    return [[[FBSimulatorError describe:@"Could not Create Screen input for display id"] inSimulator:self.simulator] failBool:error];
+  }
+  input.cropRect = cropRect;
+
+  // Then the Output
+  AVCaptureMovieFileOutput *output = [[AVCaptureMovieFileOutput alloc] init];
+  output.delegate = self;
+
+  // Create & Setup the Session.
+  AVCaptureSession *session = [[AVCaptureSession alloc] init];
+  [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(captureSessionDidStart:) name:AVCaptureSessionDidStartRunningNotification object:session];
+  if (![session canAddInput:input]) {
+    return [[[FBSimulatorError describe:@"Could not add AV Input to the Capture Sesion"] inSimulator:self.simulator] failBool:error];
+  }
+  [session addInput:input];
+  if (![session canAddOutput:output]) {
+    return [[[FBSimulatorError describe:@"Could not add AV Output to the Capture Sesion"] inSimulator:self.simulator] failBool:error];
+  }
+  [session addOutput:output];
+  self.session = session;
+  self.output = output;
+
+  // The Session is started, but the recording to file isn't started *until* capture session starts.
+  // This is because the Pixel Format changes when the Simulator hits Springboard, causing the File output to Terminate.
+  // Instead of experiencing this termination, the file recording waits until the session is in a valid state.
+  [session startRunning];
+
+  return YES;
+}
+
+- (NSString *)stopRecordingWithError:(NSError **)error
+{
+  if (!self.session) {
+    return [[FBSimulatorError describe:@"Cannot stop a Recording when one doesn't exist"] fail:error];
+  }
+
+  [self.output stopRecording];
+  [self.session stopRunning];
+
+  self.session = nil;
+  self.output = nil;
+
+  return self.filePath;
+}
+
+- (void)terminate
+{
+  [self stopRecordingWithError:nil];
+}
+
+- (void)dealloc
+{
+  [self terminate];
+}
+
+#pragma mark Notifications
+
+- (void)captureSessionDidStart:(NSNotification *)notification
+{
+  [self.output startRecordingToOutputFileURL:self.fileURL recordingDelegate:self];
+}
+
+#pragma mark AVCaptureFileOutputRecordingDelegate
+
+- (void)captureOutput:(AVCaptureFileOutput *)captureOutput didStartRecordingToOutputFileAtURL:(NSURL *)fileURL fromConnections:(NSArray *)connections;
+{
+  [self.logger logMessage:@"Capture started to %@", fileURL];
+}
+
+- (void)captureOutput:(AVCaptureFileOutput *)captureOutput didPauseRecordingToOutputFileAtURL:(NSURL *)fileURL fromConnections:(NSArray *)connections
+{
+  [self.logger logMessage:@"Capture paused at %@", fileURL];
+}
+
+- (void)captureOutput:(AVCaptureFileOutput *)captureOutput didResumeRecordingToOutputFileAtURL:(NSURL *)fileURL fromConnections:(NSArray *)connection
+{
+  [self.logger logMessage:@"Capture resumed at %@", fileURL];
+}
+
+- (void)captureOutput:(AVCaptureFileOutput *)captureOutput willFinishRecordingToOutputFileAtURL:(NSURL *)fileURL fromConnections:(NSArray *)connections error:(NSError *)error
+{
+  [self.logger logMessage:@"Will finish recording to %@", fileURL];
+}
+
+- (void)captureOutput:(AVCaptureFileOutput *)captureOutput didFinishRecordingToOutputFileAtURL:(NSURL *)fileURL fromConnections:(NSArray *)connections error:(NSError *)error;
+{
+  [self.logger logMessage:@"Did finish recording to %@", fileURL];
+}
+
+- (BOOL)captureOutputShouldProvideSampleAccurateRecordingStart:(AVCaptureOutput *)captureOutput
+{
+  return NO;
+}
+
+@end

--- a/FBSimulatorControlTests/Tests/FBSimulatorVideoRecorderTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorVideoRecorderTests.m
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <FBSimulatorControl/FBSimulator.h>
+#import <FBSimulatorControl/FBSimulatorApplication.h>
+#import <FBSimulatorControl/FBSimulatorControl.h>
+#import <FBSimulatorControl/FBSimulatorControl+Private.h>
+#import <FBSimulatorControl/FBSimulatorPool.h>
+#import <FBSimulatorControl/FBSimulatorPool+Private.h>
+#import <FBSimulatorControl/FBSimulatorControlConfiguration.h>
+#import <FBSimulatorControl/FBSimulatorApplication.h>
+#import <FBSimulatorControl/FBSimulatorSession.h>
+#import <FBSimulatorControl/FBSimulatorSessionInteraction.h>
+#import <FBSimulatorControl/FBSimulatorSessionState.h>
+#import <FBSimulatorControl/FBProcessLaunchConfiguration.h>
+#import <FBSimulatorControl/FBSimulatorConfiguration.h>
+#import <FBSimulatorControl/FBSimulatorVideoRecorder.h>
+#import <FBSimulatorControl/NSRunLoop+SimulatorControlAdditions.h>
+
+@interface FBSimulatorVideoRecorderTests : XCTestCase
+
+@end
+
+@implementation FBSimulatorVideoRecorderTests
+
+- (void)disabled_testRecordsVideo
+{
+  FBSimulatorControlConfiguration *controlConfiguration = [FBSimulatorControlConfiguration
+    configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
+    namePrefix:nil
+    bucket:0
+    options:FBSimulatorManagementOptionsDeleteOnFree];
+
+  FBSimulatorControl *control = [[FBSimulatorControl alloc] initWithConfiguration:controlConfiguration];
+
+  NSError *error = nil;
+  FBSimulatorSession *session = [control createSessionForSimulatorConfiguration:FBSimulatorConfiguration.iPhone5 error:&error];
+  XCTAssertNotNil(session);
+  XCTAssertNil(error);
+
+  FBApplicationLaunchConfiguration *appLaunch = [FBApplicationLaunchConfiguration
+    configurationWithApplication:[FBSimulatorApplication systemApplicationNamed:@"MobileSafari"]
+    arguments:@[]
+    environment:@{}];
+
+  XCTAssertTrue([[[session.interact
+    bootSimulator]
+    launchApplication:appLaunch]
+    performInteractionWithError:&error]
+  );
+
+  FBSimulatorVideoRecorder *recorder = [FBSimulatorVideoRecorder forSimulator:session.simulator logger:nil];
+  NSString *filePath = [[NSTemporaryDirectory() stringByAppendingString:NSUUID.UUID.UUIDString] stringByAppendingPathComponent:@"mp4"];
+  XCTAssertTrue([recorder startRecordingToFilePath:filePath error:&error]);
+  XCTAssertNil(error);
+
+  // Spin the run loop a bit.
+  [NSRunLoop.currentRunLoop spinRunLoopWithTimeout:10 untilTrue:^ BOOL {
+    return NO;
+  }];
+
+  filePath = [recorder stopRecordingWithError:&error];
+  XCTAssertNotNil(filePath);
+  XCTAssertNil(error);
+  XCTAssertTrue([NSFileManager.defaultManager fileExistsAtPath:filePath]);
+}
+
+- (void)disabled_testMultipleTiledSimulators
+{
+  // Approval is required externally to the Test Runner. Without approval, the tests can't run
+  if (!AXIsProcessTrusted()) {
+    NSLog(@"%@ can't run as the host process isn't trusted", NSStringFromSelector(_cmd));
+    return;
+  }
+
+  FBSimulatorControlConfiguration *controlConfiguration = [FBSimulatorControlConfiguration
+   configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
+   namePrefix:nil
+   bucket:0
+   options:FBSimulatorManagementOptionsDeleteOnFree];
+
+  FBApplicationLaunchConfiguration *appLaunch = [FBApplicationLaunchConfiguration
+   configurationWithApplication:[FBSimulatorApplication systemApplicationNamed:@"MobileSafari"]
+   arguments:@[]
+   environment:@{}];
+
+  FBSimulatorControl *control = [[FBSimulatorControl alloc] initWithConfiguration:controlConfiguration];
+
+  NSError *error = nil;
+  FBSimulatorSession *firstSession = [control createSessionForSimulatorConfiguration:FBSimulatorConfiguration.iPhone5 error:&error];
+  XCTAssertNotNil(firstSession);
+  XCTAssertNil(error);
+  XCTAssertTrue([[[[[firstSession.interact
+    bootSimulator]
+    tileSimulator]
+    recordVideo]
+    launchApplication:appLaunch]
+    performInteractionWithError:&error]
+  );
+  XCTAssertNil(error);
+
+  FBSimulatorSession *secondSession = [control createSessionForSimulatorConfiguration:FBSimulatorConfiguration.iPhone5 error:&error];
+  XCTAssertNotNil(secondSession);
+  XCTAssertNil(error);
+  XCTAssertTrue([[[[[secondSession.interact
+    bootSimulator]
+    tileSimulator]
+    recordVideo]
+    launchApplication:appLaunch]
+    performInteractionWithError:&error]
+  );
+  XCTAssertNil(error);
+
+  // Spin the run loop a bit.
+  [NSRunLoop.currentRunLoop spinRunLoopWithTimeout:10 untilTrue:^ BOOL {
+    return NO;
+  }];
+
+  NSString *filePath = firstSession.state.diagnostics[@"video"];
+  XCTAssertNotNil(filePath);
+  XCTAssertTrue([NSFileManager.defaultManager fileExistsAtPath:filePath]);
+  filePath = secondSession.state.diagnostics[@"video"];
+  XCTAssertNotNil(filePath);
+  XCTAssertTrue([NSFileManager.defaultManager fileExistsAtPath:filePath]);
+}
+
+@end


### PR DESCRIPTION
Builds on the work #29 and #23 to use `AVCaptureScreenInput` to record a video of multiple Simulators at once, to separate files.

- [x] Figure out why `Error Domain=AVFoundationErrorDomain Code=-11809 "Recording Stopped"` happens when the Simulator boots. 