### PR TITLE
Add Logs for Launched Processes

### DIFF
--- a/FBSimulatorControl/Logs/FBSimulatorLogs.h
+++ b/FBSimulatorControl/Logs/FBSimulatorLogs.h
@@ -56,7 +56,16 @@
 
 /**
  Crashes that occured in the Simulator after the start of the Session.
+
+ @return an NSArray<FBWritableLog *> of crashes that occured for user processes since the start of the session.
  */
 - (NSArray *)subprocessCrashes;
+
+/**
+ The System Log, filtered and bucketed by Applications that were launched during the Session. Returned as an NSDictionary<NSString *, FBWritableLog *>
+
+ @return an NSDictionary<FBUserLaunchedProcess *, FBWritableLog> of the logs, filtered by launched process.
+ */
+- (NSDictionary *)launchedApplicationLogs;
 
 @end

--- a/FBSimulatorControl/Logs/FBWritableLog.m
+++ b/FBSimulatorControl/Logs/FBWritableLog.m
@@ -41,7 +41,7 @@
 
 - (NSString *)temporaryFilePath
 {
-  NSString *localUniqueID = self.shortName ?: [NSString stringWithFormat:@"%@_%@", NSUUID.UUID.UUIDString, @"unkown_log"];
+  NSString *localUniqueID = self.shortName ?: [NSString stringWithFormat:@"%@_%@", NSUUID.UUID.UUIDString, @"unknown_log"];
 
   return [[NSTemporaryDirectory()
     stringByAppendingPathComponent:[NSString stringWithFormat:@"%@_%@", NSProcessInfo.processInfo.globallyUniqueString, localUniqueID]]

--- a/FBSimulatorControl/Session/FBSimulatorSessionInteraction.m
+++ b/FBSimulatorControl/Session/FBSimulatorSessionInteraction.m
@@ -289,7 +289,7 @@ NSTimeInterval const FBSimulatorInteractionDefaultTimeout = 30;
   FBSimulatorSessionLifecycle *lifecycle = self.session.lifecycle;
 
   return [self interact:^ BOOL (NSError **error, id _) {
-    FBUserLaunchedProcess *state = [lifecycle.currentState processForBinary:agent];
+    FBUserLaunchedProcess *state = [lifecycle.currentState runningProcessForBinary:agent];
     if (!state) {
       return [[[FBSimulatorError describeFormat:@"Could not kill agent %@ as it is not running", agent] inSimulator:simulator] failBool:error];
     }
@@ -384,7 +384,7 @@ NSTimeInterval const FBSimulatorInteractionDefaultTimeout = 30;
   FBSimulator *simulator = self.session.simulator;
 
   return [self interact:^ BOOL (NSError **error, id _) {
-    FBUserLaunchedProcess *processState = [session.state processForBinary:application.binary];
+    FBUserLaunchedProcess *processState = [session.state runningProcessForBinary:application.binary];
     if (!processState) {
       return [[[FBSimulatorError describeFormat:@"Could not find an active process for %@", application] inSimulator:simulator] failBool:error];
     }

--- a/FBSimulatorControl/Session/FBSimulatorSessionState+Queries.h
+++ b/FBSimulatorControl/Session/FBSimulatorSessionState+Queries.h
@@ -20,45 +20,91 @@
 @interface FBSimulatorSessionState (Queries)
 
 /**
+ Returns all of the Agents and Applications that have been launched, in the order that they were launched.
+ Reaches into previous states in order to find Agents and Applications that have been terminated.
+
+ @return An NSArray<NSUserLaunchedProcess> of All Launched Processes, most recent first.
+ */
+- (NSArray *)allUserLaunchedProcesses;
+
+/**
+ Returns all of the Applications that have been launched, in the order that they were launched.
+ Reaches into previous states in order to find Applications that have been terminated.
+ An NSArray<NSUserLaunchedProcess>
+
+ @return An NSArray<NSUserLaunchedProcess> of All Launched Applications, most recent first.
+ */
+- (NSArray *)allLaunchedApplications;
+
+/**
+ Returns all of the Agents that have been launched, in the order that they were launched.
+ Reaches into previous states in order to find Agents that have been terminated.
+
+ @return An NSArray<NSUserLaunchedProcess> of All Launched Agents, most recent first.
+ */
+- (NSArray *)allLaunchedAgents;
+
+/**
  Returns the Application that was launched most recently.
  Reaches into previous states in order to find Applications that have been terminated.
+
+ @return An FBAgentLaunchConfiguration for the most recently launched Application, nil if no Application has been launched.
  */
 - (FBApplicationLaunchConfiguration *)lastLaunchedApplication;
 
 /**
  Returns the Agent that was launched most recently.
  Reaches into previous states in order to find Agents that have been terminated.
+
+ @return An FBAgentLaunchConfiguration for the most recently launched Agent, nil if no Agent has been launched.
  */
 - (FBAgentLaunchConfiguration *)lastLaunchedAgent;
 
 /**
  Returns the Process State for the given launch configuration, does not reach into previous states.
+
+ @param launchConfig the Launch Configuration to filter running processes by.
+ @return a FBUserLaunchedProcess for a running process that matches the launch configuration, nil otherwise.
  */
-- (FBUserLaunchedProcess *)processForLaunchConfiguration:(FBProcessLaunchConfiguration *)launchConfig;
+- (FBUserLaunchedProcess *)runningProcessForLaunchConfiguration:(FBProcessLaunchConfiguration *)launchConfig;
 
 /**
  Returns the Process State for the given binary, does not reach into previous states.
+
+ @param binary the Binary of the Launched process to filter running processes by.
+ @return a FBUserLaunchedProcess for a running process that matches the launch configuration, nil otherwise.
  */
-- (FBUserLaunchedProcess *)processForBinary:(FBSimulatorBinary *)binary;
+- (FBUserLaunchedProcess *)runningProcessForBinary:(FBSimulatorBinary *)binary;
 
 /**
  Returns the Process State for the given Application, does not reach into previous states.
+
+ @param application the Application of the Launched process to filter running processes by.
+ @return a FBUserLaunchedProcess for a running process that matches the launch configuration, nil otherwise.
  */
-- (FBUserLaunchedProcess *)processForApplication:(FBSimulatorApplication *)application;
+- (FBUserLaunchedProcess *)runningProcessForApplication:(FBSimulatorApplication *)application;
 
 /**
  Returns Agent State for all running agents, does not reach into previous states.
+
+ @return an NSArray<FBUserLaunchedProcess> of the currently running, User Launched Agents.
  */
 - (NSArray *)runningAgents;
 
 /**
  Returns Application State for all running applications, does not reach into previous states.
+
+ @return an NSArray<FBUserLaunchedProcess> of the currently running, User Launched Applications.
  */
 - (NSArray *)runningApplications;
 
 /**
  Finds the first diagnostic for the provided name, matching the application.
  Reaches into previous states in order to find Diagnostics for Applications that have been terminated.
+
+ @param the Name of the Diagnostic to search for.
+ @param application the Application's diagnostic to search for.
+ @return the diagnostic data associated with the query, nil if none could be found.
  */
 - (id)diagnosticNamed:(NSString *)name forApplication:(FBSimulatorApplication *)application;
 

--- a/FBSimulatorControl/Session/FBSimulatorSessionStateGenerator.m
+++ b/FBSimulatorControl/Session/FBSimulatorSessionStateGenerator.m
@@ -54,7 +54,7 @@
 {
   return [self updateCurrentState:^ FBSimulatorSessionState * (FBSimulatorSessionState *state) {
     NSCParameterAssert(state.lifecycle != FBSimulatorSessionLifecycleStateNotStarted);
-    NSCParameterAssert([state processForLaunchConfiguration:launchConfig] == nil);
+    NSCParameterAssert([state runningProcessForLaunchConfiguration:launchConfig] == nil);
 
     FBUserLaunchedProcess *processState = [FBUserLaunchedProcess new];
     processState.processIdentifier = processIdentifier;
@@ -72,11 +72,11 @@
 - (instancetype)update:(FBSimulatorApplication *)application withDiagnosticNamed:(NSString *)diagnosticName data:(id)data
 {
   NSPredicate *predicate = [NSPredicate predicateWithBlock:^ BOOL (FBSimulatorSessionState *sessionState, NSDictionary *bindings) {
-    return [sessionState processForApplication:application] != nil;
+    return [sessionState runningProcessForApplication:application] != nil;
   }];
 
   return [self amendPriorState:predicate update:^ FBSimulatorSessionState * (FBSimulatorSessionState *sessionState) {
-    FBUserLaunchedProcess *currentProcessState = [sessionState processForApplication:application];
+    FBUserLaunchedProcess *currentProcessState = [sessionState runningProcessForApplication:application];
     NSCAssert(currentProcessState, @"Can't get current process state");
 
     FBUserLaunchedProcess *nextProcessState = [self.class
@@ -107,7 +107,7 @@
 {
   return [self updateCurrentState:^ FBSimulatorSessionState * (FBSimulatorSessionState *sessionState) {
     NSCParameterAssert(sessionState.lifecycle != FBSimulatorSessionLifecycleStateNotStarted);
-    FBUserLaunchedProcess *processState = [sessionState processForBinary:binary];
+    FBUserLaunchedProcess *processState = [sessionState runningProcessForBinary:binary];
     NSCParameterAssert(processState);
 
     NSMutableOrderedSet *runningProcessesSet = sessionState.runningProcessesSet;

--- a/FBSimulatorControl/Tasks/FBTask+Private.h
+++ b/FBSimulatorControl/Tasks/FBTask+Private.h
@@ -14,8 +14,9 @@
 @property (nonatomic, strong, readwrite) NSTask *task;
 @property (nonatomic, copy, readwrite) NSSet *acceptableStatusCodes;
 
-@property (nonatomic, assign, readwrite) BOOL hasTerminated;
 @property (nonatomic, copy, readwrite) void (^terminationHandler)(id<FBTask>);
+
+@property (atomic, assign, readwrite) BOOL hasTerminated;
 @property (atomic, strong, readwrite) NSError *runningError;
 
 + (instancetype)taskWithNSTask:(NSTask *)nsTask acceptableStatusCodes:(NSSet *)acceptableStatusCodes stdOutPath:(NSString *)stdOutPath stdErrPath:(NSString *)stdErrPath;

--- a/FBSimulatorControl/Tasks/FBTask.h
+++ b/FBSimulatorControl/Tasks/FBTask.h
@@ -60,8 +60,18 @@ extern NSTimeInterval const FBTaskDefaultTimeout;
 - (NSString *)stdErr;
 
 /**
- Returns the Error associated with the shell command (if any). May be called from any thread.
+ Returns the Error associated with the task (if any). May be called from any thread.
  */
 - (NSError *)error;
+
+/**
+ Returns YES if the task has terminated, NO otherwise.
+ */
+- (BOOL)hasTerminated;
+
+/**
+ Returns YES if the task terminated without an error, NO otherwise
+ */
+- (BOOL)wasSuccessful;
 
 @end

--- a/FBSimulatorControlTests/Tests/FBSimulatorLogsTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorLogsTests.m
@@ -67,4 +67,15 @@
   }];
 }
 
+- (void)flakyOnTravis_testLaunchedApplicationLogs
+{
+  FBSimulatorSession *session = [self createBootedSession];
+  FBApplicationLaunchConfiguration *appLaunch = FBSimulatorControlFixtures.tableSearchAppLaunch.injectingShimulator;
+  [self.assert interactionSuccessful:[[session.interact installApplication:appLaunch.application] launchApplication:appLaunch]];
+
+  [self assertFindsNeedle:@"Shimulator" fromHaystackBlock:^ NSString * {
+    return [[session.logs.launchedApplicationLogs.allValues firstObject] asString];
+  }];
+}
+
 @end

--- a/FBSimulatorControlTests/Tests/FBSimulatorSessionLifecycleTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorSessionLifecycleTests.m
@@ -44,7 +44,7 @@
 
   [self.assert interactionSuccessful:[session.interact.bootSimulator launchApplication:appLaunch]];
 
-  FBUserLaunchedProcess *process = [session.state processForApplication:appLaunch.application];
+  FBUserLaunchedProcess *process = [session.state runningProcessForApplication:appLaunch.application];
   XCTAssertNotNil(process);
   if (!process) {
     // Need to guard against continuing the test in case the PID is 0 or -1 to avoid nuking the machine.
@@ -73,7 +73,7 @@
   XCTAssertTrue(wasUnexpected);
   [NSNotificationCenter.defaultCenter removeObserver:token];
 
-  XCTAssertFalse([session.state processForApplication:appLaunch.application]);
+  XCTAssertFalse([session.state runningProcessForApplication:appLaunch.application]);
 }
 
 - (void)testNotifiedByExpectedApplicationTermination
@@ -87,7 +87,7 @@
 
   [self.assert interactionSuccessful:[session.interact.bootSimulator launchApplication:appLaunch]];
 
-  FBUserLaunchedProcess *process = [session.state processForApplication:appLaunch.application];
+  FBUserLaunchedProcess *process = [session.state runningProcessForApplication:appLaunch.application];
   XCTAssertNotNil(process);
   if (!process) {
     // Need to guard against continuing the test in case the PID is 0 or -1 to avoid nuking the machine.
@@ -116,7 +116,7 @@
   XCTAssertTrue(wasExpected);
   [NSNotificationCenter.defaultCenter removeObserver:token];
 
-  XCTAssertFalse([session.state processForApplication:appLaunch.application]);
+  XCTAssertFalse([session.state runningProcessForApplication:appLaunch.application]);
 }
 
 


### PR DESCRIPTION
Adds provisional support for bucketing the syslog by launched processes, using the process identifier of previously launched processes. This is pretty suboptimal at the moment and it should be possible to improve upon this with `asl` or `syslog` in the future. 

There were some changes that needed to be made in file handling for `FBTask` so this was updated also.