### PR TITLE
Support Custom SimDeviceSets

### DIFF
--- a/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.h
@@ -37,12 +37,21 @@ typedef NS_OPTIONS(NSUInteger, FBSimulatorManagementOptions){
  @param options the options for Simulator Management.
  @returns a new Configuration Object with the arguments applied.
  */
-+ (instancetype)configurationWithSimulatorApplication:(FBSimulatorApplication *)simulatorApplication namePrefix:(NSString *)namePrefix bucket:(NSInteger)bucketID options:(FBSimulatorManagementOptions)options;
++ (instancetype)configurationWithSimulatorApplication:(FBSimulatorApplication *)simulatorApplication
+                                        deviceSetPath:(NSString *)deviceSetPath
+                                           namePrefix:(NSString *)namePrefix
+                                               bucket:(NSInteger)bucketID
+                                              options:(FBSimulatorManagementOptions)options;
 
 /**
  The FBSimulatorApplication for the Simulator.app.
  */
 @property (nonatomic, copy, readonly) FBSimulatorApplication *simulatorApplication;
+
+/**
+ The Location of the SimDeviceSet. If no path is provided, the default device set will be used.
+ */
+@property (nonatomic, copy, readonly) NSString *deviceSetPath;
 
 /**
  The String to prefix all `FBSimulatorControl` Simulators with.

--- a/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.m
@@ -16,6 +16,7 @@ NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
 @interface FBSimulatorControlConfiguration ()
 
 @property (nonatomic, copy, readwrite) FBSimulatorApplication *simulatorApplication;
+@property (nonatomic, copy, readwrite) NSString *deviceSetPath;
 @property (nonatomic, copy, readwrite) NSString *namePrefix;
 @property (nonatomic, assign, readwrite) NSInteger bucketID;
 @property (nonatomic, assign, readwrite) FBSimulatorManagementOptions options;
@@ -24,13 +25,18 @@ NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
 
 @implementation FBSimulatorControlConfiguration
 
-+ (instancetype)configurationWithSimulatorApplication:(FBSimulatorApplication *)simulatorApplication namePrefix:(NSString *)namePrefix bucket:(NSInteger)bucketID options:(FBSimulatorManagementOptions)options
++ (instancetype)configurationWithSimulatorApplication:(FBSimulatorApplication *)simulatorApplication
+                                        deviceSetPath:(NSString *)deviceSetPath
+                                           namePrefix:(NSString *)namePrefix
+                                               bucket:(NSInteger)bucketID
+                                              options:(FBSimulatorManagementOptions)options
 {
   NSParameterAssert(simulatorApplication);
   NSParameterAssert(bucketID >= 0);
 
   FBSimulatorControlConfiguration *configuration = [self new];
   configuration.simulatorApplication = simulatorApplication;
+  configuration.deviceSetPath = deviceSetPath;
   configuration.namePrefix = namePrefix.length > 0 ? namePrefix : FBSimulatorControlConfigurationDefaultNamePrefix;
   configuration.bucketID = bucketID;
   configuration.options = options;
@@ -41,6 +47,7 @@ NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
 {
   return [self.class
     configurationWithSimulatorApplication:self.simulatorApplication
+    deviceSetPath:self.deviceSetPath
     namePrefix:self.namePrefix
     bucket:self.bucketID
     options:self.options];
@@ -48,7 +55,7 @@ NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
 
 - (NSUInteger)hash
 {
-  return self.simulatorApplication.hash | self.namePrefix.hash | self.bucketID | self.options;
+  return self.simulatorApplication.hash | self.deviceSetPath.hash | self.namePrefix.hash | self.bucketID | self.options;
 }
 
 - (BOOL)isEqual:(FBSimulatorControlConfiguration *)object
@@ -57,6 +64,7 @@ NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
     return NO;
   }
   return [self.simulatorApplication isEqual:object.simulatorApplication] &&
+         ((self.deviceSetPath == nil && object.deviceSetPath == nil) || [self.deviceSetPath isEqual:object.deviceSetPath]) &&
          [self.namePrefix isEqualToString:object.namePrefix] &&
          self.bucketID == object.bucketID &&
          self.options == object.options;
@@ -65,7 +73,8 @@ NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
 - (NSString *)description
 {
   return [NSString stringWithFormat:
-    @"Pool Config | Sim App %@ | Prefix %@ | Bucket Id %ld | Options %ld",
+    @"Pool Config | Set Path %@ | Sim App %@ | Prefix %@ | Bucket Id %ld | Options %ld",
+    self.deviceSetPath,
     self.simulatorApplication,
     self.namePrefix,
     self.bucketID,

--- a/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.h
@@ -34,4 +34,9 @@
  */
 + (NSString *)sdkVersion;
 
+/**
+ YES if passing a custom SimDeviceSet to the Simulator App is Supported.
+ */
++ (BOOL)supportsCustomDeviceSets;
+
 @end

--- a/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.m
@@ -107,4 +107,12 @@
   return sdkVersion;
 }
 
++ (BOOL)supportsCustomDeviceSets
+{
+  // Prior to Xcode 7, 'iOS Simulator.app' calls `+[SimDeviceSet defaultSet]` directly
+  // This means that the '-DeviceSetPath' won't do anything for Simulators booted with prior to Xcode 7.
+  // It should be possible to fix this by injecting a shim that swizzles this method in these Xcode versions.
+  return [self.sdkVersionNumber isGreaterThanOrEqualTo:[NSDecimalNumber decimalNumberWithString:@"9.0"]];
+}
+
 @end

--- a/FBSimulatorControlTests/Tests/FBSimulatorControlConfigurationTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorControlConfigurationTests.m
@@ -24,6 +24,7 @@
 
   FBSimulatorControlConfiguration *config = [FBSimulatorControlConfiguration
     configurationWithSimulatorApplication:application
+    deviceSetPath:nil
     namePrefix:@"TestEnv"
     bucket:1
     options:FBSimulatorManagementOptionsDeleteManagedSimulatorsOnFirstStart];

--- a/FBSimulatorControlTests/Tests/FBSimulatorPoolAllocationTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorPoolAllocationTests.m
@@ -35,6 +35,7 @@
 {
   FBSimulatorControlConfiguration *controlConfiguration = [FBSimulatorControlConfiguration
     configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
+    deviceSetPath:nil
     namePrefix:nil
     bucket:0
     options:FBSimulatorManagementOptionsEraseOnFree];

--- a/FBSimulatorControlTests/Tests/FBSimulatorPoolTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorPoolTests.m
@@ -60,6 +60,7 @@
 
   FBSimulatorControlConfiguration *poolConfig = [FBSimulatorControlConfiguration
     configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
+    deviceSetPath:nil
     namePrefix:nil
     bucket:1
     options:0];

--- a/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.h
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.h
@@ -25,6 +25,11 @@
  */
 - (FBSimulatorManagementOptions)managementOptions;
 
+/*
+ The Per-Test-Case Device Set Path.
+ */
+- (NSString *)deviceSetPath;
+
 @property (nonatomic, strong, readonly) FBSimulatorControl *control;
 @property (nonatomic, strong, readonly) FBSimulatorControlNotificationAssertion *notificationAssertion;
 

--- a/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
@@ -40,6 +40,7 @@
 {
   FBSimulatorControlConfiguration *configuration = [FBSimulatorControlConfiguration
     configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
+    deviceSetPath:self.deviceSetPath
     namePrefix:nil
     bucket:0
     options:[self managementOptions]];
@@ -52,6 +53,11 @@
 {
   [self.control.simulatorPool killManagedSimulatorsWithError:nil];
   self.control = nil;
+}
+
+- (NSString *)deviceSetPath
+{
+  return nil;
 }
 
 @end


### PR DESCRIPTION
It's possible to change `Simulator.app` to use a different device set by passing `-DeviceSetPath` as an arg to the launched `Simulator`. This will be vastly preferable to using Prefixes to isolate simulators between processes.

cc @mmmulani @ExtremeMan 