### PR TITLE
Remove WDA Helper

### DIFF
--- a/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration+Helpers.h
+++ b/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration+Helpers.h
@@ -19,15 +19,3 @@
 - (instancetype)withDiagnosticEnvironment;
 
 @end
-
-@interface FBAgentLaunchConfiguration (Helpers)
-
-/**
- Creates and returns a new Configuration for launching WebDriverAgent.
-
- @param simulator the Simulator to create the configuration for.
- @returna new Agent Launch Configuration for the provided Simulator.
- */
-+ (instancetype)defaultWebDriverAgentConfigurationForSimulator:(FBSimulator *)simulator;
-
-@end

--- a/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration+Helpers.m
+++ b/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration+Helpers.m
@@ -35,31 +35,3 @@
 }
 
 @end
-
-@implementation FBAgentLaunchConfiguration (Helpers)
-
-+ (instancetype)defaultWebDriverAgentConfigurationForSimulator:(FBSimulator *)simulator
-{
-  NSParameterAssert(simulator);
-
-  NSBundle *bundle = [NSBundle bundleForClass:[self class]];
-  NSString *webDriverPath = [bundle pathForResource:@"WebDriverAgent" ofType:@""];
-  NSAssert(webDriverPath, @"WebDriverAgent should exist in bundle %@", bundle);
-
-  NSDictionary *containingEnvironment = NSProcessInfo.processInfo.environment;
-  NSMutableDictionary *agentEnvironment = [NSMutableDictionary dictionary];
-
-  if ([containingEnvironment[@"RUN_FRESH_WEB_DRIVER_AGENT"] boolValue]) {
-    webDriverPath = [[@(__FILE__) stringByDeletingLastPathComponent] stringByAppendingPathComponent:@"WebDriverAgent"];
-  }
-  if (containingEnvironment[@"BUCKET_ID"]) {
-    agentEnvironment[@"PORT_OFFSET"] = containingEnvironment[@"BUCKET_ID"];
-  }
-
-  NSString *stdErrPath = [simulator.dataDirectory stringByAppendingPathComponent:@"WebDriverAgent.log"];
-
-  FBSimulatorBinary *binary = [FBSimulatorBinary binaryWithPath:webDriverPath error:nil];
-  return [self configurationWithBinary:binary arguments:@[] environment:[agentEnvironment copy] stdOutPath:nil stdErrPath:stdErrPath];
-}
-
-@end


### PR DESCRIPTION
WDA doesn't exist in the bundle from which it is fetched (the `FBSimulatorControl.framework`), it doesn't make much sense to have this here.

We can replace this with better documentation and samples. There is no `WebDriverAgent` binary artifact  here yet.