### PR TITLE
Figure out the Application Home Directory with launchctl

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -7,9 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		877123F01BDA78AA00530B1E /* FBSimulatorVideoUploader.h in Headers */ = {isa = PBXBuildFile; fileRef = 877123EE1BDA78AA00530B1E /* FBSimulatorVideoUploader.h */; settings = {ASSET_TAGS = (); }; };
-		877123F11BDA78AA00530B1E /* FBSimulatorVideoUploader.m in Sources */ = {isa = PBXBuildFile; fileRef = 877123EF1BDA78AA00530B1E /* FBSimulatorVideoUploader.m */; settings = {ASSET_TAGS = (); }; };
-		877123F31BDA797800530B1E /* video0.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 877123F21BDA797800530B1E /* video0.mp4 */; settings = {ASSET_TAGS = (); }; };
+		877123F01BDA78AA00530B1E /* FBSimulatorVideoUploader.h in Headers */ = {isa = PBXBuildFile; fileRef = 877123EE1BDA78AA00530B1E /* FBSimulatorVideoUploader.h */; };
+		877123F11BDA78AA00530B1E /* FBSimulatorVideoUploader.m in Sources */ = {isa = PBXBuildFile; fileRef = 877123EF1BDA78AA00530B1E /* FBSimulatorVideoUploader.m */; };
+		877123F31BDA797800530B1E /* video0.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 877123F21BDA797800530B1E /* video0.mp4 */; };
 		AA017F271BD7770300F45E9D /* FBSimulatorLogsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA017F251BD7770300F45E9D /* FBSimulatorLogsTests.m */; };
 		AA017F281BD7770300F45E9D /* FBWritableLogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA017F261BD7770300F45E9D /* FBWritableLogTests.m */; };
 		AA017F2F1BD7771300F45E9D /* FBSimulatorLogs.h in Headers */ = {isa = PBXBuildFile; fileRef = AA017F2A1BD7771300F45E9D /* FBSimulatorLogs.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -110,7 +110,7 @@
 		AA74B99C1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA74B99B1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m */; };
 		AA74B99E1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA74B99D1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m */; };
 		AA7B7BB51BDA4B9100CD028C /* FBSimulatorLogs+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7B7BB41BDA4A9100CD028C /* FBSimulatorLogs+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AA7EA4061BB309C30065DC52 /* FBSimulatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA7EA4041BB309C30065DC52 /* FBSimulatorTests.m */; };
+		AA7EA4061BB309C30065DC52 /* FBSimulatorQueriesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA7EA4041BB309C30065DC52 /* FBSimulatorQueriesTests.m */; };
 		AA819DB71B9FB40D002F58CA /* FBSimulatorControl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E291A4B50E500000001 /* FBSimulatorControl.framework */; };
 		AA8DF8C01BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA8DF8BF1BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m */; };
 		AA8DF8C91BB18B3700CC0411 /* FBInteraction.h in Headers */ = {isa = PBXBuildFile; fileRef = AA8DF8C61BB18B3700CC0411 /* FBInteraction.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -851,7 +851,7 @@
 		AA74B99B1BB02CD600C1E59C /* FBSimulatorPoolAllocationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorPoolAllocationTests.m; sourceTree = "<group>"; };
 		AA74B99D1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBProcessLaunchConfigurationTests.m; sourceTree = "<group>"; };
 		AA7B7BB41BDA4A9100CD028C /* FBSimulatorLogs+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FBSimulatorLogs+Private.h"; sourceTree = "<group>"; };
-		AA7EA4041BB309C30065DC52 /* FBSimulatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorTests.m; sourceTree = "<group>"; };
+		AA7EA4041BB309C30065DC52 /* FBSimulatorQueriesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorQueriesTests.m; sourceTree = "<group>"; };
 		AA819DB21B9FB40D002F58CA /* FBSimulatorControlTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FBSimulatorControlTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA819E0B1B9FB427002F58CA /* FBSimulatorControlTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "FBSimulatorControlTests-Info.plist"; sourceTree = "<group>"; };
 		AA8DF8BF1BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorSessionLifecycleTests.m; sourceTree = "<group>"; };
@@ -1684,7 +1684,7 @@
 				AAD305181BD4CE020047376E /* FBSimulatorSessionInteractionTests.m */,
 				AA8DF8BF1BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m */,
 				AA51E4951BA1CA3C0053141E /* FBSimulatorStateTests.m */,
-				AA7EA4041BB309C30065DC52 /* FBSimulatorTests.m */,
+				AA7EA4041BB309C30065DC52 /* FBSimulatorQueriesTests.m */,
 				AAB4AC231BBBC1A60046F6A1 /* FBSimulatorTilingStrategyTests.m */,
 				AAB4AC1B1BB586860046F6A1 /* FBSimulatorVideoRecorderTests.m */,
 				AAC241271BB311970054570C /* FBSimulatorWindowTilingTests.m */,
@@ -2040,7 +2040,7 @@
 				AAC241281BB311970054570C /* FBSimulatorWindowTilingTests.m in Sources */,
 				AA51E49E1BA1CA3C0053141E /* FBSimulatorStateTests.m in Sources */,
 				AA51E49C1BA1CA3C0053141E /* FBSimulatorControlSimulatorLaunchTests.m in Sources */,
-				AA7EA4061BB309C30065DC52 /* FBSimulatorTests.m in Sources */,
+				AA7EA4061BB309C30065DC52 /* FBSimulatorQueriesTests.m in Sources */,
 				AAD305191BD4CE020047376E /* FBSimulatorSessionInteractionTests.m in Sources */,
 				AA017F281BD7770300F45E9D /* FBWritableLogTests.m in Sources */,
 				AAB4AC271BBBC6880046F6A1 /* FBSimulatorControlTestCase.m in Sources */,

--- a/FBSimulatorControl/Logs/FBSimulatorLogs.m
+++ b/FBSimulatorControl/Logs/FBSimulatorLogs.m
@@ -14,6 +14,7 @@
 
 #import "FBConcurrentCollectionOperations.h"
 #import "FBSimulator.h"
+#import "FBSimulator+Queries.h"
 #import "FBSimulatorSession.h"
 #import "FBSimulatorSessionState+Queries.h"
 #import "FBWritableLog.h"

--- a/FBSimulatorControl/Management/FBSimulator+Queries.h
+++ b/FBSimulatorControl/Management/FBSimulator+Queries.h
@@ -9,7 +9,20 @@
 
 #import <FBSimulatorControl/FBSimulator.h>
 
+@class FBUserLaunchedProcess;
+
 @interface FBSimulator (Queries)
+
+/**
+ The Path to this Simulator's launchd_sim plist. Returns nil if the path does not exist.
+ Expected to return a path when the Simulator is in the Booted state.
+ */
+- (NSString *)launchdBootstrapPath;
+
+/**
+ The Process Identifier of the Simulator's launchd_sim. -1 if it is not running
+ */
+- (NSInteger)launchdSimProcessIdentifier;
 
 /**
  Returns YES if the reciever has an active launchd_sim process.
@@ -21,5 +34,10 @@
  Returns an NSArray<id<FBSimulatorProcess>> of the subprocesses of launchd_sim.
  */
 - (NSArray *)launchedProcesses;
+
+/**
+ Returns an path to the Application Home.
+ */
+- (NSString *)pathToApplicationHome:(FBUserLaunchedProcess *)process;
 
 @end

--- a/FBSimulatorControl/Management/FBSimulator.h
+++ b/FBSimulatorControl/Management/FBSimulator.h
@@ -84,17 +84,6 @@ typedef NS_ENUM(NSInteger, FBSimulatorState) {
 @property (nonatomic, copy, readonly) NSString *dataDirectory;
 
 /**
- The Path to this Simulator's launchd_sim plist. Returns nil if the path does not exist.
- Expected to return a path when the Simulator is in the Booted state.
- */
-@property (nonatomic, copy, readonly) NSString *launchdBootstrapPath;
-
-/**
- The Process Identifier of the Simulator's launchd_sim. -1 if it is not running
- */
-@property (nonatomic, assign, readonly) NSInteger launchdSimProcessIdentifier;
-
-/**
  The Application that the Simulator should be launched with.
  */
 @property (nonatomic, copy, readonly) FBSimulatorApplication *simulatorApplication;

--- a/FBSimulatorControl/Management/FBSimulator.m
+++ b/FBSimulatorControl/Management/FBSimulator.m
@@ -86,37 +86,6 @@ NSTimeInterval const FBSimulatorDefaultTimeout = 20;
   return self.device.dataPath;
 }
 
-- (NSString *)launchdBootstrapPath
-{
-  NSString *expectedPath = [[self.pool.deviceSet.setPath
-    stringByAppendingPathComponent:self.udid]
-    stringByAppendingPathComponent:@"/data/var/run/launchd_bootstrap.plist"];
-
-  if (![NSFileManager.defaultManager fileExistsAtPath:expectedPath]) {
-    return nil;
-  }
-  return expectedPath;
-}
-
-- (NSInteger)launchdSimProcessIdentifier
-{
-  NSString *bootstrapPath = self.launchdBootstrapPath;
-  if (!bootstrapPath) {
-    return -1;
-  }
-
-  NSInteger processIdentifier = [[[[FBTaskExecutor.sharedInstance
-    taskWithLaunchPath:@"/usr/bin/pgrep" arguments:@[@"-f", bootstrapPath]]
-    startSynchronouslyWithTimeout:5]
-    stdOut]
-    integerValue];
-
-  if (processIdentifier < 2) {
-    return -1;
-  }
-  return processIdentifier;
-}
-
 - (NSInteger)processIdentifier
 {
   return _processIdentifier > 1 ? _processIdentifier : [self inferredProcessIdentifier];

--- a/FBSimulatorControl/Management/FBSimulatorPredicates.m
+++ b/FBSimulatorControl/Management/FBSimulatorPredicates.m
@@ -14,6 +14,7 @@
 #import <CoreSimulator/SimRuntime.h>
 
 #import "FBSimulator.h"
+#import "FBSimulator+Queries.h"
 #import "FBSimulatorConfiguration+CoreSimulator.h"
 #import "FBSimulatorControlConfiguration.h"
 #import "FBSimulatorPool+Private.h"

--- a/FBSimulatorControl/Tasks/FBTaskExecutor.h
+++ b/FBSimulatorControl/Tasks/FBTaskExecutor.h
@@ -62,6 +62,14 @@ extern NSString *const FBTaskExecutorErrorDomain;
 - (instancetype)withShellTaskCommand:(NSString *)shellCommand;
 
 /**
+  The Shell Command to execute as a format string. Will override any launch path or arguments set with `withArguments` or `withLaunchPath`.
+
+  @param format the Shell Command to execute.
+  @return a builder, with the arguments applied.
+  */
+- (instancetype)withShellTaskCommandFmt:(NSString *)format, ... NS_FORMAT_FUNCTION(1,2);
+
+/**
  Assigns a path for StdOut and StdErr for the built task.
 
  @param stdOutPath the path to write stdout to. Must not be nil.

--- a/FBSimulatorControl/Tasks/FBTaskExecutor.m
+++ b/FBSimulatorControl/Tasks/FBTaskExecutor.m
@@ -103,6 +103,15 @@ static NSString *const FBTaskShellExecutablePath = @"/bin/sh";
   return executor;
 }
 
+- (instancetype)withShellTaskCommandFmt:(NSString *)format, ...
+{
+  va_list args;
+  va_start(args, format);
+  NSString *string = [[NSString alloc] initWithFormat:format arguments:args];
+  va_end(args);
+  return [self withShellTaskCommand:string];
+}
+
 - (instancetype)withStdOutPath:(NSString *)stdOutPath stdErrPath:(NSString *)stdErrPath
 {
   FBTaskExecutor *executor = [self copy];

--- a/FBSimulatorControlTests/Tests/FBSimulatorQueriesTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorQueriesTests.m
@@ -11,6 +11,7 @@
 
 #import <FBSimulatorControl/FBProcessLaunchConfiguration.h>
 #import <FBSimulatorControl/FBSimulator+Private.h>
+#import <FBSimulatorControl/FBSimulator+Queries.h>
 #import <FBSimulatorControl/FBSimulator.h>
 #import <FBSimulatorControl/FBSimulatorApplication.h>
 #import <FBSimulatorControl/FBSimulatorConfiguration.h>
@@ -26,11 +27,11 @@
 
 #import "FBSimulatorControlTestCase.h"
 
-@interface FBSimulatorTests : FBSimulatorControlTestCase
+@interface FBSimulatorQueriesTests : FBSimulatorControlTestCase
 
 @end
 
-@implementation FBSimulatorTests
+@implementation FBSimulatorQueriesTests
 
 - (void)flaky_testCanInferProcessIdentiferAppropriately
 {
@@ -41,6 +42,16 @@
   session.simulator.processIdentifier = -1;
   NSInteger actual = session.simulator.processIdentifier;
   XCTAssertEqual(expected, actual);
+}
+
+- (void)testCanFindApplicationHome
+{
+  FBSimulatorSession *session = [self createBootedSessionWithUserApplication];
+  FBUserLaunchedProcess *process = session.state.runningApplications.firstObject;
+  XCTAssertNotNil(process);
+
+  NSString *path = [session.simulator pathToApplicationHome:process];
+  XCTAssertTrue([NSFileManager.defaultManager fileExistsAtPath:path]);
 }
 
 @end

--- a/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.h
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.h
@@ -40,6 +40,11 @@
 - (FBSimulatorSession *)createBootedSession;
 
 /**
+ Create a Session with a booted Simulator with a booted TableSearch app, of the default configuration.
+ */
+- (FBSimulatorSession *)createBootedSessionWithUserApplication;
+
+/**
  The Per-Test-Case Management Options.
  */
 @property (nonatomic, assign, readwrite) FBSimulatorManagementOptions managementOptions;

--- a/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
@@ -9,6 +9,7 @@
 
 #import "FBSimulatorControlTestCase.h"
 
+#import <FBSimulatorControl/FBProcessLaunchConfiguration.h>
 #import <FBSimulatorControl/FBSimulator.h>
 #import <FBSimulatorControl/FBSimulatorApplication.h>
 #import <FBSimulatorControl/FBSimulatorConfiguration.h>
@@ -21,6 +22,7 @@
 #import <FBSimulatorControl/FBSimulatorSessionInteraction.h>
 
 #import "FBSimulatorControlAssertions.h"
+#import "FBSimulatorControlFixtures.h"
 
 @implementation FBSimulatorControlTestCase
 
@@ -73,6 +75,18 @@
 {
   FBSimulatorSession *session = [self createSession];
   [self.assert interactionSuccessful:session.interact.bootSimulator];
+  return session;
+}
+
+- (FBSimulatorSession *)createBootedSessionWithUserApplication
+{
+  FBApplicationLaunchConfiguration *appLaunch = [FBApplicationLaunchConfiguration
+    configurationWithApplication:[FBSimulatorControlFixtures tableSearchApplicationWithError:nil]
+    arguments:@[]
+    environment:@{}];
+
+  FBSimulatorSession *session = [self createSession];
+  [self.assert interactionSuccessful:[[session.interact.bootSimulator installApplication:appLaunch.application] launchApplication:appLaunch]];
   return session;
 }
 


### PR DESCRIPTION
Adds `pathToApplicationHome:` that calls `launchctl` on the Simulator in order to obtain the Home of the application from the `procinfo` of the Application. The Application Home can currently only be inferred if the Application is running, as `CoreSimulator` doesn't have this API