### PR TITLE
Base XCTestCase

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		AAB4AC211BB59B790046F6A1 /* FBSimulatorWindowTilingStrategy.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB4AC1F1BB59B790046F6A1 /* FBSimulatorWindowTilingStrategy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AAB4AC221BB59B790046F6A1 /* FBSimulatorWindowTilingStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = AAB4AC201BB59B790046F6A1 /* FBSimulatorWindowTilingStrategy.m */; settings = {ASSET_TAGS = (); }; };
 		AAB4AC241BBBC1A60046F6A1 /* FBSimulatorTilingStrategyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AAB4AC231BBBC1A60046F6A1 /* FBSimulatorTilingStrategyTests.m */; settings = {ASSET_TAGS = (); }; };
+		AAB4AC271BBBC6880046F6A1 /* FBSimulatorControlTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = AAB4AC261BBBC6880046F6A1 /* FBSimulatorControlTestCase.m */; settings = {ASSET_TAGS = (); }; };
 		AAC083751B9FB88B00451648 /* CoreSimulator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E29B6970A5500000000 /* CoreSimulator.framework */; };
 		AAC083761B9FB89600451648 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E29A6018C7A00000000 /* CoreGraphics.framework */; };
 		AAC083781B9FBA7600451648 /* FBSimulatorControl.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1DD70E291A4B50E500000001 /* FBSimulatorControl.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -833,6 +834,8 @@
 		AAB4AC1F1BB59B790046F6A1 /* FBSimulatorWindowTilingStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorWindowTilingStrategy.h; sourceTree = "<group>"; };
 		AAB4AC201BB59B790046F6A1 /* FBSimulatorWindowTilingStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorWindowTilingStrategy.m; sourceTree = "<group>"; };
 		AAB4AC231BBBC1A60046F6A1 /* FBSimulatorTilingStrategyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorTilingStrategyTests.m; sourceTree = "<group>"; };
+		AAB4AC251BBBC6880046F6A1 /* FBSimulatorControlTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorControlTestCase.h; sourceTree = "<group>"; };
+		AAB4AC261BBBC6880046F6A1 /* FBSimulatorControlTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorControlTestCase.m; sourceTree = "<group>"; };
 		AAC2411A1BB30CB30054570C /* FBSimulatorPredicates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorPredicates.h; sourceTree = "<group>"; };
 		AAC2411B1BB30CB30054570C /* FBSimulatorPredicates.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorPredicates.m; sourceTree = "<group>"; };
 		AAC2411F1BB311200054570C /* FBSimulatorWindowTiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorWindowTiler.h; sourceTree = "<group>"; };
@@ -1664,6 +1667,8 @@
 			children = (
 				AA8DFB0C1BAC76B60076A6C2 /* FBSimulatorControlNotificationAssertion.h */,
 				AA8DFB0D1BAC76B60076A6C2 /* FBSimulatorControlNotificationAssertion.m */,
+				AAB4AC251BBBC6880046F6A1 /* FBSimulatorControlTestCase.h */,
+				AAB4AC261BBBC6880046F6A1 /* FBSimulatorControlTestCase.m */,
 				AA8DFB0E1BAC76B60076A6C2 /* FBSimulatorSessionStateAssertion.h */,
 				AA8DFB0F1BAC76B60076A6C2 /* FBSimulatorSessionStateAssertion.m */,
 			);
@@ -1960,6 +1965,7 @@
 				AA51E49E1BA1CA3C0053141E /* FBSimulatorStateTests.m in Sources */,
 				AA51E49C1BA1CA3C0053141E /* FBSimulatorControlSimulatorLaunchTests.m in Sources */,
 				AA7EA4061BB309C30065DC52 /* FBSimulatorTests.m in Sources */,
+				AAB4AC271BBBC6880046F6A1 /* FBSimulatorControlTestCase.m in Sources */,
 				AA51E49D1BA1CA3C0053141E /* FBSimulatorPoolTests.m in Sources */,
 				AA74B99C1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m in Sources */,
 				AA51E4991BA1CA3C0053141E /* FBSimulatorApplicationTests.m in Sources */,

--- a/FBSimulatorControlTests/Tests/FBSimulatorControlApplicationLaunchTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorControlApplicationLaunchTests.m
@@ -9,8 +9,6 @@
 
 #import <XCTest/XCTest.h>
 
-#import <OCMock/OCMock.h>
-
 #import <FBSimulatorControl/FBProcessLaunchConfiguration.h>
 #import <FBSimulatorControl/FBSimulator.h>
 #import <FBSimulatorControl/FBSimulatorApplication.h>
@@ -22,44 +20,15 @@
 #import <FBSimulatorControl/FBSimulatorSession.h>
 #import <FBSimulatorControl/FBSimulatorSessionInteraction.h>
 #import <FBSimulatorControl/FBSimulatorSessionLifecycle.h>
-#import <FBSimulatorControl/FBSimulatorSessionState+Queries.h>
-#import <FBSimulatorControl/FBSimulatorSessionState.h>
-#import <CoreSimulator/SimDevice.h>
-#import <CoreSimulator/SimDeviceSet.h>
 
 #import "FBSimulatorControlNotificationAssertion.h"
+#import "FBSimulatorControlTestCase.h"
 
-@interface FBSimulatorControlApplicationLaunchTests : XCTestCase
-
-@property (nonatomic, strong) FBSimulatorControl *control;
-@property (nonatomic, strong) FBSimulatorControlNotificationAssertion *notificationAssertion;
+@interface FBSimulatorControlApplicationLaunchTests : FBSimulatorControlTestCase
 
 @end
 
 @implementation FBSimulatorControlApplicationLaunchTests
-
-- (void)setUp
-{
-  FBSimulatorManagementOptions options =
-    FBSimulatorManagementOptionsDeleteManagedSimulatorsOnFirstStart |
-    FBSimulatorManagementOptionsKillUnmanagedSimulatorsOnFirstStart |
-    FBSimulatorManagementOptionsDeleteOnFree;
-
-  FBSimulatorControlConfiguration *configuration = [FBSimulatorControlConfiguration
-    configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
-    namePrefix:nil
-    bucket:0
-    options:options];
-
-  self.control = [[FBSimulatorControl alloc] initWithConfiguration:configuration];
-  self.notificationAssertion = [FBSimulatorControlNotificationAssertion new];
-}
-
-- (void)tearDown
-{
-  [self.control.simulatorPool killManagedSimulatorsWithError:nil];
-  self.control = nil;
-}
 
 - (void)testLaunchesSafariApplication
 {

--- a/FBSimulatorControlTests/Tests/FBSimulatorControlSimulatorLaunchTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorControlSimulatorLaunchTests.m
@@ -24,42 +24,15 @@
 #import <FBSimulatorControl/FBSimulatorSessionLifecycle.h>
 #import <FBSimulatorControl/FBSimulatorSessionState+Queries.h>
 #import <FBSimulatorControl/FBSimulatorSessionState.h>
-#import <CoreSimulator/SimDevice.h>
-#import <CoreSimulator/SimDeviceSet.h>
 
 #import "FBSimulatorControlNotificationAssertion.h"
+#import "FBSimulatorControlTestCase.h"
 
-@interface FBSimulatorControlSimulatorLaunchTests : XCTestCase
-
-@property (nonatomic, strong) FBSimulatorControl *control;
-@property (nonatomic, strong) FBSimulatorControlNotificationAssertion *notificationAssertion;
+@interface FBSimulatorControlSimulatorLaunchTests : FBSimulatorControlTestCase
 
 @end
 
 @implementation FBSimulatorControlSimulatorLaunchTests
-
-- (void)setUp
-{
-  FBSimulatorManagementOptions options =
-    FBSimulatorManagementOptionsDeleteManagedSimulatorsOnFirstStart |
-    FBSimulatorManagementOptionsKillUnmanagedSimulatorsOnFirstStart |
-    FBSimulatorManagementOptionsDeleteOnFree;
-
-  FBSimulatorControlConfiguration *configuration = [FBSimulatorControlConfiguration
-    configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
-    namePrefix:nil
-    bucket:0
-    options:options];
-
-  self.control = [[FBSimulatorControl alloc] initWithConfiguration:configuration];
-  self.notificationAssertion = [FBSimulatorControlNotificationAssertion new];
-}
-
-- (void)tearDown
-{
-  [self.control.simulatorPool killManagedSimulatorsWithError:nil];
-  self.control = nil;
-}
 
 - (void)testLaunchesSingleSimulator
 {

--- a/FBSimulatorControlTests/Tests/FBSimulatorSessionLifecycleTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorSessionLifecycleTests.m
@@ -24,29 +24,13 @@
 #import <FBSimulatorControl/FBSimulatorSessionState+Queries.h>
 #import <FBSimulatorControl/NSRunLoop+SimulatorControlAdditions.h>
 
-@interface FBSimulatorSessionLifecycleTests : XCTestCase
+#import "FBSimulatorControlTestCase.h"
 
-@property (nonatomic, strong) FBSimulatorControl *control;
+@interface FBSimulatorSessionLifecycleTests : FBSimulatorControlTestCase
 
 @end
 
 @implementation FBSimulatorSessionLifecycleTests
-
-- (void)setUp
-{
-  FBSimulatorManagementOptions options =
-  FBSimulatorManagementOptionsDeleteManagedSimulatorsOnFirstStart |
-  FBSimulatorManagementOptionsKillUnmanagedSimulatorsOnFirstStart |
-  FBSimulatorManagementOptionsDeleteOnFree;
-
-  FBSimulatorControlConfiguration *configuration = [FBSimulatorControlConfiguration
-    configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
-    namePrefix:nil
-    bucket:0
-    options:options];
-
-  self.control = [[FBSimulatorControl alloc] initWithConfiguration:configuration];
-}
 
 - (void)testNotifiedByUnexpectedApplicationTermination
 {

--- a/FBSimulatorControlTests/Tests/FBSimulatorTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorTests.m
@@ -24,29 +24,13 @@
 #import <FBSimulatorControl/FBSimulatorSessionState+Queries.h>
 #import <FBSimulatorControl/FBSimulatorSessionState.h>
 
-@interface FBSimulatorTests : XCTestCase
+#import "FBSimulatorControlTestCase.h"
 
-@property (nonatomic, strong) FBSimulatorControl *control;
+@interface FBSimulatorTests : FBSimulatorControlTestCase
 
 @end
 
 @implementation FBSimulatorTests
-
-- (void)setUp
-{
-  FBSimulatorManagementOptions options =
-    FBSimulatorManagementOptionsDeleteManagedSimulatorsOnFirstStart |
-    FBSimulatorManagementOptionsKillUnmanagedSimulatorsOnFirstStart |
-    FBSimulatorManagementOptionsDeleteOnFree;
-
-  FBSimulatorControlConfiguration *configuration = [FBSimulatorControlConfiguration
-    configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
-    namePrefix:nil
-    bucket:0
-    options:options];
-
-  self.control = [[FBSimulatorControl alloc] initWithConfiguration:configuration];
-}
 
 - (void)flaky_testCanInferProcessIdentiferAppropriately
 {

--- a/FBSimulatorControlTests/Tests/FBSimulatorVideoRecorderTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorVideoRecorderTests.m
@@ -25,7 +25,9 @@
 #import <FBSimulatorControl/FBSimulatorVideoRecorder.h>
 #import <FBSimulatorControl/NSRunLoop+SimulatorControlAdditions.h>
 
-@interface FBSimulatorVideoRecorderTests : XCTestCase
+#import "FBSimulatorControlTestCase.h"
+
+@interface FBSimulatorVideoRecorderTests : FBSimulatorControlTestCase
 
 @end
 
@@ -33,16 +35,8 @@
 
 - (void)disabled_testRecordsVideo
 {
-  FBSimulatorControlConfiguration *controlConfiguration = [FBSimulatorControlConfiguration
-    configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
-    namePrefix:nil
-    bucket:0
-    options:FBSimulatorManagementOptionsDeleteOnFree];
-
-  FBSimulatorControl *control = [[FBSimulatorControl alloc] initWithConfiguration:controlConfiguration];
-
   NSError *error = nil;
-  FBSimulatorSession *session = [control createSessionForSimulatorConfiguration:FBSimulatorConfiguration.iPhone5 error:&error];
+  FBSimulatorSession *session = [self.control createSessionForSimulatorConfiguration:FBSimulatorConfiguration.iPhone5 error:&error];
   XCTAssertNotNil(session);
   XCTAssertNil(error);
 
@@ -81,21 +75,13 @@
     return;
   }
 
-  FBSimulatorControlConfiguration *controlConfiguration = [FBSimulatorControlConfiguration
-   configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
-   namePrefix:nil
-   bucket:0
-   options:FBSimulatorManagementOptionsDeleteOnFree];
-
   FBApplicationLaunchConfiguration *appLaunch = [FBApplicationLaunchConfiguration
    configurationWithApplication:[FBSimulatorApplication systemApplicationNamed:@"MobileSafari"]
    arguments:@[]
    environment:@{}];
 
-  FBSimulatorControl *control = [[FBSimulatorControl alloc] initWithConfiguration:controlConfiguration];
-
   NSError *error = nil;
-  FBSimulatorSession *firstSession = [control createSessionForSimulatorConfiguration:FBSimulatorConfiguration.iPhone5 error:&error];
+  FBSimulatorSession *firstSession = [self.control createSessionForSimulatorConfiguration:FBSimulatorConfiguration.iPhone5 error:&error];
   XCTAssertNotNil(firstSession);
   XCTAssertNil(error);
   XCTAssertTrue([[[[[firstSession.interact
@@ -107,7 +93,7 @@
   );
   XCTAssertNil(error);
 
-  FBSimulatorSession *secondSession = [control createSessionForSimulatorConfiguration:FBSimulatorConfiguration.iPhone5 error:&error];
+  FBSimulatorSession *secondSession = [self.control createSessionForSimulatorConfiguration:FBSimulatorConfiguration.iPhone5 error:&error];
   XCTAssertNotNil(secondSession);
   XCTAssertNil(error);
   XCTAssertTrue([[[[[secondSession.interact

--- a/FBSimulatorControlTests/Tests/FBSimulatorWindowTilingTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorWindowTilingTests.m
@@ -26,29 +26,13 @@
 #import <FBSimulatorControl/FBSimulatorWindowTiler.h>
 #import <FBSimulatorControl/FBSimulatorWindowTilingStrategy.h>
 
-@interface FBSimulatorWindowTilingTests : XCTestCase
+#import "FBSimulatorControlTestCase.h"
 
-@property (nonatomic, strong) FBSimulatorControl *control;
+@interface FBSimulatorWindowTilingTests : FBSimulatorControlTestCase
 
 @end
 
 @implementation FBSimulatorWindowTilingTests
-
-- (void)setUp
-{
-  FBSimulatorManagementOptions options =
-  FBSimulatorManagementOptionsDeleteManagedSimulatorsOnFirstStart |
-  FBSimulatorManagementOptionsKillUnmanagedSimulatorsOnFirstStart |
-  FBSimulatorManagementOptionsDeleteOnFree;
-
-  FBSimulatorControlConfiguration *configuration = [FBSimulatorControlConfiguration
-    configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
-    namePrefix:nil
-    bucket:0
-    options:options];
-
-  self.control = [[FBSimulatorControl alloc] initWithConfiguration:configuration];
-}
 
 - (void)testTilesSingleiPhoneSimulatorInTopLeft
 {

--- a/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.h
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.h
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <FBSimulatorControl/FBSimulatorControlConfiguration.h>
+
+@class FBSimulatorControl;
+@class FBSimulatorControlNotificationAssertion;
+
+/**
+ A Test Case that boostraps a FBSimulatorControl instance.
+ Should be overridden to provide Integration tests for Simulators.
+ */
+@interface FBSimulatorControlTestCase : XCTestCase
+
+/*
+ The Per-Test-Case Management Options.
+ */
+- (FBSimulatorManagementOptions)managementOptions;
+
+@property (nonatomic, strong, readonly) FBSimulatorControl *control;
+@property (nonatomic, strong, readonly) FBSimulatorControlNotificationAssertion *notificationAssertion;
+
+@end

--- a/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBSimulatorControlTestCase.h"
+
+#import <FBSimulatorControl/FBSimulatorControl.h>
+#import <FBSimulatorControl/FBSimulatorControl+Private.h>
+#import <FBSimulatorControl/FBSimulatorPool.h>
+#import <FBSimulatorControl/FBSimulatorPool+Private.h>
+#import <FBSimulatorControl/FBSimulatorControlConfiguration.h>
+#import <FBSimulatorControl/FBSimulatorApplication.h>
+#import <FBSimulatorControl/FBSimulator.h>
+#import <FBSimulatorControl/FBSimulatorConfiguration.h>
+
+#import "FBSimulatorControlNotificationAssertion.h"
+
+@interface FBSimulatorControlTestCase ()
+
+@property (nonatomic, strong, readwrite) FBSimulatorControl *control;
+@property (nonatomic, strong, readwrite) FBSimulatorControlNotificationAssertion *notificationAssertion;
+
+@end
+
+@implementation FBSimulatorControlTestCase
+
+- (FBSimulatorManagementOptions)managementOptions
+{
+  return FBSimulatorManagementOptionsDeleteManagedSimulatorsOnFirstStart |
+         FBSimulatorManagementOptionsKillUnmanagedSimulatorsOnFirstStart |
+         FBSimulatorManagementOptionsDeleteOnFree;
+}
+
+- (void)setUp
+{
+  FBSimulatorControlConfiguration *configuration = [FBSimulatorControlConfiguration
+    configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
+    namePrefix:nil
+    bucket:0
+    options:[self managementOptions]];
+
+  self.control = [[FBSimulatorControl alloc] initWithConfiguration:configuration];
+  self.notificationAssertion = [FBSimulatorControlNotificationAssertion new];
+}
+
+- (void)tearDown
+{
+  [self.control.simulatorPool killManagedSimulatorsWithError:nil];
+  self.control = nil;
+}
+
+@end


### PR DESCRIPTION
Moves a lot of the duplicated code for creating `FBSimulatorControl` to a `XCTestCase` subclass. Drastically reduces the amount of boiler plate and provides a common way of cleaning up `FBSimulator` instances after they have been allocated by a Test Case.