### PR TITLE
Improve robustness of killAll in DeviceSet

### DIFF
--- a/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.h
@@ -19,8 +19,9 @@ extern NSString *const FBSimulatorControlConfigurationDefaultNamePrefix;
 typedef NS_OPTIONS(NSUInteger, FBSimulatorManagementOptions){
   FBSimulatorManagementOptionsDeleteAllOnFirstStart = 1 << 0,
   FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart = 1 << 1,
-  FBSimulatorManagementOptionsDeleteOnFree = 1 << 2,
-  FBSimulatorManagementOptionsEraseOnFree = 1 << 3,
+  FBSimulatorManagementOptionsIgnoreSpuriousKillFail = 1 << 2,
+  FBSimulatorManagementOptionsDeleteOnFree = 1 << 3,
+  FBSimulatorManagementOptionsEraseOnFree = 1 << 4,
 };
 
 /**

--- a/FBSimulatorControl/Management/FBSimulator.h
+++ b/FBSimulatorControl/Management/FBSimulator.h
@@ -69,6 +69,11 @@ typedef NS_ENUM(NSInteger, FBSimulatorState) {
 @property (nonatomic, assign, readonly) FBSimulatorState state;
 
 /**
+ A string representation of the Simulator State.
+ */
+@property (nonatomic, copy, readonly) NSString *stateString;
+
+/**
  The Process Identifier of the Simulator. -1 if it is not running
  */
 @property (nonatomic, assign, readonly) NSInteger processIdentifier;

--- a/FBSimulatorControl/Management/FBSimulator.m
+++ b/FBSimulatorControl/Management/FBSimulator.m
@@ -71,6 +71,11 @@ NSTimeInterval const FBSimulatorDefaultTimeout = 20;
   return self.device.state;
 }
 
+- (NSString *)stateString
+{
+  return [FBSimulator stateStringFromSimulatorState:self.state];
+}
+
 - (FBSimulatorApplication *)simulatorApplication
 {
   return self.pool.configuration.simulatorApplication;

--- a/FBSimulatorControl/Management/FBSimulatorControl.m
+++ b/FBSimulatorControl/Management/FBSimulatorControl.m
@@ -110,9 +110,10 @@
     return [[[[FBSimulatorError describe:@"Failed to teardown previous simulators"] causedBy:innerError] recursiveDescription] failBool:error];
   }
 
-  BOOL killUnmanaged = (self.configuration.options & FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart) == FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart;
-  if (killUnmanaged) {
-    if (![self.simulatorPool killSpuriousSimulatorsWithError:&innerError]) {
+  BOOL killSpurious = (self.configuration.options & FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart) == FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart;
+  if (killSpurious) {
+    BOOL failOnSpuriousKillFail = (self.configuration.options & FBSimulatorManagementOptionsIgnoreSpuriousKillFail) != FBSimulatorManagementOptionsIgnoreSpuriousKillFail;
+    if (![self.simulatorPool killSpuriousSimulatorsWithError:&innerError] && failOnSpuriousKillFail) {
       return [[[[FBSimulatorError describe:@"Failed to kill spurious simulators"] causedBy:innerError] recursiveDescription] failBool:error];
     }
   }

--- a/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
@@ -80,7 +80,7 @@
 
 - (void)setUp
 {
-  self.managementOptions = FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart | FBSimulatorManagementOptionsDeleteOnFree;
+  self.managementOptions = FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart | FBSimulatorManagementOptionsIgnoreSpuriousKillFail | FBSimulatorManagementOptionsDeleteOnFree;
   self.simulatorConfiguration = FBSimulatorConfiguration.iPhone5;
   self.deviceSetPath = nil;
 }


### PR DESCRIPTION
Instead of building up a massive list of simulators to kill using `grep -e` based upon the contents of the `DeviceSet` it's easier to just kill all using the path to the `SimDeviceSet` in the params as this will always be passed. The same applies to Simulators launched without a DeviceSet, which just searches based upon the existence of `CurrentDeviceUDID`. 