### PR TITLE
Add Window Tiling Strategies

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -106,6 +106,9 @@
 		AAB4AC1A1BB586640046F6A1 /* FBSimulatorVideoRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = AAB4AC181BB586640046F6A1 /* FBSimulatorVideoRecorder.m */; settings = {ASSET_TAGS = (); }; };
 		AAB4AC1C1BB586860046F6A1 /* FBSimulatorVideoRecorderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AAB4AC1B1BB586860046F6A1 /* FBSimulatorVideoRecorderTests.m */; settings = {ASSET_TAGS = (); }; };
 		AAB4AC1E1BB586930046F6A1 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAB4AC1D1BB586930046F6A1 /* AVFoundation.framework */; };
+		AAB4AC211BB59B790046F6A1 /* FBSimulatorWindowTilingStrategy.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB4AC1F1BB59B790046F6A1 /* FBSimulatorWindowTilingStrategy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AAB4AC221BB59B790046F6A1 /* FBSimulatorWindowTilingStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = AAB4AC201BB59B790046F6A1 /* FBSimulatorWindowTilingStrategy.m */; settings = {ASSET_TAGS = (); }; };
+		AAB4AC241BBBC1A60046F6A1 /* FBSimulatorTilingStrategyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AAB4AC231BBBC1A60046F6A1 /* FBSimulatorTilingStrategyTests.m */; settings = {ASSET_TAGS = (); }; };
 		AAC083751B9FB88B00451648 /* CoreSimulator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E29B6970A5500000000 /* CoreSimulator.framework */; };
 		AAC083761B9FB89600451648 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E29A6018C7A00000000 /* CoreGraphics.framework */; };
 		AAC083781B9FBA7600451648 /* FBSimulatorControl.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1DD70E291A4B50E500000001 /* FBSimulatorControl.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -827,6 +830,9 @@
 		AAB4AC181BB586640046F6A1 /* FBSimulatorVideoRecorder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorVideoRecorder.m; sourceTree = "<group>"; };
 		AAB4AC1B1BB586860046F6A1 /* FBSimulatorVideoRecorderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorVideoRecorderTests.m; sourceTree = "<group>"; };
 		AAB4AC1D1BB586930046F6A1 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		AAB4AC1F1BB59B790046F6A1 /* FBSimulatorWindowTilingStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorWindowTilingStrategy.h; sourceTree = "<group>"; };
+		AAB4AC201BB59B790046F6A1 /* FBSimulatorWindowTilingStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorWindowTilingStrategy.m; sourceTree = "<group>"; };
+		AAB4AC231BBBC1A60046F6A1 /* FBSimulatorTilingStrategyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorTilingStrategyTests.m; sourceTree = "<group>"; };
 		AAC2411A1BB30CB30054570C /* FBSimulatorPredicates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorPredicates.h; sourceTree = "<group>"; };
 		AAC2411B1BB30CB30054570C /* FBSimulatorPredicates.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorPredicates.m; sourceTree = "<group>"; };
 		AAC2411F1BB311200054570C /* FBSimulatorWindowTiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorWindowTiler.h; sourceTree = "<group>"; };
@@ -1619,6 +1625,7 @@
 				AA8DF8BF1BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m */,
 				AA51E4951BA1CA3C0053141E /* FBSimulatorStateTests.m */,
 				AA7EA4041BB309C30065DC52 /* FBSimulatorTests.m */,
+				AAB4AC231BBBC1A60046F6A1 /* FBSimulatorTilingStrategyTests.m */,
 				AAB4AC1B1BB586860046F6A1 /* FBSimulatorVideoRecorderTests.m */,
 				AAC241271BB311970054570C /* FBSimulatorWindowTilingTests.m */,
 			);
@@ -1680,6 +1687,8 @@
 				AA377CF71BB3EC9C0058E26E /* FBSimulatorWindowHelpers.m */,
 				AAC2411F1BB311200054570C /* FBSimulatorWindowTiler.h */,
 				AAC241201BB311200054570C /* FBSimulatorWindowTiler.m */,
+				AAB4AC1F1BB59B790046F6A1 /* FBSimulatorWindowTilingStrategy.h */,
+				AAB4AC201BB59B790046F6A1 /* FBSimulatorWindowTilingStrategy.m */,
 			);
 			path = Tiling;
 			sourceTree = "<group>";
@@ -1774,6 +1783,7 @@
 				AAB4AC191BB586640046F6A1 /* FBSimulatorVideoRecorder.h in Headers */,
 				AA4877201BAC74B9007F7D23 /* FBSimulatorControlStaticConfiguration.h in Headers */,
 				AA4877511BAC74B9007F7D23 /* FBTaskExecutor+Private.h in Headers */,
+				AAB4AC211BB59B790046F6A1 /* FBSimulatorWindowTilingStrategy.h in Headers */,
 				AAC2411C1BB30CB30054570C /* FBSimulatorPredicates.h in Headers */,
 				AA4877371BAC74B9007F7D23 /* FBDispatchSourceNotifier.h in Headers */,
 				AA4877281BAC74B9007F7D23 /* FBSimulatorControl.h in Headers */,
@@ -1908,6 +1918,7 @@
 				AA48773D1BAC74B9007F7D23 /* FBSimulatorSession.m in Sources */,
 				AA48771D1BAC74B9007F7D23 /* FBSimulatorConfiguration.m in Sources */,
 				AA48772F1BAC74B9007F7D23 /* FBSimulatorPool.m in Sources */,
+				AAB4AC221BB59B790046F6A1 /* FBSimulatorWindowTilingStrategy.m in Sources */,
 				AA4877241BAC74B9007F7D23 /* FBSimulator+Queries.m in Sources */,
 				AA48771F1BAC74B9007F7D23 /* FBSimulatorControlConfiguration.m in Sources */,
 				AA4877501BAC74B9007F7D23 /* FBTaskExecutor+Convenience.m in Sources */,
@@ -1940,6 +1951,7 @@
 				AA51E49A1BA1CA3C0053141E /* FBSimulatorControlApplicationLaunchTests.m in Sources */,
 				AA8DF8C01BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m in Sources */,
 				AA51E49B1BA1CA3C0053141E /* FBSimulatorControlConfigurationTests.m in Sources */,
+				AAB4AC241BBBC1A60046F6A1 /* FBSimulatorTilingStrategyTests.m in Sources */,
 				AA8DFB111BAC76B60076A6C2 /* FBSimulatorSessionStateAssertion.m in Sources */,
 				AAB4AC1C1BB586860046F6A1 /* FBSimulatorVideoRecorderTests.m in Sources */,
 				AA74B99E1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m in Sources */,

--- a/FBSimulatorControl/Session/FBSimulatorSessionInteraction.h
+++ b/FBSimulatorControl/Session/FBSimulatorSessionInteraction.h
@@ -18,6 +18,7 @@
 @class FBSimulatorBinary;
 @class FBSimulatorSession;
 @class FBSimulatorSessionLifecycle;
+@protocol FBSimulatorWindowTilingStrategy;
 
 /**
  The Concrete Interactions for a Simulator Session.
@@ -37,7 +38,12 @@
 - (instancetype)bootSimulator;
 
 /**
- Tiles the Simulator in the first available position on the Display.
+ Tiles the Simulator according to the 'tilingStrategy'.
+ */
+- (instancetype)tileSimulator:(id<FBSimulatorWindowTilingStrategy>)tilingStrategy;
+
+/**
+ Tiles the Simulator according to the occlusion other Simulators.
  */
 - (instancetype)tileSimulator;
 

--- a/FBSimulatorControl/Session/FBSimulatorSessionInteraction.m
+++ b/FBSimulatorControl/Session/FBSimulatorSessionInteraction.m
@@ -26,6 +26,7 @@
 #import "FBSimulatorSessionState+Queries.h"
 #import "FBSimulatorSessionState.h"
 #import "FBSimulatorWindowTiler.h"
+#import "FBSimulatorWindowTilingStrategy.h"
 #import "FBSimulatorVideoRecorder.h"
 #import "FBTaskExecutor.h"
 
@@ -77,18 +78,23 @@ NSTimeInterval const FBSimulatorInteractionDefaultTimeout = 30;
   }];
 }
 
-- (instancetype)tileSimulator
+- (instancetype)tileSimulator:(id<FBSimulatorWindowTilingStrategy>)tilingStrategy;
 {
   FBSimulator *simulator = self.session.simulator;
 
   return [self interact:^ BOOL (NSError **error) {
-    FBSimulatorWindowTiler *tiler = [FBSimulatorWindowTiler withSimulator:simulator];
+    FBSimulatorWindowTiler *tiler = [FBSimulatorWindowTiler withSimulator:simulator strategy:tilingStrategy];
     NSError *innerError = nil;
     if (CGRectIsNull([tiler placeInForegroundWithError:&innerError])) {
       return [FBSimulatorError failBoolWithError:innerError errorOut:error];
     }
     return YES;
   }];
+}
+
+- (instancetype)tileSimulator
+{
+  return [self tileSimulator:[FBSimulatorWindowTilingStrategy horizontalOcclusionStrategy:self.session.simulator]];
 }
 
 - (instancetype)recordVideo

--- a/FBSimulatorControl/Tiling/FBSimulatorWindowHelpers.m
+++ b/FBSimulatorControl/Tiling/FBSimulatorWindowHelpers.m
@@ -86,7 +86,11 @@ static void EnsureCGIsInitialized(void)
   }
 
   CGDirectDisplayID displayID = 0;
-  CGGetDisplaysWithRect(windowBounds, 1, &displayID, NULL);
+  uint32_t matchingDisplayCount = 0;
+  CGGetDisplaysWithRect(windowBounds, 1, &displayID, &matchingDisplayCount);
+  if (!matchingDisplayCount) {
+    return 0;
+  }
 
   if (cropRect) {
     CGRect displayBounds = CGDisplayBounds(displayID);
@@ -98,7 +102,7 @@ static void EnsureCGIsInitialized(void)
     );
   }
   if (screenSize) {
-    *screenSize = CGDisplayScreenSize(displayID);
+    *screenSize = CGDisplayBounds(displayID).size;
   }
 
   return displayID;

--- a/FBSimulatorControl/Tiling/FBSimulatorWindowTiler.h
+++ b/FBSimulatorControl/Tiling/FBSimulatorWindowTiler.h
@@ -11,9 +11,12 @@
 #import <Cocoa/Cocoa.h>
 
 @class FBSimulator;
+@protocol FBSimulatorWindowTilingStrategy;
 
 /**
- A class responsible for tiling Simulator Windows and bringing them to the foreground
+ A Class responsible for tiling Simulator Windows and bringing them to the foreground.
+ Tiling differes from 'calculating layout' in the traditional sense since it's undesirable to re-align Windows that have already been placed.
+ Keeping a Simulator in the same position since it's first placement means that cropping a recorded video becomes trivial.
  */
 @interface FBSimulatorWindowTiler : NSObject
 
@@ -21,9 +24,10 @@
  Creates and returns a new Window Tiler for the provided Simulator
  
  @param simulator the Simulator to position.
+ @param strategy the Strategy to use for determining the position of Windows.s
  @return a new FBWindowTiler instance.
  */
-+ (instancetype)withSimulator:(FBSimulator *)simulator;
++ (instancetype)withSimulator:(FBSimulator *)simulator strategy:(id<FBSimulatorWindowTilingStrategy>)strategy;
 
 /**
  Moves the Simuator into the foreground in the first available position that is not occluded by any other Simulator

--- a/FBSimulatorControl/Tiling/FBSimulatorWindowTilingStrategy.h
+++ b/FBSimulatorControl/Tiling/FBSimulatorWindowTilingStrategy.h
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class FBSimulator;
+
+/**
+ A Protocol for defining a Strategy of the placement of Simulator Windows within the host's display.
+ */
+@protocol FBSimulatorWindowTilingStrategy <NSObject>
+
+/**
+ Returns the best position for a window.
+
+ @param size the Size of the Window to place.
+ @param error an Error out for any error that occurred.
+ @return the target position of the rectangle, or CGRectNull if there is no possible placement for the Window.s
+ */
+- (CGRect)targetPositionOfWindowWithSize:(CGSize)windowSize inScreenSize:(CGSize)screenSize withError:(NSError **)error;
+
+@end
+
+/**
+ Implementations of Tiling Strategy
+ */
+@interface FBSimulatorWindowTilingStrategy : NSObject
+
+/**
+ A Strategy that tiles windows horizontally based on the presence of occluding Simulators, determined by the existence of Simulators other than the 'target'.
+
+ @param targetSimulator the existing Simulator to place. Simulators other than the 'targetSimulator' will be considered occluded areas.
+ @return a Window Tiling Strategy
+ */
++ (id<FBSimulatorWindowTilingStrategy>)horizontalOcclusionStrategy:(FBSimulator *)targetSimulator;
+
+/**
+ A Strategy that tiles windows horizontally based on a offset in a horizontally divided screen.
+
+ @param offset the offset
+ @param total the total number of offsets
+ @return a Window Tiling Strategy
+ */
++ (id<FBSimulatorWindowTilingStrategy>)isolatedRegionStrategyWithOffset:(NSInteger)offset total:(NSInteger)total;
+
+@end

--- a/FBSimulatorControl/Tiling/FBSimulatorWindowTilingStrategy.m
+++ b/FBSimulatorControl/Tiling/FBSimulatorWindowTilingStrategy.m
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBSimulatorWindowTilingStrategy.h"
+
+#import "FBSimulator.h"
+#import "FBSimulatorError.h"
+#import "FBSimulatorWindowHelpers.h"
+
+static inline NSRange FBHorizontalOcclusionRange(CGRect rect)
+{
+  rect = CGRectIntegral(rect);
+  return NSMakeRange(
+    (NSUInteger) CGRectGetMinX(rect),
+    (NSUInteger) (CGRectGetMaxX(rect) - CGRectGetMinX(rect))
+  );
+}
+
+@interface FBWindowTilingStrategy_HorizontalOcclusion : NSObject <FBSimulatorWindowTilingStrategy>
+
+@property (nonatomic, strong, readwrite) FBSimulator *targetSimulator;
+
+@end
+
+@implementation FBWindowTilingStrategy_HorizontalOcclusion
+
+- (CGRect)targetPositionOfWindowWithSize:(CGSize)windowSize inScreenSize:(CGSize)screenSize withError:(NSError **)error
+{
+  NSMutableIndexSet *xOccluded = [NSMutableIndexSet indexSet];
+  NSArray *occludingWindows = [FBSimulatorWindowHelpers obtainBoundsOfOtherSimulators:self.targetSimulator];
+
+  // Only checks the X-Axis
+  for (NSValue *contentRectValue in occludingWindows) {
+    [xOccluded addIndexesInRange:FBHorizontalOcclusionRange(contentRectValue.rectValue)];
+  }
+
+  CGRect rect = { CGPointZero, windowSize };
+  while ([xOccluded containsIndexesInRange:FBHorizontalOcclusionRange(rect)]) {
+    rect.origin.x += CGRectGetWidth(rect);
+  }
+  return rect;
+}
+
+@end
+
+@interface FBWindowTilingStrategy_IsolatedRegion : NSObject <FBSimulatorWindowTilingStrategy>
+
+@property (nonatomic, assign, readwrite) NSInteger offset;
+@property (nonatomic, assign, readwrite) NSInteger total;
+
+
+@end
+
+@implementation FBWindowTilingStrategy_IsolatedRegion
+
+- (CGRect)targetPositionOfWindowWithSize:(CGSize)windowSize inScreenSize:(CGSize)screenSize withError:(NSError **)error
+{
+  if (self.total < 1) {
+    return [[FBSimulatorError describe:@"Cannot Tile with total < 1"] failRect:error];
+  }
+  if (self.offset >= self.total) {
+    return [[FBSimulatorError describe:@"Cannot Tile with offset >= total"] failRect:error];
+  }
+
+  return CGRectMake (
+    floor((screenSize.width / self.total) * self.offset),
+    0,
+    windowSize.width,
+    windowSize.height
+  );
+}
+
+@end
+
+@implementation FBSimulatorWindowTilingStrategy
+
++ (id<FBSimulatorWindowTilingStrategy>)horizontalOcclusionStrategy:(FBSimulator *)targetSimulator;
+{
+  FBWindowTilingStrategy_HorizontalOcclusion *strategy = [FBWindowTilingStrategy_HorizontalOcclusion new];
+  strategy.targetSimulator = targetSimulator;
+  return strategy;
+}
+
++ (id<FBSimulatorWindowTilingStrategy>)isolatedRegionStrategyWithOffset:(NSInteger)offset total:(NSInteger)total
+{
+  FBWindowTilingStrategy_IsolatedRegion *strategy = [FBWindowTilingStrategy_IsolatedRegion new];
+  strategy.offset = offset;
+  strategy.total = total;
+  return strategy;
+}
+
+@end

--- a/FBSimulatorControlTests/Tests/FBSimulatorTilingStrategyTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorTilingStrategyTests.m
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <FBSimulatorControl/FBSimulatorWindowTilingStrategy.h>
+
+@interface FBSimulatorTilingStrategyTests : XCTestCase
+
+@end
+
+@implementation FBSimulatorTilingStrategyTests
+
+- (void)testTilesInRegions
+{
+  CGRect window = [[FBSimulatorWindowTilingStrategy isolatedRegionStrategyWithOffset:0 total:3]
+    targetPositionOfWindowWithSize:CGSizeMake(100, 200) inScreenSize:CGSizeMake(1024, 768) withError:nil];
+  XCTAssertTrue(CGRectEqualToRect(CGRectMake(0, 0, 100, 200), window));
+
+  window = [[FBSimulatorWindowTilingStrategy isolatedRegionStrategyWithOffset:1 total:3]
+    targetPositionOfWindowWithSize:CGSizeMake(300, 200) inScreenSize:CGSizeMake(1024, 768) withError:nil];
+  XCTAssertTrue(CGRectEqualToRect(CGRectMake(341, 0, 300, 200), window));
+
+  window = [[FBSimulatorWindowTilingStrategy isolatedRegionStrategyWithOffset:2 total:3]
+    targetPositionOfWindowWithSize:CGSizeMake(200, 500) inScreenSize:CGSizeMake(1024, 768) withError:nil];
+  XCTAssertTrue(CGRectEqualToRect(CGRectMake(682, 0, 200, 500), window));
+}
+
+@end

--- a/FBSimulatorControlTests/Tests/FBSimulatorWindowTilingTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorWindowTilingTests.m
@@ -24,6 +24,7 @@
 #import <FBSimulatorControl/FBSimulatorSessionState+Queries.h>
 #import <FBSimulatorControl/FBSimulatorSessionState.h>
 #import <FBSimulatorControl/FBSimulatorWindowTiler.h>
+#import <FBSimulatorControl/FBSimulatorWindowTilingStrategy.h>
 
 @interface FBSimulatorWindowTilingTests : XCTestCase
 
@@ -68,7 +69,9 @@
   XCTAssertTrue(success);
   XCTAssertNil(error);
 
-  FBSimulatorWindowTiler *tiler = [FBSimulatorWindowTiler withSimulator:session.simulator];
+  FBSimulatorWindowTiler *tiler = [FBSimulatorWindowTiler
+    withSimulator:session.simulator
+    strategy:[FBSimulatorWindowTilingStrategy horizontalOcclusionStrategy:session.simulator]];
   CGRect position = [tiler placeInForegroundWithError:&error];
   XCTAssertNil(error);
   XCTAssertEqual(CGRectGetMinX(position), 0);
@@ -97,7 +100,9 @@
   XCTAssertTrue(success);
   XCTAssertNil(error);
 
-  FBSimulatorWindowTiler *tiler = [FBSimulatorWindowTiler withSimulator:firstSession.simulator];
+  FBSimulatorWindowTiler *tiler = [FBSimulatorWindowTiler
+    withSimulator:firstSession.simulator
+    strategy:[FBSimulatorWindowTilingStrategy horizontalOcclusionStrategy:firstSession.simulator]];
   CGRect position = [tiler placeInForegroundWithError:&error];
   XCTAssertNil(error);
   XCTAssertEqual(CGRectGetMinX(position), 0);
@@ -113,7 +118,9 @@
   XCTAssertTrue(success);
   XCTAssertNil(error);
 
-  tiler = [FBSimulatorWindowTiler withSimulator:secondSession.simulator];
+  tiler = [FBSimulatorWindowTiler
+    withSimulator:secondSession.simulator
+    strategy:[FBSimulatorWindowTilingStrategy horizontalOcclusionStrategy:secondSession.simulator]];
   position = [tiler placeInForegroundWithError:&error];
   XCTAssertNil(error);
   XCTAssertEqual(CGRectGetMinX(position), 320 / scaleFactor);
@@ -129,7 +136,9 @@
   XCTAssertTrue(success);
   XCTAssertNil(error);
 
-  tiler = [FBSimulatorWindowTiler withSimulator:thirdSession.simulator];
+  tiler = [FBSimulatorWindowTiler
+    withSimulator:thirdSession.simulator
+    strategy:[FBSimulatorWindowTilingStrategy horizontalOcclusionStrategy:thirdSession.simulator]];
   position = [tiler placeInForegroundWithError:&error];
   XCTAssertNil(error);
   XCTAssertEqual(CGRectGetMinX(position), 640 / scaleFactor);


### PR DESCRIPTION
There's more than one way of tiling windows within the Display bounds, so this should be pulled out into a strategy that defines the interface for interacting with other windows. 

For example, it may be possible to guarantee a maximum number of simulators, so offsetting in regions of a display is good enough.

Later, it may make sense to be able to compose these strategies. For example, there could be multiple tests in parallel with multiple simulators per-test. In this case the tests could be tiled horizontally and vertical tiling for the simulators within a test. 