### PR TITLE
Preconditions for Session Interactions

### DIFF
--- a/FBSimulatorControl/Session/FBSimulatorSessionInteraction.m
+++ b/FBSimulatorControl/Session/FBSimulatorSessionInteraction.m
@@ -141,11 +141,25 @@ NSTimeInterval const FBSimulatorInteractionDefaultTimeout = 30;
 
 - (instancetype)launchApplication:(FBApplicationLaunchConfiguration *)appLaunch
 {
+  NSParameterAssert(appLaunch);
+
   FBSimulator *simulator = self.session.simulator;
   FBSimulatorSessionLifecycle *lifecycle = self.session.lifecycle;
 
   return [self interact:^ BOOL (NSError **error) {
     NSError *innerError = nil;
+    NSDictionary *installedApps = [simulator.device installedAppsWithError:&innerError];
+    if (!installedApps) {
+      return [[[FBSimulatorError describe:@"Failed to get installed apps"] inSimulator:simulator] failBool:error];
+    }
+    if (!installedApps[appLaunch.application.bundleID]) {
+      return [[[[FBSimulatorError
+        describeFormat:@"Couldn't App %@ can't be launched as it isn't installed", appLaunch.application.bundleID]
+        extraInfo:@"installed_apps" value:installedApps]
+        inSimulator:simulator]
+        failBool:error];
+    }
+
     NSFileHandle *stdOut = nil;
     NSFileHandle *stdErr = nil;
     if (![FBSimulatorSessionInteraction createHandlesForLaunchConfiguration:appLaunch stdOut:&stdOut stdErr:&stdErr error:&innerError]) {
@@ -174,6 +188,8 @@ NSTimeInterval const FBSimulatorInteractionDefaultTimeout = 30;
 
 - (instancetype)signal:(int)signo application:(FBSimulatorApplication *)application
 {
+  NSParameterAssert(application);
+
   FBSimulatorSessionLifecycle *lifecycle = self.session.lifecycle;
   FBSimulator *simulator = self.session.simulator;
 
@@ -189,6 +205,8 @@ NSTimeInterval const FBSimulatorInteractionDefaultTimeout = 30;
 
 - (instancetype)launchAgent:(FBAgentLaunchConfiguration *)agentLaunch
 {
+  NSParameterAssert(agentLaunch);
+
   FBSimulator *simulator = self.session.simulator;
   FBSimulatorSessionLifecycle *lifecycle = self.session.lifecycle;
 
@@ -222,6 +240,8 @@ NSTimeInterval const FBSimulatorInteractionDefaultTimeout = 30;
 
 - (instancetype)killAgent:(FBSimulatorBinary *)agent
 {
+  NSParameterAssert(agent);
+
   FBSimulator *simulator = self.session.simulator;
   FBSimulatorSessionLifecycle *lifecycle = self.session.lifecycle;
 
@@ -241,6 +261,8 @@ NSTimeInterval const FBSimulatorInteractionDefaultTimeout = 30;
 
 - (instancetype)openURL:(NSURL *)url
 {
+  NSParameterAssert(url);
+
   FBSimulator *simulator = self.session.simulator;
 
   return [self interact:^ BOOL (NSError **error) {

--- a/FBSimulatorControl/Utility/FBSimulatorError.h
+++ b/FBSimulatorControl/Utility/FBSimulatorError.h
@@ -43,7 +43,12 @@ extern NSString *const FBSimulatorControlErrorDomain;
 - (id)fail:(NSError **)error;
 
 /**
- Attach additional diagnostic information from the Simulator.
+ Attach additional diagnostic information.
+ */
+- (instancetype)extraInfo:(NSString *)key value:(id)value;
+
+/**
+ Automatically attach Simulator diagnostic info.
  */
 - (instancetype)inSimulator:(FBSimulator *)simulator;
 

--- a/FBSimulatorControl/Utility/FBSimulatorError.m
+++ b/FBSimulatorControl/Utility/FBSimulatorError.m
@@ -99,11 +99,20 @@ NSString *const FBSimulatorControlErrorDomain = @"com.facebook.FBSimulatorContro
   return nil;
 }
 
+- (instancetype)extraInfo:(NSString *)key value:(id)value
+{
+  if (!key || !value) {
+    return self;
+  }
+  self.additionalInfo[key] = value;
+  return self;
+}
+
 - (instancetype)inSimulator:(FBSimulator *)simulator
 {
-  self.additionalInfo[@"launchd_is_running"] = @(simulator.hasActiveLaunchdSim);
-  self.additionalInfo[@"launchd_subprocesses"] = [simulator launchedProcesses];
-  return self;
+  return [[self
+    extraInfo:@"launchd_is_running" value:@(simulator.hasActiveLaunchdSim)]
+    extraInfo:@"launchd_subprocesses" value:[simulator launchedProcesses]];
 }
 
 - (NSError *)build


### PR DESCRIPTION
Adds some preconditions for interactions in the form of Assertions or Errors:
- Assertions for Progammer Error: nil values passed to methods
- Errors for when the Simulator is not in a state to perform an interaction: can't run an app if it isn't installed