### PR TITLE
Add query for existence of log data to FBWritableLog

### DIFF
--- a/FBSimulatorControl/Logs/FBWritableLog.h
+++ b/FBSimulatorControl/Logs/FBWritableLog.h
@@ -52,6 +52,11 @@
  */
 @property (nonatomic, readonly, copy) NSString *asPath;
 
+/**
+ Whether the log has content or is missing/empty.
+ */
+@property (nonatomic, readonly, assign) BOOL hasLogContent;
+
 @end
 
 /**

--- a/FBSimulatorControl/Logs/FBWritableLog.m
+++ b/FBSimulatorControl/Logs/FBWritableLog.m
@@ -48,6 +48,11 @@
     stringByAppendingPathExtension:self.fileType ?: @"unknown_log"];
 }
 
+- (BOOL)hasLogContent
+{
+  return NO;
+}
+
 @end
 
 @implementation FBWritableLog_Data
@@ -74,6 +79,11 @@
     }
   }
   return self.logPath;
+}
+
+- (BOOL)hasLogContent
+{
+  return self.logData.length >= 1;
 }
 
 @end
@@ -104,6 +114,11 @@
   return self.logPath;
 }
 
+- (BOOL)hasLogContent
+{
+  return self.logString.length >= 1;
+}
+
 @end
 
 @implementation FBWritableLog_Path
@@ -127,6 +142,12 @@
 - (NSString *)asPath
 {
   return self.logPath;
+}
+
+- (BOOL)hasLogContent
+{
+  NSDictionary *attributes = [NSFileManager.defaultManager attributesOfItemAtPath:self.logPath error:nil];
+  return attributes[NSFileSize] && [attributes[NSFileSize] unsignedLongLongValue] > 0;
 }
 
 @end


### PR DESCRIPTION
Depending on the backing-store of the log data there is an optimal way of figuring out whether there is any content or not. `hasLogContent` is used in preference to `isEmpty` as this allows checking for the existence of a writable log & it's data in one method call (msgsend to nil).