### PR TITLE
Remove Managed/Unmanaged Simulator Distinction

### DIFF
--- a/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.h
@@ -17,8 +17,8 @@
 extern NSString *const FBSimulatorControlConfigurationDefaultNamePrefix;
 
 typedef NS_OPTIONS(NSUInteger, FBSimulatorManagementOptions){
-  FBSimulatorManagementOptionsDeleteManagedSimulatorsOnFirstStart = 1 << 0,
-  FBSimulatorManagementOptionsKillUnmanagedSimulatorsOnFirstStart = 1 << 1,
+  FBSimulatorManagementOptionsDeleteAllOnFirstStart = 1 << 0,
+  FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart = 1 << 1,
   FBSimulatorManagementOptionsDeleteOnFree = 1 << 2,
   FBSimulatorManagementOptionsEraseOnFree = 1 << 3,
 };
@@ -32,15 +32,11 @@ typedef NS_OPTIONS(NSUInteger, FBSimulatorManagementOptions){
  Creates and returns a new Configuration with the provided parameters.
 
  @param simulatorApplication the FBSimulatorApplication for the Simulator.app.
- @param namePrefix the String to prefix all `FBSimulatorControl` managed Simulators with. Will default to 'E2E' if nil.
- @param bucketID the Bucket of the launched Simulators. Multiple processes cannot share the same Bucket ID.
  @param options the options for Simulator Management.
  @returns a new Configuration Object with the arguments applied.
  */
 + (instancetype)configurationWithSimulatorApplication:(FBSimulatorApplication *)simulatorApplication
                                         deviceSetPath:(NSString *)deviceSetPath
-                                           namePrefix:(NSString *)namePrefix
-                                               bucket:(NSInteger)bucketID
                                               options:(FBSimulatorManagementOptions)options;
 
 /**
@@ -52,17 +48,6 @@ typedef NS_OPTIONS(NSUInteger, FBSimulatorManagementOptions){
  The Location of the SimDeviceSet. If no path is provided, the default device set will be used.
  */
 @property (nonatomic, copy, readonly) NSString *deviceSetPath;
-
-/**
- The String to prefix all `FBSimulatorControl` Simulators with.
- Simulators in the same Pool will share the same `namePrefix` and `bucketID`.
- */
-@property (nonatomic, copy, readonly) NSString *namePrefix;
-
-/**
- The Bucket of the launched Simulators. Multiple processes cannot share the same Bucket ID.
- */
-@property (nonatomic, assign, readonly) NSInteger bucketID;
 
 /**
  The options for Simulator Management.

--- a/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.m
@@ -17,8 +17,6 @@ NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
 
 @property (nonatomic, copy, readwrite) FBSimulatorApplication *simulatorApplication;
 @property (nonatomic, copy, readwrite) NSString *deviceSetPath;
-@property (nonatomic, copy, readwrite) NSString *namePrefix;
-@property (nonatomic, assign, readwrite) NSInteger bucketID;
 @property (nonatomic, assign, readwrite) FBSimulatorManagementOptions options;
 
 @end
@@ -27,18 +25,13 @@ NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
 
 + (instancetype)configurationWithSimulatorApplication:(FBSimulatorApplication *)simulatorApplication
                                         deviceSetPath:(NSString *)deviceSetPath
-                                           namePrefix:(NSString *)namePrefix
-                                               bucket:(NSInteger)bucketID
                                               options:(FBSimulatorManagementOptions)options
 {
   NSParameterAssert(simulatorApplication);
-  NSParameterAssert(bucketID >= 0);
 
   FBSimulatorControlConfiguration *configuration = [self new];
   configuration.simulatorApplication = simulatorApplication;
   configuration.deviceSetPath = deviceSetPath;
-  configuration.namePrefix = namePrefix.length > 0 ? namePrefix : FBSimulatorControlConfigurationDefaultNamePrefix;
-  configuration.bucketID = bucketID;
   configuration.options = options;
   return configuration;
 }
@@ -48,14 +41,12 @@ NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
   return [self.class
     configurationWithSimulatorApplication:self.simulatorApplication
     deviceSetPath:self.deviceSetPath
-    namePrefix:self.namePrefix
-    bucket:self.bucketID
     options:self.options];
 }
 
 - (NSUInteger)hash
 {
-  return self.simulatorApplication.hash | self.deviceSetPath.hash | self.namePrefix.hash | self.bucketID | self.options;
+  return self.simulatorApplication.hash | self.deviceSetPath.hash | self.options;
 }
 
 - (BOOL)isEqual:(FBSimulatorControlConfiguration *)object
@@ -65,19 +56,15 @@ NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
   }
   return [self.simulatorApplication isEqual:object.simulatorApplication] &&
          ((self.deviceSetPath == nil && object.deviceSetPath == nil) || [self.deviceSetPath isEqual:object.deviceSetPath]) &&
-         [self.namePrefix isEqualToString:object.namePrefix] &&
-         self.bucketID == object.bucketID &&
          self.options == object.options;
 }
 
 - (NSString *)description
 {
   return [NSString stringWithFormat:
-    @"Pool Config | Set Path %@ | Sim App %@ | Prefix %@ | Bucket Id %ld | Options %ld",
+    @"Pool Config | Set Path %@ | Sim App %@ | Options %ld",
     self.deviceSetPath,
     self.simulatorApplication,
-    self.namePrefix,
-    self.bucketID,
     self.options
   ];
 }

--- a/FBSimulatorControl/Management/FBSimulator+Private.h
+++ b/FBSimulatorControl/Management/FBSimulator+Private.h
@@ -17,15 +17,8 @@
 @property (nonatomic, strong, readwrite) SimDevice *device;
 @property (nonatomic, weak, readwrite) FBSimulatorPool *pool;
 @property (nonatomic, assign, readwrite) NSInteger processIdentifier;
-
-+ (instancetype)inflateFromSimDevice:(SimDevice *)simDevice configuration:(FBSimulatorControlConfiguration *)configuration;
-
-@end
-
-@interface FBManagedSimulator ()
-
-@property (nonatomic, assign, readwrite) NSInteger bucketID;
-@property (nonatomic, assign, readwrite) NSInteger offset;
 @property (nonatomic, copy, readwrite) FBSimulatorConfiguration *configuration;
+
++ (instancetype)inflateFromSimDevice:(SimDevice *)device configuration:(FBSimulatorConfiguration *)configuration pool:(FBSimulatorPool *)pool;
 
 @end

--- a/FBSimulatorControl/Management/FBSimulator.h
+++ b/FBSimulatorControl/Management/FBSimulator.h
@@ -43,22 +43,27 @@ typedef NS_ENUM(NSInteger, FBSimulatorState) {
 @property (nonatomic, strong, readonly) SimDevice *device;
 
 /**
+ Whether the Simulator is allocated or not.
+ */
+@property (nonatomic, assign, readonly, getter=isAllocated) BOOL allocated;
+
+/**
  The Pool to which the Simulator Belongs.
  */
 @property (nonatomic, weak, readonly) FBSimulatorPool *pool;
 
 /**
- The Name of the allocated device.
+ The Name of the allocated Simulator.
  */
 @property (nonatomic, copy, readonly) NSString *name;
 
 /**
- The UDID of the allocated device.
+ The UDID of the allocated Simulator.
  */
 @property (nonatomic, copy, readonly) NSString *udid;
 
 /**
- The State of the allocated device.
+ The State of the allocated Simulator.
  */
 @property (nonatomic, assign, readonly) FBSimulatorState state;
 
@@ -89,6 +94,11 @@ typedef NS_ENUM(NSInteger, FBSimulatorState) {
 @property (nonatomic, copy, readonly) FBSimulatorApplication *simulatorApplication;
 
 /**
+ The FBSimulatorConfiguration representing this Simulator.
+ */
+@property (nonatomic, copy, readonly) FBSimulatorConfiguration *configuration;
+
+/**
  Synchronously waits on the provided state.
 
  @param state the state to wait on
@@ -115,37 +125,8 @@ typedef NS_ENUM(NSInteger, FBSimulatorState) {
  */
 + (FBSimulatorState)simulatorStateFromStateString:(NSString *)stateString;
 
-@end
-
 /**
- Defines the Additional Properties and Methods that exist on a 'Managed' Simulator.
- A Managed Simulator is one that has Allocation and Freeing semantics.
- */
-@interface FBManagedSimulator : FBSimulator
-
-/**
- Whether the Simulator is Allocated.
- */
-@property (nonatomic, assign, readonly, getter=isAllocated) BOOL allocated;
-
-/**
- The Bucket ID of the allocated device. Bucket IDs are used to segregate a range of devices, so that multiple
- processes can use Simulators, without colliding
- */
-@property (nonatomic, assign, readonly) NSInteger bucketID;
-
-/**
- The Offset represents the position in the pool of this device. Multiple devices of the same type can be allocated in the same pool.
- */
-@property (nonatomic, assign, readonly) NSInteger offset;
-
-/**
- The Configuration that this Simulator was created and will be launched with.
- */
-@property (nonatomic, copy, readonly) FBSimulatorConfiguration *configuration;
-
-/**
- Calls `freeSimulator:error:` on this device's pool, with the reciever as the first argument
+ Calls `freeSimulator:error:` on this device's pool, with the reciever as the first argument.
 
  @param error an error out for any error that occured.
  @returns YES if the freeing of the device was successful, NO otherwise.

--- a/FBSimulatorControl/Management/FBSimulatorControl+Private.h
+++ b/FBSimulatorControl/Management/FBSimulatorControl+Private.h
@@ -20,5 +20,6 @@
 @property (nonatomic, assign, readwrite) BOOL hasRunOnce;
 
 - (instancetype)initWithConfiguration:(FBSimulatorControlConfiguration *)configuration;
+- (BOOL)firstRunPreconditionsWithError:(NSError **)error;
 
 @end

--- a/FBSimulatorControl/Management/FBSimulatorControl.m
+++ b/FBSimulatorControl/Management/FBSimulatorControl.m
@@ -72,7 +72,7 @@
     return [FBSimulatorError failWithError:innerError description:@"Failed to meet first run preconditions" errorOut:error];
   }
 
-  FBManagedSimulator *simulator = [self.simulatorPool
+  FBSimulator *simulator = [self.simulatorPool
     allocateSimulatorWithConfiguration:simulatorConfiguration
     error:&innerError];
 
@@ -101,19 +101,19 @@
     }
   }
 
-  BOOL deleteOnStart = (self.configuration.options & FBSimulatorManagementOptionsDeleteManagedSimulatorsOnFirstStart) == FBSimulatorManagementOptionsDeleteManagedSimulatorsOnFirstStart;
+  BOOL deleteOnStart = (self.configuration.options & FBSimulatorManagementOptionsDeleteAllOnFirstStart) == FBSimulatorManagementOptionsDeleteAllOnFirstStart;
   NSArray *result = deleteOnStart
-    ? [self.simulatorPool deleteManagedSimulatorsWithError:&innerError]
-    : [self.simulatorPool killManagedSimulatorsWithError:&innerError];
+    ? [self.simulatorPool deleteAllWithError:&innerError]
+    : [self.simulatorPool killAllWithError:&innerError];
 
   if (!result) {
     return [FBSimulatorError failBoolWithError:innerError description:@"Failed to teardown previous simulators" errorOut:error];
   }
 
-  BOOL killUnmanaged = (self.configuration.options & FBSimulatorManagementOptionsKillUnmanagedSimulatorsOnFirstStart) == FBSimulatorManagementOptionsKillUnmanagedSimulatorsOnFirstStart;
+  BOOL killUnmanaged = (self.configuration.options & FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart) == FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart;
   if (killUnmanaged) {
-    if (![self.simulatorPool killUnmanagedSimulatorsWithError:&innerError]) {
-      return [FBSimulatorError failBoolWithError:innerError description:@"Failed to kill unmanaged simulators" errorOut:error];
+    if (![self.simulatorPool killSpuriousSimulatorsWithError:&innerError]) {
+      return [FBSimulatorError failBoolWithError:innerError description:@"Failed to kill spurious simulators" errorOut:error];
     }
   }
 

--- a/FBSimulatorControl/Management/FBSimulatorPool.h
+++ b/FBSimulatorControl/Management/FBSimulatorPool.h
@@ -9,7 +9,6 @@
 
 #import <Foundation/Foundation.h>
 
-@class FBManagedSimulator;
 @class FBSimulator;
 @class FBSimulatorConfiguration;
 @class FBSimulatorControlConfiguration;
@@ -40,8 +39,8 @@
 
 /**
  An Ordered Set of the Simulators for the DeviceSet.
- This includes allocated and un-allocated simulators, as well as managed and unmanaged simulators.
- Ordering is based on name descending.
+ This includes allocated and un-allocated Simulators.
+ Ordering is based on the ordering of SimDeviceSet.
  Is an NSOrderedSet<FBSimulator>
  */
 @property (nonatomic, copy, readonly) NSOrderedSet *allSimulators;
@@ -60,7 +59,7 @@
  @param error an error out for any error that occured.
  @returns a device if one could be found or created, nil if an error occured.
  */
-- (FBManagedSimulator *)allocateSimulatorWithConfiguration:(FBSimulatorConfiguration *)configuration error:(NSError **)error;
+- (FBSimulator *)allocateSimulatorWithConfiguration:(FBSimulatorConfiguration *)configuration error:(NSError **)error;
 
 /**
  Marks a device that was previously returned from `allocateDeviceWithName:sdkVersion:error:` as free.
@@ -70,31 +69,23 @@
  @param error an error out for any error that occured.
  @returns YES if the freeing of the device was successful, NO otherwise.
  */
-- (BOOL)freeSimulator:(FBManagedSimulator *)simulator error:(NSError **)error;
+- (BOOL)freeSimulator:(FBSimulator *)simulator error:(NSError **)error;
 
 /**
- Kills all of the Simulators that this Pool is responsible for.
+ Kills all of the Simulators the reciever's Device Set.
 
  @param error an error out if any error occured.
  @returns an array of the Simulators that this were killed if successful, nil otherwise.
  */
-- (NSArray *)killManagedSimulatorsWithError:(NSError **)error;
+- (NSArray *)killAllWithError:(NSError **)error;
 
 /**
- Kills all of the Simulators that this, or any other Pool is responsible for.
+ Kills all of the Simulators that are not launched by `FBSimulatorControl`. These can be Simulators launched via Xcode or Instruments.
 
  @param error an error out if any error occured.
- @returns an array of the Simulators that this were killed if successful, nil otherwise.
+ @returns an YES if successful, nil otherwise.
  */
-- (NSArray *)killPooledSimulatorsWithError:(NSError **)error;
-
-/**
- Kills all of the Simulators that this are not managed by this pool, or any other.
-
- @param error an error out if any error occured.
- @returns an array of the Simulators that this were killed if successful, nil otherwise.
- */
-- (NSArray *)killUnmanagedSimulatorsWithError:(NSError **)error;
+- (BOOL)killSpuriousSimulatorsWithError:(NSError **)error;
 
 /**
  Erases the Simulators that this Pool is responsible for.
@@ -103,7 +94,7 @@
  @param error an error out if any error occured.
  @returns an array of the Simulators that this Pool is responsible if successful, nil otherwise.
  */
-- (NSArray *)eraseManagedSimulatorsWithError:(NSError **)error;
+- (NSArray *)eraseAllWithError:(NSError **)error;
 
 /**
  Delete all of the Simulators Managed by this Pool, killing them first.
@@ -111,15 +102,7 @@
  @param error an error out if any error occured.
  @returns an Array of the names of the Simulators that were deleted if successful, nil otherwise.
  */
-- (NSArray *)deleteManagedSimulatorsWithError:(NSError **)error;
-
-/**
- Delete all of the Simulators that this Pool, or any other pool is responsiblef for, killing them first.
-
- @param error an error out if any error occured.
- @returns an Array of the names of the Simulators that were deleted if successful, nil otherwise.
- */
-- (NSArray *)deletePooledSimulatorsWithError:(NSError **)error;
+- (NSArray *)deleteAllWithError:(NSError **)error;
 
 @end
 
@@ -145,50 +128,22 @@
  @param deviceType the Device Type of the Device to search for. Must not be nil.
  @return The Allocated device created by FBSimulatorPool.
  */
-- (FBManagedSimulator *)allocatedSimulatorWithDeviceType:(NSString *)deviceType;
-
-/**
- An Ordered Set of the Simulators that this Pool is responsible for.
- This includes allocated and un-allocated simulators.
- Ordering is based on name descending.
- Is an NSOrderedSet<FBManagedSimulator>
- */
-@property (nonatomic, copy, readonly) NSOrderedSet *allSimulatorsInPool;
-
-/**
- An Ordered Set of the Simulators that any posible Pool is responsible for.
- This includes allocated and un-allocated simulators.
- Ordering is based on name descending.
- Is an NSOrderedSet<FBManagedSimulator>
- */
-@property (nonatomic, copy, readonly) NSOrderedSet *allPooledSimulators;
+- (FBSimulator *)allocatedSimulatorWithDeviceType:(NSString *)deviceType;
 
 /**
  An Ordered Set of the Simulators that this Pool has allocated.
  This includes only allocated simulators.
- Is an NSOrderedSet<FBManagedSimulator>
+ Is an NSOrderedSet<FBSimulator>
  */
 @property (nonatomic, copy, readonly) NSOrderedSet *allocatedSimulators;
 
 /**
  An Ordered Set of the Simulators that this Pool has allocated.
  This includes only allocated simulators.
- Ordering is based on name descending.
- Is an NSOrderedSet<FBManagedSimulator>
+ Ordering is based on the recency of the allocation: the most recent allocated Simulator is at the end of the Set.
+ Is an NSOrderedSet<FBSimulator>
  */
 @property (nonatomic, copy, readonly) NSOrderedSet *unallocatedSimulators;
-
-/**
- An Ordered Set of all the Simulators for the Device Set.
- Is an NSOrderedSet<FBSimulator>
- */
-@property (nonatomic, copy, readonly) NSOrderedSet *allSimulators;
-
-/**
- An Ordered Set of the Simulators that no Pool is responsible for.
- Is an NSOrderedSet<FBSimulator>
- */
-@property (nonatomic, copy, readonly) NSOrderedSet *unmanagedSimulators;
 
 /**
  An Ordered Set of the Simulators that have been launched by any pool, or not by FBSimulatorControl at all.

--- a/FBSimulatorControl/Management/FBSimulatorPredicates.h
+++ b/FBSimulatorControl/Management/FBSimulatorPredicates.h
@@ -11,22 +11,13 @@
 
 @class FBSimulator;
 @class FBSimulatorPool;
+@class FBSimulatorConfiguration;
 
 /**
- Predicates for filtering the sets of available Simulators.
+ Predicates for filtering collections of available Simulators.
  NSCompoundPredicate can be used to compose Predicates.
  */
 @interface FBSimulatorPredicates : NSObject
-
-/**
- Predicate for Simulators that are managed by any Pool.
- */
-+ (NSPredicate *)managed;
-
-/**
- Predicate for Simulators that are managed by a specific Pool.
- */
-+ (NSPredicate *)managedByPool:(FBSimulatorPool *)pool;
 
 /**
  Predicate for Simulators that are allocated in a specific Pool.
@@ -39,11 +30,6 @@
 + (NSPredicate *)unallocatedByPool:(FBSimulatorPool *)pool;
 
 /**
- Predicate for Simulators that are not managed by any Pool.
- */
-+ (NSPredicate *)unmanaged;
-
-/**
  Predicate for Simulators that are launched.
  */
 + (NSPredicate *)launched;
@@ -52,5 +38,10 @@
  Predicate for only the provided Simulator.
  */
 + (NSPredicate *)only:(FBSimulator *)simulator;
+
+/**
+ Predicate for matching SimDevices against a Configuration.
+ */
++ (NSPredicate *)matchingConfiguration:(FBSimulatorConfiguration *)configuration;
 
 @end

--- a/FBSimulatorControl/Management/FBSimulatorPredicates.m
+++ b/FBSimulatorControl/Management/FBSimulatorPredicates.m
@@ -9,29 +9,17 @@
 
 #import "FBSimulatorPredicates.h"
 
+#import <CoreSimulator/SimDevice.h>
+#import <CoreSimulator/SimDeviceType.h>
+#import <CoreSimulator/SimRuntime.h>
+
 #import "FBSimulator.h"
+#import "FBSimulatorConfiguration+CoreSimulator.h"
 #import "FBSimulatorControlConfiguration.h"
 #import "FBSimulatorPool+Private.h"
 #import "FBSimulatorPool.h"
 
 @implementation FBSimulatorPredicates
-
-+ (NSPredicate *)managed
-{
-  return [NSPredicate predicateWithBlock:^ BOOL (FBSimulator *simulator, NSDictionary *_) {
-    return [simulator isKindOfClass:FBManagedSimulator.class];
-  }];
-}
-
-+ (NSPredicate *)managedByPool:(FBSimulatorPool *)pool
-{
-  return [NSCompoundPredicate andPredicateWithSubpredicates:@[
-    self.managed,
-    [NSPredicate predicateWithBlock:^ BOOL (FBManagedSimulator *simulator, NSDictionary *_) {
-      return pool.configuration.bucketID == simulator.bucketID;
-    }]
-  ]];
-}
 
 + (NSPredicate *)allocatedByPool:(FBSimulatorPool *)pool
 {
@@ -43,14 +31,8 @@
 + (NSPredicate *)unallocatedByPool:(FBSimulatorPool *)pool
 {
   return [NSCompoundPredicate andPredicateWithSubpredicates:@[
-    [self managedByPool:pool],
     [NSCompoundPredicate notPredicateWithSubpredicate:[self allocatedByPool:pool]],
   ]];
-}
-
-+ (NSPredicate *)unmanaged
-{
-  return [NSCompoundPredicate notPredicateWithSubpredicate:self.managed];
 }
 
 + (NSPredicate *)launched
@@ -64,6 +46,14 @@
 {
   return [NSPredicate predicateWithBlock:^ BOOL (FBSimulator *candidate, NSDictionary *_) {
     return simulator.udid && [candidate.udid isEqual:simulator.udid];
+  }];
+}
+
++ (NSPredicate *)matchingConfiguration:(FBSimulatorConfiguration *)configuration
+{
+  return [NSPredicate predicateWithBlock:^ BOOL (FBSimulator *candidate, NSDictionary *_) {
+    return [candidate.device.deviceType.name isEqual:configuration.deviceType.name] &&
+           [candidate.device.runtime.name isEqual:configuration.runtime.name];
   }];
 }
 

--- a/FBSimulatorControl/Session/FBSimulatorSession+Private.h
+++ b/FBSimulatorControl/Session/FBSimulatorSession+Private.h
@@ -15,7 +15,7 @@
 
 @interface FBSimulatorSession ()
 
-@property (nonatomic, strong, readwrite) FBManagedSimulator *simulator;
+@property (nonatomic, strong, readwrite) FBSimulator *simulator;
 @property (nonatomic, strong, readwrite) FBSimulatorSessionLifecycle *lifecycle;
 
 @end

--- a/FBSimulatorControl/Session/FBSimulatorSession.h
+++ b/FBSimulatorControl/Session/FBSimulatorSession.h
@@ -9,7 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class FBManagedSimulator;
+@class FBSimulator;
 @class FBSimulatorSessionInteraction;
 @class FBSimulatorSessionState;
 
@@ -25,12 +25,12 @@
  @param simulator the Simulator to manage the session for.
  @returns a new `FBSimulatorSession`.
  */
-+ (instancetype)sessionWithSimulator:(FBManagedSimulator *)simulator;
++ (instancetype)sessionWithSimulator:(FBSimulator *)simulator;
 
 /**
  The Simulator for this session
  */
-@property (nonatomic, strong, readonly) FBManagedSimulator *simulator;
+@property (nonatomic, strong, readonly) FBSimulator *simulator;
 
 /**
  Returns the Session Information for the reciever.

--- a/FBSimulatorControl/Session/FBSimulatorSession.m
+++ b/FBSimulatorControl/Session/FBSimulatorSession.m
@@ -24,14 +24,14 @@
 
 #pragma mark - Initializers
 
-+ (instancetype)sessionWithSimulator:(FBManagedSimulator *)simulator
++ (instancetype)sessionWithSimulator:(FBSimulator *)simulator
 {
   NSParameterAssert(simulator);
 
   return [[FBSimulatorSession alloc] initWithSimulator:simulator];
 }
 
-- (instancetype)initWithSimulator:(FBManagedSimulator *)simulator
+- (instancetype)initWithSimulator:(FBSimulator *)simulator
 {
   self = [super init];
   if (!self) {

--- a/FBSimulatorControl/Session/FBSimulatorSessionInteraction.m
+++ b/FBSimulatorControl/Session/FBSimulatorSessionInteraction.m
@@ -47,7 +47,7 @@ NSTimeInterval const FBSimulatorInteractionDefaultTimeout = 30;
 
 - (instancetype)bootSimulator
 {
-  FBManagedSimulator *simulator = self.session.simulator;
+  FBSimulator *simulator = self.session.simulator;
   FBSimulatorSessionLifecycle *lifecycle = self.session.lifecycle;
 
   return [self interact:^ BOOL (NSError **error) {

--- a/FBSimulatorControlTests/Tests/FBSimulatorControlConfigurationTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorControlConfigurationTests.m
@@ -25,14 +25,10 @@
   FBSimulatorControlConfiguration *config = [FBSimulatorControlConfiguration
     configurationWithSimulatorApplication:application
     deviceSetPath:nil
-    namePrefix:@"TestEnv"
-    bucket:1
-    options:FBSimulatorManagementOptionsDeleteManagedSimulatorsOnFirstStart];
+    options:FBSimulatorManagementOptionsEraseOnFree];
   FBSimulatorControlConfiguration *configCopy = [config copy];
 
   XCTAssertEqualObjects(config.simulatorApplication, configCopy.simulatorApplication);
-  XCTAssertEqualObjects(config.namePrefix, configCopy.namePrefix);
-  XCTAssertEqual(config.bucketID, configCopy.bucketID);
   XCTAssertEqual(config.options, configCopy.options);
   XCTAssertEqualObjects(config, configCopy);
 }

--- a/FBSimulatorControlTests/Tests/FBSimulatorStateTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorStateTests.m
@@ -38,7 +38,7 @@
   device.UDID = [NSUUID UUID];
   device.name = @"iPhoneMega";
 
-  FBManagedSimulator *simulator = [FBManagedSimulator new];
+  FBSimulator *simulator = [FBSimulator new];
   simulator.device = (id)device;
 
   FBSimulatorSession *session = [FBSimulatorSession new];

--- a/FBSimulatorControlTests/Utilities/FBSimulatorControlNotificationAssertion.m
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorControlNotificationAssertion.m
@@ -72,6 +72,7 @@
 {
   if (self.notificationsRecieved.count == 0) {
     XCTFail(@"There was no notification to recieve for %@", notificationName);
+    return;
   }
   XCTAssertEqualObjects(notificationName, [self.notificationsRecieved[0] name]);
   [self.notificationsRecieved removeObjectAtIndex:0];

--- a/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.h
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.h
@@ -12,9 +12,9 @@
 #import <FBSimulatorControl/FBSimulatorControlConfiguration.h>
 
 @class FBInteractionAssertion;
+@class FBSimulator;
 @class FBSimulatorConfiguration;
 @class FBSimulatorControl;
-@class FBManagedSimulator;
 @class FBSimulatorControlNotificationAssertion;
 @class FBSimulatorSession;
 
@@ -42,7 +42,7 @@
 /**
  Allocates a Simulator with a default configuration.
  */
-- (FBManagedSimulator *)allocateSimulator;
+- (FBSimulator *)allocateSimulator;
 
 /**
  Creates a Session with the default configuration.

--- a/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
@@ -37,8 +37,7 @@
 
 - (FBSimulatorManagementOptions)managementOptions
 {
-  return FBSimulatorManagementOptionsDeleteManagedSimulatorsOnFirstStart |
-         FBSimulatorManagementOptionsKillUnmanagedSimulatorsOnFirstStart |
+  return FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart |
          FBSimulatorManagementOptionsDeleteOnFree;
 }
 
@@ -54,10 +53,10 @@
 
 #pragma mark Helper Actions
 
-- (FBManagedSimulator *)allocateSimulator
+- (FBSimulator *)allocateSimulator
 {
   NSError *error = nil;
-  FBManagedSimulator *simulator = [self.control.simulatorPool allocateSimulatorWithConfiguration:self.simulatorConfiguration error:&error];
+  FBSimulator *simulator = [self.control.simulatorPool allocateSimulatorWithConfiguration:self.simulatorConfiguration error:&error];
   XCTAssertNil(error);
   XCTAssertNotNil(simulator);
   return simulator;
@@ -86,8 +85,6 @@
   FBSimulatorControlConfiguration *configuration = [FBSimulatorControlConfiguration
     configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
     deviceSetPath:self.deviceSetPath
-    namePrefix:nil
-    bucket:0
     options:[self managementOptions]];
 
   self.control = [[FBSimulatorControl alloc] initWithConfiguration:configuration];
@@ -97,7 +94,7 @@
 
 - (void)tearDown
 {
-  [self.control.simulatorPool killManagedSimulatorsWithError:nil];
+  [self.control.simulatorPool killAllWithError:nil];
   self.control = nil;
 }
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,11 @@ For a high level overview:
 - `FBSimulatorApplication` is a wrapper around Applications, you can create them for your own Apps or use `+[FBSimulatorApplication systemApplicationNamed:]` to launch System Apps.
 - `FBApplicationLaunchConfiguration` describes the launch of an Application, it's arguments and environment.
 - `FBSimulatorSessionState` provides a the current state and history of the known state of the Simulator, including the Unix Process IDs of the running Applications and Agents. You can further automate by using command line tools like [`sample(1)`](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/sample.1.html), [`lldb(1)`](https://developer.apple.com/library/prerelease/mac/documentation/Darwin/Reference/ManPages/man1/lldb.1.html), [`heap(1)`](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/heap.1.html) and [`instruments(1)`](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/instruments.1.html).
-- The "Bucket ID" that a pool manages allows multiple processes to manage a subset of simulators, without interfering with the simulators created by other processes. By creating and starting Sessions in separate processes with their own buckets, allows Simulators to be run in parallel. This can be particularly beneficial for running Automated Tests in parallel, since much of the time a Simulator is idling the Host's CPU. Buckets can be re-used 
+
+## Multisim
+`FBSimulatorControl` launches Xcode's Simulator Applications directly, allowing specific Simulators to be targeted by UDID. `Simulator.app` uses a default set of Simulators located at `~/Library/Developer/CoreSimulator/Devices`. By passing arguments to the `Simulator.app` binary, a different Device Set can be used, allowing multiple pools of Simulators to be booted, without interference.
+
+This is only supported on Xcode 7.
 
 ## Contributing
 See the [CONTRIBUTING](CONTRIBUTING) file for how to help out. There's plenty to work on the issues!


### PR DESCRIPTION
`SimDeviceSets` are a far superior way of ensuring that Simulators are segregated and put elsewhere. Removing the concept of a 'Managed' Simulator vastly simplifies the allocation process and means that the default device set doesn't get littered with Simulators. This will also allow other tools to use `FBSimulatorControl` to manipulate Simulators that were created externally from `FBSimulatorControl`