### PR TITLE
Add fbsimctl

### DIFF
--- a/FBSimulatorControl/Management/FBSimulatorPredicates.h
+++ b/FBSimulatorControl/Management/FBSimulatorPredicates.h
@@ -9,7 +9,8 @@
 
 #import <Foundation/Foundation.h>
 
-@class FBSimulator;
+#import <FBSimulatorControl/FBSimulator.h>
+
 @class FBSimulatorConfiguration;
 @class FBSimulatorPool;
 
@@ -38,6 +39,16 @@
  Predicate for only the provided Simulator.
  */
 + (NSPredicate *)only:(FBSimulator *)simulator;
+
+/**
+ Predicate for only the provided Simulator UDID.
+ */
++ (NSPredicate *)onlyUDID:(NSString *)udid;
+
+/**
+ Predicate for only the provided Simulator State.
+ */
++ (NSPredicate *)withState:(FBSimulatorState)state;
 
 /**
  Predicate for matching SimDevices against a Configuration.

--- a/FBSimulatorControl/Management/FBSimulatorPredicates.m
+++ b/FBSimulatorControl/Management/FBSimulatorPredicates.m
@@ -44,8 +44,20 @@
 
 + (NSPredicate *)only:(FBSimulator *)simulator
 {
+  return [self onlyUDID:simulator.udid];
+}
+
++ (NSPredicate *)onlyUDID:(NSString *)udid
+{
   return [NSPredicate predicateWithBlock:^ BOOL (FBSimulator *candidate, NSDictionary *_) {
-    return simulator.udid && [candidate.udid isEqual:simulator.udid];
+    return udid && [candidate.udid isEqual:udid];
+  }];
+}
+
++ (NSPredicate *)withState:(FBSimulatorState)state
+{
+  return [NSPredicate predicateWithBlock:^ BOOL (FBSimulator *candidate, NSDictionary *_) {
+    return candidate.state == state;
   }];
 }
 

--- a/fbsimctl/Sources/Arguments.swift
+++ b/fbsimctl/Sources/Arguments.swift
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import Foundation
+
+private enum Argument {
+  case Single(String, Bool)
+  case Double(String, String, Bool)
+}
+
+public extension Subcommand {
+  public static let HELP_STR = "help"
+  public static let INTERACT = "interact"
+  public static let LIST = "list"
+  public static let BOOT = "boot"
+  public static let SHUTDOWN = "shutdown"
+}

--- a/fbsimctl/Sources/Bridging.swift
+++ b/fbsimctl/Sources/Bridging.swift
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import Foundation
+import FBSimulatorControl
+
+extension FBSimulatorState : CustomStringConvertible {
+  public var description: String {
+    get {
+      return FBSimulator.stateStringFromSimulatorState(self)
+    }
+  }
+}

--- a/fbsimctl/Sources/Command.swift
+++ b/fbsimctl/Sources/Command.swift
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import Foundation
+import FBSimulatorControl
+
+/**
+ Defines a single transaction with FBSimulatorControl
+*/
+public struct Command {
+  let configuration: Configuration
+  let subcommand: Subcommand
+}
+
+/**
+  Describes the Configuration for the running of a Command
+*/
+public struct Configuration {
+  let deviceSetPath: String?
+
+  static func defaultConfiguration() -> Configuration {
+    return Configuration(deviceSetPath: nil)
+  }
+}
+
+/**
+ Defines a Format for displaying Simulator Information
+*/
+public indirect enum Format {
+  case UDID
+  case Name
+  case DeviceName
+  case OSVersion
+  case Compound([Format])
+}
+
+/**
+ Defines the pieces of a Query for Simulators
+*/
+public indirect enum Query {
+  case UDID(String)
+  case State(FBSimulatorState)
+  case Compound([Query])
+  case Configured(FBSimulatorConfiguration)
+}
+
+/**
+ The Base of all fbsimctl commands
+*/
+public indirect enum Subcommand {
+  case Interact(Int?)
+  case List(Query, Format)
+  case Boot(Query)
+  case Shutdown(Query)
+  case Diagnose(Query)
+  case Help(Subcommand?)
+}

--- a/fbsimctl/Sources/Constants.h
+++ b/fbsimctl/Sources/Constants.h
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface Constants : NSObject
+
++ (int32_t)sol_socket;
++ (int32_t)so_reuseaddr;
+
+@end

--- a/fbsimctl/Sources/Constants.m
+++ b/fbsimctl/Sources/Constants.m
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "Constants.h"
+
+#import <sys/socket.h>
+
+@implementation Constants
+
++ (int32_t)sol_socket
+{
+  return SOL_SOCKET;
+}
+
++ (int32_t)so_reuseaddr
+{
+  return SO_REUSEADDR;
+}
+
+@end

--- a/fbsimctl/Sources/Help.swift
+++ b/fbsimctl/Sources/Help.swift
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import Foundation
+
+public extension Command {
+  static func getHelp() -> String {
+    return "Help"
+  }
+}

--- a/fbsimctl/Sources/LineBuffer.swift
+++ b/fbsimctl/Sources/LineBuffer.swift
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import Foundation
+
+class LineBuffer {
+  unowned let delegate: LineBufferDelegate
+
+  private var buffer: String = ""
+
+  init(delegate: LineBufferDelegate) {
+    self.delegate = delegate
+  }
+
+  func appendData(data: NSData) {
+    let string = String(data: data, encoding: NSUTF8StringEncoding)!
+    self.buffer.appendContentsOf(string)
+    self.runBuffer()
+  }
+
+  private func runBuffer() {
+    let buffer = self.buffer
+    let lines = buffer
+      .componentsSeparatedByCharactersInSet(NSCharacterSet.newlineCharacterSet())
+      .filter { line in
+        line != ""
+    }
+    if (lines.isEmpty) {
+      return
+    }
+
+    self.buffer = ""
+    let delegate = self.delegate
+
+    dispatch_async(dispatch_get_main_queue()) {
+      for line in lines {
+        delegate.buffer(line)
+      }
+    }
+  }
+}
+
+protocol LineBufferDelegate : class {
+  func buffer(lineAvailable: String)
+}

--- a/fbsimctl/Sources/Parsers.swift
+++ b/fbsimctl/Sources/Parsers.swift
@@ -1,0 +1,331 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import Foundation
+import FBSimulatorControl
+
+public extension Command {
+  public static func fromArguments(arguments: [String]) -> Command {
+    do {
+      let (_, command) = try Command.parser().parse(arguments)
+      return command
+    } catch {
+      return Command(configuration: Configuration.defaultConfiguration(), subcommand: .Help(nil))
+    }
+  }
+}
+
+enum ParseError : ErrorType {
+  case EndOfInput
+  case DoesNotMatch(String, String)
+  case InvalidNumber
+
+  private static func DoesNotMatchAnyOf(matches: [String]) -> ParseError {
+    let inner = (matches as NSArray).componentsJoinedByString(", ")
+    return .DoesNotMatch("any of", "[\(inner)]")
+  }
+}
+
+/**
+ Protocol for parsing a list of tokens.
+ */
+struct Parser<A> {
+  let output: [String] throws -> ([String], A)
+
+  func parse(tokens: [String]) throws -> ([String], A) {
+    let (nextTokens, value) = try output(tokens)
+    return (nextTokens, value)
+  }
+}
+
+/**
+  Primitives
+*/
+private extension Parser {
+  func fmap<B>(f: A -> B) -> Parser<B> {
+    return Parser<B>() { input in
+      let (tokensOut, a) = try self.output(input)
+      return (tokensOut, f(a))
+    }
+  }
+
+  func bind<B>(f: A -> Parser<B>) -> Parser<B> {
+    return Parser<B> { tokens in
+      let (tokensA, valueA) = try self.parse(tokens)
+      let (tokensB, valueB) = try f(valueA).parse(tokensA)
+      return (tokensB, valueB)
+    }
+  }
+
+  func optional() -> Parser<A?> {
+    return Parser<A?> { tokens in
+      do {
+        let (nextTokens, value) = try self.parse(tokens)
+        return (nextTokens, Optional.Some(value))
+      } catch {
+        return (tokens, nil)
+      }
+    }
+  }
+
+  func sequence<B>(p: Parser<B>) -> Parser<B> {
+    return self.bind { _ in p }
+  }
+}
+
+/**
+  Derivatives
+*/
+private extension Parser {
+  func handle(f: () -> A) -> Parser<A> {
+    return self
+      .optional()
+      .fmap { optionalValue in
+        guard let value = optionalValue else {
+          return f()
+        }
+        return value
+      }
+  }
+
+  func fallback(a: A) -> Parser<A> {
+    return self.handle { _ in a }
+  }
+
+  static func fail(error: ParseError) -> Parser<A> {
+    return Parser<A> { _ in
+      throw error
+    }
+  }
+
+  static func single(f: String throws -> A) -> Parser<A> {
+    return Parser<A>() { tokens in
+      guard let actual = tokens.first else {
+        throw ParseError.EndOfInput
+      }
+      return try (Array(tokens.dropFirst(1)), f(actual))
+    }
+  }
+
+  static func ofString(string: String, constant: A) -> Parser<A> {
+    return Parser.single { token in
+      if token != string {
+        throw ParseError.DoesNotMatch(token, string)
+      }
+      return constant
+    }
+  }
+
+  static func ofInt() -> Parser<Int> {
+    return Parser<Int>.single { token in
+      guard let integer = NSNumberFormatter().numberFromString(token)?.integerValue else {
+        throw ParseError.InvalidNumber
+      }
+      return integer
+    }
+  }
+
+  static func ofTwo<B>(a: Parser<A>, b: Parser<B>) -> Parser<(A, B)> {
+    return a.bind { valueA in
+      return b.fmap { valueB in
+        return (valueA, valueB)
+      }
+    }
+  }
+
+  static func ofMany(parsers: [Parser<A>]) -> Parser<[A]> {
+    return self.ofManyCount(parsers, count: 0)
+  }
+
+  static func ofAny(parsers: [Parser<A>]) -> Parser<A> {
+    return self.ofManyCount(parsers, count: 1)
+      .fmap { $0.first! }
+  }
+
+  static func succeeded(token: String, by: Parser<A>) -> Parser<A> {
+    return Parser<()>
+      .ofString(token, constant: ())
+      .sequence(by)
+  }
+
+  private static func ofManyCount(parsers: [Parser<A>], count: Int) -> Parser<[A]> {
+    assert(count >= 0, "Count should be >= 0")
+    return Parser<[A]>() { tokens in
+      var success = true
+      var values: [A] = []
+      var runningArgs = tokens
+      var successes = 0
+
+      while (success && !runningArgs.isEmpty) {
+        success = false
+        for parser in parsers {
+          do {
+            let output = try parser.parse(runningArgs)
+            success = true
+            successes++
+            runningArgs = output.0
+            values.append(output.1)
+          } catch {}
+        }
+      }
+
+      if (successes < count) {
+        throw ParseError.EndOfInput
+      }
+      return (runningArgs, values)
+    }
+  }
+}
+
+protocol Parsable {
+  static func parser() -> Parser<Self>
+}
+
+extension FBSimulatorState : Parsable {
+  static func parser() -> Parser<FBSimulatorState> {
+    return Parser<FBSimulatorState>.single { token in
+      let state = FBSimulator.simulatorStateFromStateString(token)
+      switch (state) {
+      case .Unknown:
+        throw ParseError.DoesNotMatchAnyOf([
+          FBSimulatorState.Creating.description,
+          FBSimulatorState.Shutdown.description,
+          FBSimulatorState.Booting.description,
+          FBSimulatorState.Booted.description,
+          FBSimulatorState.ShuttingDown.description
+        ])
+      default:
+        return state
+      }
+    }
+  }
+}
+
+extension Command : Parsable {
+  static func parser() -> Parser<Command> {
+    return Parser
+      .ofTwo(Configuration.parser(), b: Subcommand.parser())
+      .fmap { (configuration, subcommand) in
+        Command(configuration: configuration, subcommand: subcommand)
+      }
+  }
+}
+
+extension Configuration : Parsable {
+  static func parser() -> Parser<Configuration> {
+    return Parser
+      .succeeded("--device-set", by: Parser.single { Configuration(deviceSetPath: $0) } )
+      .fallback(Configuration.defaultConfiguration())
+  }
+}
+
+extension Subcommand : Parsable {
+  static func parser() -> Parser<Subcommand> {
+    return Parser.ofAny([
+      self.helpParser(),
+      self.interactParser(),
+      self.listParser(),
+      self.bootParser(),
+      self.shutdownParser(),
+      self.diagnoseParser(),
+    ])
+  }
+
+  static func helpParser() -> Parser<Subcommand> {
+    return Parser.ofString("help", constant: .Help(nil))
+  }
+
+  static func interactParser() -> Parser<Subcommand> {
+    return Parser
+      .succeeded("interact", by: Parser.succeeded("--port", by: Parser<Int>.ofInt()).optional())
+      .fmap { Subcommand.Interact($0) }
+  }
+
+  static func listParser() -> Parser<Subcommand> {
+    let followingParser = Parser
+      .ofTwo(Query.parser(), b: Format.parser())
+      .fmap { (query, format) in
+        Subcommand.List(query, format)
+      }
+
+    return Parser.succeeded("list", by: followingParser)
+  }
+
+  static func bootParser() -> Parser<Subcommand> {
+    return Parser
+      .succeeded("boot", by: Query.parser())
+      .fmap { Subcommand.Boot($0) }
+  }
+
+  static func shutdownParser() -> Parser<Subcommand> {
+    return Parser
+      .succeeded("shutdown", by: Query.parser())
+      .fmap { Subcommand.Shutdown($0) }
+  }
+
+  static func diagnoseParser() -> Parser<Subcommand> {
+    return Parser
+      .succeeded("diagnose", by: Query.parser())
+      .fmap { Subcommand.Diagnose($0) }
+  }
+}
+
+extension Query : Parsable {
+  static func parser() -> Parser<Query> {
+    return Parser
+      .ofAny([
+        Parser.ofString("creating", constant: Query.State(FBSimulatorState.Creating)),
+        Parser.ofString("shutdown", constant: Query.State(FBSimulatorState.Shutdown)),
+        Parser.ofString("booting", constant: Query.State(FBSimulatorState.Booting)),
+        Parser.ofString("booted", constant: Query.State(FBSimulatorState.Booted)),
+        Parser.ofString("shutting-down", constant: Query.State(FBSimulatorState.Booted)),
+        Query.udidParser(),
+        Query.nameParser()
+      ])
+  }
+
+  private static func udidParser() -> Parser<Query> {
+    return Parser.single { token in
+      guard let _ = NSUUID(UUIDString: token) else {
+        throw ParseError.InvalidNumber
+      }
+      return Query.UDID(token)
+    }
+  }
+
+  private static func nameParser() -> Parser<Query> {
+    return Parser.single { token in
+      let mapping = FBSimulatorConfiguration.configurationsToAvailableDeviceTypes() as! [FBSimulatorConfiguration : AnyObject]
+      let deviceNames = Set(mapping.keys.map { $0.deviceName })
+      if (!deviceNames.contains(token)) {
+        throw ParseError.InvalidNumber
+      }
+      let configuration: FBSimulatorConfiguration! = FBSimulatorConfiguration.named(token)
+      return Query.Configured(configuration)
+    }
+  }
+}
+
+extension Format : Parsable {
+  static func parser() -> Parser<Format> {
+    return Parser
+      .ofMany([
+        Parser.ofString("--udid", constant: Format.UDID),
+        Parser.ofString("--name", constant: Format.Name),
+        Parser.ofString("--device-name", constant: Format.Name),
+        Parser.ofString("--os-constant: version", constant: Format.Name)
+      ])
+      .fmap { formats in
+        if (formats.isEmpty) {
+          return Format.Compound([Format.Name, Format.UDID])
+        }
+        return Format.Compound(formats)
+      }
+  }
+}

--- a/fbsimctl/Sources/Relay.swift
+++ b/fbsimctl/Sources/Relay.swift
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import Foundation
+
+/**
+ A Class that acts as a sink and source of lines, transforming input to output via InputOutputRelayDataSource
+ */
+protocol Relay {
+  func start()
+  func stop()
+}
+
+/**
+ DataSource for transforming Input to Output
+ */
+protocol RelayTransformer {
+  func transform(input: String) -> Output
+}
+
+/**
+  Enum for defining the result of a translation
+ */
+public enum Output {
+  case Success(String)
+  case Failure(String)
+}
+
+/**
+ A sink of Strings
+ */
+protocol OutputWriter {
+  func writeOut(string: String)
+  func writeErr(string: String)
+}
+
+/**
+  A Connection of input to output via a buffer
+ */
+class RelayConnection : LineBufferDelegate {
+  let transformer: RelayTransformer
+  let outputWriter: OutputWriter
+  lazy var lineBuffer: LineBuffer = LineBuffer(delegate: self)
+
+  init (transformer: RelayTransformer, outputWriter: OutputWriter) {
+    self.transformer = transformer
+    self.outputWriter = outputWriter
+  }
+
+  func buffer(lineAvailable: String) {
+    let result = self.transformer.transform(lineAvailable)
+    switch (result) {
+    case .Success(let string):
+      self.outputWriter.writeOut(string)
+    case .Failure(let string):
+      self.outputWriter.writeErr(string)
+    }
+  }
+}

--- a/fbsimctl/Sources/Runners.swift
+++ b/fbsimctl/Sources/Runners.swift
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import Foundation
+import FBSimulatorControl
+
+protocol Runner {
+  func run() -> Output
+}
+
+extension Command {
+  func runFromCLI() -> Void {
+    switch (BaseRunner(command: self).run()) {
+    case .Failure(let string):
+      print(string)
+    case .Success(let string):
+      print(string)
+    }
+  }
+}
+
+private struct BaseRunner : Runner {
+  let command: Command
+
+  func run() -> Output {
+    switch (self.command.subcommand) {
+    case .Help:
+      return .Success(Command.getHelp())
+    default:
+      break
+    }
+
+    let controlConfiguration = FBSimulatorControlConfiguration(
+      simulatorApplication: try! FBSimulatorApplication(error: ()),
+      deviceSetPath: nil,
+      options: .KillSpuriousSimulatorsOnFirstStart
+    )
+    let control = FBSimulatorControl.sharedInstanceWithConfiguration(controlConfiguration)
+    switch (self.command.subcommand) {
+    case .Interact(let portNumber):
+      return InteractionRunner(control: control, portNumber: portNumber).run()
+    default:
+      let runner = SubcommandRunner(subcommand: self.command.subcommand, control: control)
+      return runner.run()
+    }
+  }
+}
+
+private struct SubcommandRunner : Runner {
+  let subcommand: Subcommand
+  let control: FBSimulatorControl
+
+  // TODO: Sessions don't make much sense in this context, combine multiple simulators into one session
+  func run() -> Output {
+    switch (self.subcommand) {
+    case .List(let query, let format):
+      let simulators = Query.perform(control.simulatorPool, query: query)
+      return .Success(Format.formatAll(format)(simulators: simulators))
+    case .Boot(let query):
+      return self.runSessionWithQuery(query) { session in
+        try session.interact().bootSimulator().performInteraction()
+        return "Booted \(session.simulator.udid)"
+      }
+    case .Shutdown:
+      return .Failure("unimplemented")
+    case .Diagnose(let query):
+      return self.runSessionWithQuery(query) { session in
+        if let sysLog = session.simulator.logs.systemLog() {
+          return "\(sysLog.shortName) \(sysLog.asPath)"
+        }
+        return ""
+      }
+    default:
+      return .Failure("unimplemented")
+    }
+  }
+
+  private func runSessionWithQuery(query: Query, with: FBSimulatorSession throws -> String) -> Output {
+    do {
+      var buffer = ""
+      let simulators = Query.perform(self.control.simulatorPool, query: query)
+      for simulator in simulators {
+        let session = FBSimulatorSession(simulator: simulator)
+        let result = try with(session)
+        buffer.appendContentsOf(result)
+        buffer.append("\n" as Character)
+      }
+      return .Success(buffer)
+    } catch let error as NSError {
+      return .Failure(error.description)
+    }
+  }
+}
+
+
+private class InteractionRunner : Runner, RelayTransformer {
+  let control: FBSimulatorControl
+  let portNumber: Int?
+
+  init(control: FBSimulatorControl, portNumber: Int?) {
+    self.control = control
+    self.portNumber = portNumber
+  }
+
+  func run() -> Output {
+    if let portNumber = self.portNumber {
+      print("Starting Socket server on \(portNumber)")
+      SocketRelay(portNumber: portNumber, transformer: self).start()
+      return .Success("Ending Socket Server")
+    }
+    print("Starting local interactive mode")
+    StdIORelay(transformer: self).start()
+    return .Success("Ending local interactive mode")
+  }
+
+  func transform(input: String) -> Output {
+    let arguments = input.componentsSeparatedByCharactersInSet(NSCharacterSet.whitespaceCharacterSet())
+    do {
+      let (_, command) = try Command.parser().parse(arguments)
+      let runner = SubcommandRunner(subcommand: command.subcommand, control: self.control)
+      return runner.run()
+    } catch {
+      return .Failure("NOPE")
+    }
+  }
+}
+
+private extension Query {
+  static func perform(pool: FBSimulatorPool, query: Query) -> [FBSimulator] {
+    return pool.allSimulators.filteredOrderedSetUsingPredicate(query.get(pool)).array as! [FBSimulator]
+  }
+
+  func get(pool: FBSimulatorPool) -> NSPredicate {
+    switch (self) {
+    case .UDID(let udid):
+      return FBSimulatorPredicates.onlyUDID(udid)
+    case .State(let state):
+      return FBSimulatorPredicates.withState(state)
+    case .Configured(let configuration):
+      return FBSimulatorPredicates.matchingConfiguration(configuration)
+    case .Compound(let subqueries):
+      let predicates = subqueries.map {$0.get(pool)}
+      return NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
+    }
+  }
+}
+
+private extension Format {
+  static func format(format: Format)(simulator: FBSimulator) -> String {
+    switch (format) {
+    case Format.UDID:
+      return simulator.udid
+    case Format.Name:
+      return simulator.name
+    case Format.DeviceName:
+      return simulator.configuration.deviceName
+    case Format.OSVersion:
+      return simulator.configuration.osVersionString
+    case Format.Compound(let subformats):
+      let tokens: NSArray = subformats.map { Format.format($0)(simulator: simulator) }
+      return tokens.componentsJoinedByString(" ")
+    }
+  }
+
+  static func formatAll(format: Format)(simulators: [FBSimulator]) -> String {
+    return simulators
+      .map(Format.format(format))
+      .joinWithSeparator("\n")
+  }
+}

--- a/fbsimctl/Sources/SignalHandler.swift
+++ b/fbsimctl/Sources/SignalHandler.swift
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import Foundation
+
+class SignalHandler {
+  let callback: String -> Void
+  var sources: [dispatch_source_t] = []
+
+  init(callback: String -> Void) {
+    self.callback = callback
+  }
+
+  private func register() {
+    let signalPairs: [(Int32, String)] = [
+      (SIGTERM, "SIGTERM"),
+      (SIGHUP, "SIGHUP"),
+      (SIGINT, "SIGINT")
+    ]
+    self.sources = signalPairs.map { (signal, name) in
+      let source = dispatch_source_create(
+        DISPATCH_SOURCE_TYPE_SIGNAL,
+        UInt(signal),
+        0,
+        dispatch_get_main_queue()
+      )
+      dispatch_source_set_event_handler(source) {
+        self.callback(name)
+      }
+      dispatch_resume(source)
+      return source
+    }
+  }
+
+  private func unregister() {
+    for source in self.sources {
+      dispatch_source_cancel(source)
+    }
+  }
+}
+
+extension SignalHandler {
+  static func runUntilSignalled() {
+    var signalled = false
+    let handler = SignalHandler { signalName in
+      print("Signalled by \(signalName)")
+      signalled = true
+    }
+
+    handler.register()
+    NSRunLoop.currentRunLoop().spinRunLoopWithTimeout(DBL_MAX) { signalled }
+    handler.unregister()
+  }
+}

--- a/fbsimctl/Sources/SocketRelay.swift
+++ b/fbsimctl/Sources/SocketRelay.swift
@@ -1,0 +1,353 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import Foundation
+
+let DefaultReadLength = 1024
+let DefaultWriteCharacters = 512
+
+func acceptCallback(socket: CFSocket!, callback: CFSocketCallBackType, address: NSData!, data: UnsafePointer<Void>, info: UnsafeMutablePointer<Void>) -> Void {
+  if callback != CFSocketCallBackType.AcceptCallBack {
+    return
+  }
+
+  print(sockaddr_in.fromData(address).description)
+
+  let acceptHandle = UnsafePointer<CFSocketNativeHandle>(data).memory
+  let socketHandle = CFSocketGetNative(socket)
+  print("Accept Handle \(acceptHandle) Socket Handle \(socketHandle)")
+  assert(acceptHandle != socketHandle, "Accept and Socket FD are the same")
+
+  var readStreamPointer: Unmanaged<CFReadStream>? = nil
+  var writeStreamPointer: Unmanaged<CFWriteStream>? = nil
+
+  CFStreamCreatePairWithSocket(
+    kCFAllocatorDefault,
+    acceptHandle,
+    &readStreamPointer,
+    &writeStreamPointer
+  )
+
+  let readStream = readStreamPointer?.takeUnretainedValue()
+  let writeStream = writeStreamPointer?.takeUnretainedValue()
+  let socketRelay = Unmanaged<SocketRelay>.fromOpaque(COpaquePointer(info)).takeUnretainedValue()
+  socketRelay.registerConnection(readStream!, outputStream: writeStream!)
+}
+
+extension sockaddr_in6 : CustomStringConvertible {
+  static func fromData(data: NSData) -> sockaddr_in6 {
+    var addr = sockaddr_in6()
+    data.getBytes(&addr, length: strideof(sockaddr_in6))
+    return addr
+  }
+
+  public var description: String {
+    return "Port \(self.sin6_port.littleEndian)"
+  }
+}
+
+extension sockaddr_in : CustomStringConvertible {
+  static func fromData(data: NSData) -> sockaddr_in {
+    var addr = sockaddr_in()
+    data.getBytes(&addr, length: strideof(sockaddr_in))
+    return addr
+  }
+
+  public var description: String {
+    return "Port \(self.sin_port)"
+  }
+}
+
+extension NSStreamStatus : CustomStringConvertible {
+  public var description: String {
+    switch (self) {
+    case NotOpen: return "None"
+    case Opening: return "Opening"
+    case Open: return "Open"
+    case Reading: return "Reading"
+    case Writing: return "Writing"
+    case AtEnd: return "AtEnd"
+    case Closed: return "Closed"
+    case Error: return "Error"
+    }
+  }
+}
+
+extension NSStreamEvent : CustomStringConvertible {
+  public var description: String {
+    switch (self.rawValue) {
+    case NSStreamEvent.None.rawValue: return "None"
+    case NSStreamEvent.OpenCompleted.rawValue: return "OpenCompleted"
+    case NSStreamEvent.HasBytesAvailable.rawValue: return "HasBytesAvailable"
+    case NSStreamEvent.HasSpaceAvailable.rawValue: return "HasSpaceAvailable"
+    case NSStreamEvent.ErrorOccurred.rawValue: return "ErrorOccured"
+    case NSStreamEvent.EndEncountered.rawValue: return "EndEncountered"
+    default: return "Unknown"
+    }
+  }
+}
+
+protocol SocketConnectionDelegate {
+  func connectionClosed(socketConnection: SocketConnection)
+}
+
+class SocketConnection {
+  private class InputDelegate : NSObject, NSStreamDelegate {
+    let lineBuffer: LineBuffer
+
+    init(lineBuffer: LineBuffer) {
+      self.lineBuffer = lineBuffer
+    }
+
+    @objc func stream(stream: NSStream, handleEvent eventCode: NSStreamEvent) {
+      guard let stream = stream as? NSInputStream else {
+        return
+      }
+
+      print("Input Event \(eventCode.description)")
+      switch (eventCode.rawValue) {
+        case NSStreamEvent.HasBytesAvailable.rawValue:
+          let buffer = UnsafeMutablePointer<UInt8>.alloc(DefaultReadLength)
+          let count = stream.read(buffer, maxLength: DefaultReadLength)
+          let data = NSData(bytesNoCopy: buffer, length: count)
+          lineBuffer.appendData(data)
+          buffer.destroy()
+        default:
+          return
+      }
+    }
+  }
+
+  private class OutputDelegate : NSObject, NSStreamDelegate, OutputWriter {
+    var buffer: String = ""
+    let stream: NSOutputStream
+
+    init (stream: NSOutputStream) {
+      self.stream = stream
+    }
+
+    @objc func stream(stream: NSStream, handleEvent eventCode: NSStreamEvent) {
+      assert(stream == self.stream, "Handled delegate from unexpected stream")
+      print("Output Event \(eventCode.description)")
+      switch (eventCode.rawValue) {
+        case NSStreamEvent.HasSpaceAvailable.rawValue:
+          self.flushAvailable()
+        default:
+          return
+      }
+    }
+
+    func writeOut(string: String) {
+      buffer.appendContentsOf(string)
+      self.flushAvailable()
+    }
+
+    func writeErr(string: String) {
+      buffer.appendContentsOf(string)
+      self.flushAvailable()
+    }
+
+    func flushAvailable() {
+      while (buffer.characters.count > 0 && self.stream.hasSpaceAvailable) {
+        // TODO: Buffer appropriately
+        let range = buffer.characters.indices
+        let slice = buffer.substringWithRange(range)
+        self.buffer = ""
+
+        let data = slice.dataUsingEncoding(NSUTF8StringEncoding)!
+        let cData = UnsafeMutablePointer<UInt8>.alloc(data.length)
+        data.getBytes(cData, length: data.length)
+        stream.write(cData, maxLength: data.length)
+        cData.destroy()
+      }
+    }
+  }
+
+  private let readStream: NSInputStream
+  private let readStreamDelegate: InputDelegate
+
+  private let writeStream: NSOutputStream
+  private let writeStreamDelegate: OutputDelegate
+
+  private let relayConnection: RelayConnection
+
+  init(readStream: NSInputStream, writeStream: NSOutputStream, delegate: SocketConnectionDelegate, transformer: RelayTransformer) {
+    self.writeStream = writeStream
+    self.writeStreamDelegate = OutputDelegate(stream: writeStream)
+    self.relayConnection = RelayConnection(transformer: transformer, outputWriter: self.writeStreamDelegate)
+    self.readStream = readStream
+    self.readStreamDelegate = InputDelegate(lineBuffer: self.relayConnection.lineBuffer)
+  }
+
+  func start() {
+    assert(self.readStream.streamStatus == NSStreamStatus.NotOpen, "Expected an unopened Read Stream")
+    assert(self.writeStream.streamStatus == NSStreamStatus.NotOpen, "Expected an unopened Write Stream")
+
+    self.readStream.delegate = self.readStreamDelegate
+    self.readStream.scheduleInRunLoop(NSRunLoop.currentRunLoop(), forMode: NSDefaultRunLoopMode)
+    self.readStream.open()
+
+    self.writeStream.delegate = self.writeStreamDelegate
+    self.writeStream.scheduleInRunLoop(NSRunLoop.currentRunLoop(), forMode: NSDefaultRunLoopMode)
+    self.writeStream.open()
+  }
+
+  func stop() {
+    self.readStream.close()
+    self.writeStream.close()
+  }
+}
+
+class SocketRelay : Relay, SocketConnectionDelegate {
+  struct Options {
+    let portNumber: Int
+    let bindIPv4: Bool
+    let bindIPv6: Bool
+
+    func portNumberNetworkByteOrder() -> in_port_t {
+      return UInt16(self.portNumber).bigEndian
+    }
+  }
+
+  let options: SocketRelay.Options
+  var transformer: RelayTransformer
+  var registeredConnections: [SocketConnection] = []
+
+  init(portNumber: Int, transformer: RelayTransformer) {
+    self.transformer = transformer
+    self.options = SocketRelay.Options(portNumber: portNumber, bindIPv4: false, bindIPv6: true)
+  }
+
+  func start() {
+    createSocketsAndRunInRunLoop()
+    SignalHandler.runUntilSignalled()
+  }
+
+  func stop() {
+
+  }
+
+  private func socketContext() -> CFSocketContext {
+    return CFSocketContext(
+      version: 0,
+      info: UnsafeMutablePointer(Unmanaged.passUnretained(self).toOpaque()),
+      retain: nil,
+      release: nil,
+      copyDescription: nil
+    )
+  }
+
+  private func setSocketOptions(socket: CFSocket) {
+    let socketDescriptor = CFSocketGetNative(socket)
+    var yes: Int32 = 1
+    let result = setsockopt(socketDescriptor, Constants.sol_socket(), Constants.so_reuseaddr(), &yes, UInt32(strideof(Int32)))
+    assert(result != -1, "Expected to be able to setsockopt")
+  }
+
+  private func createSocket4() -> CFSocket {
+    var context = socketContext()
+    let sock = CFSocketCreate(
+      kCFAllocatorDefault,
+      PF_INET,
+      SOCK_STREAM,
+      IPPROTO_TCP,
+      CFSocketCallBackType.AcceptCallBack.rawValue,
+      acceptCallback,
+      &context
+    )
+    setSocketOptions(sock)
+
+    var addr = sockaddr_in(
+      sin_len: UInt8(strideof(sockaddr_in)),
+      sin_family: UInt8(AF_INET),
+      sin_port: self.options.portNumberNetworkByteOrder(),
+      sin_addr: in_addr(s_addr: UInt32(0).bigEndian),
+      sin_zero: (0, 0, 0, 0, 0, 0, 0, 0)
+    )
+
+    let data: CFDataRef = NSData(bytes: &addr, length: strideof(sockaddr_in))
+    let error = CFSocketSetAddress(sock, data)
+    assert(error == CFSocketError.Success, "Could not bind ipv4")
+
+    return sock
+  }
+
+  private func createSocket6() -> CFSocket {
+    var context = socketContext()
+    let sock = CFSocketCreate(
+      kCFAllocatorDefault,
+      PF_INET6,
+      SOCK_STREAM,
+      IPPROTO_TCP,
+      CFSocketCallBackType.AcceptCallBack.rawValue,
+      acceptCallback,
+      &context
+    )
+    setSocketOptions(sock)
+
+    var addr = sockaddr_in6(
+      sin6_len: UInt8(strideof(sockaddr_in6)),
+      sin6_family: UInt8(AF_INET6),
+      sin6_port: self.options.portNumberNetworkByteOrder(),
+      sin6_flowinfo: 0,
+      sin6_addr: in6addr_any,
+      sin6_scope_id: 0
+    )
+
+    let data: CFDataRef = NSData(bytes: &addr, length: strideof(sockaddr_in6))
+    let error = CFSocketSetAddress(sock, data)
+    assert(error == CFSocketError.Success, "Could not bind ipv6")
+
+    return sock
+  }
+
+  func createSocketsAndRunInRunLoop() {
+    var sockets: [CFSocket] = []
+
+    if (self.options.bindIPv4) {
+      sockets.append(createSocket4())
+    }
+    if (self.options.bindIPv6) {
+      sockets.append(createSocket6())
+    }
+
+    for socket in sockets {
+      let source = CFSocketCreateRunLoopSource(
+        kCFAllocatorDefault,
+        socket,
+        0
+      )
+      CFRunLoopAddSource(
+        CFRunLoopGetCurrent(),
+        source,
+        kCFRunLoopDefaultMode
+      )
+
+      let native = CFSocketGetNative(socket)
+      print("Native socket of \(native)")
+      assert(native != 0, "Couldn't get native socket")
+    }
+  }
+
+  func registerConnection(inputStream: NSInputStream, outputStream: NSOutputStream) {
+    let connection = SocketConnection(
+      readStream: inputStream,
+      writeStream: outputStream,
+      delegate: self,
+      transformer: self.transformer
+    )
+
+    registeredConnections.append(connection)
+    connection.start()
+  }
+
+  func connectionClosed(socketConnection: SocketConnection) {
+
+  }
+}

--- a/fbsimctl/Sources/StdIORelay.swift
+++ b/fbsimctl/Sources/StdIORelay.swift
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import Foundation
+
+class StdIORelay : Relay {
+  let relayConnection: RelayConnection
+
+  private let stdIn: NSFileHandle
+
+  init(transformer: RelayTransformer) {
+    self.relayConnection = RelayConnection(transformer: transformer, outputWriter: StdIOWriter())
+    self.stdIn = NSFileHandle.fileHandleWithStandardInput()
+  }
+
+  func start() {
+    let lineBuffer = self.relayConnection.lineBuffer
+
+    self.stdIn.readabilityHandler = { handle in
+      let data = handle.availableData
+      lineBuffer.appendData(data)
+    }
+    SignalHandler.runUntilSignalled()
+  }
+
+  func stop() {
+    self.stdIn.readabilityHandler = nil
+  }
+
+  class StdIOWriter : OutputWriter {
+    private let stdOut: NSFileHandle
+    private let stdErr: NSFileHandle
+
+    init() {
+      self.stdOut = NSFileHandle.fileHandleWithStandardOutput()
+      self.stdErr = NSFileHandle.fileHandleWithStandardError()
+    }
+
+    func writeOut(string: String) {
+      self.write(string, handle: self.stdOut)
+    }
+
+    func writeErr(string: String) {
+      self.write(string, handle: self.stdErr)
+    }
+
+    private func write(var string: String, handle: NSFileHandle) {
+      if (string.characters.last != "\n") {
+        string.append("\n" as Character)
+      }
+      let data = string.dataUsingEncoding(NSUTF8StringEncoding)!
+      handle.writeData(data)
+    }
+  }
+}

--- a/fbsimctl/Sources/fbsimctl-Bridging-Header.h
+++ b/fbsimctl/Sources/fbsimctl-Bridging-Header.h
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "Constants.h"

--- a/fbsimctl/Sources/main.swift
+++ b/fbsimctl/Sources/main.swift
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import Foundation
+
+Command
+  .fromArguments(Array(NSProcessInfo.processInfo().arguments.dropFirst(1)))
+  .runFromCLI()

--- a/fbsimctl/fbsimctl.xcodeproj/project.pbxproj
+++ b/fbsimctl/fbsimctl.xcodeproj/project.pbxproj
@@ -1,0 +1,320 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		AA93B7C71BE835B100CF6A56 /* Relay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA93B7C41BE835B100CF6A56 /* Relay.swift */; };
+		AA93B7C81BE835B100CF6A56 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA93B7C51BE835B100CF6A56 /* main.swift */; };
+		AA93B7CA1BE8361800CF6A56 /* FBSimulatorControl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA93B7C91BE8361800CF6A56 /* FBSimulatorControl.framework */; };
+		AA93B7CC1BE8380B00CF6A56 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA93B7C31BE835B100CF6A56 /* Command.swift */; };
+		AA93B7CE1BE9543000CF6A56 /* Parsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA93B7CD1BE9543000CF6A56 /* Parsers.swift */; };
+		AA93B7D01BE9544000CF6A56 /* Runners.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA93B7CF1BE9544000CF6A56 /* Runners.swift */; };
+		AA93B7D21BEA679600CF6A56 /* Help.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA93B7D11BEA679600CF6A56 /* Help.swift */; };
+		AA93B7D41BEA7ED800CF6A56 /* Arguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA93B7D31BEA7ED800CF6A56 /* Arguments.swift */; };
+		AA93B7D61BEA97A700CF6A56 /* Bridging.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA93B7D51BEA97A700CF6A56 /* Bridging.swift */; };
+		AAEAC9BB1BF23BAE00B5F957 /* FBSimulatorControl.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = AA93B7C91BE8361800CF6A56 /* FBSimulatorControl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		AAEAC9BD1BF3CD7B00B5F957 /* SignalHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEAC9BC1BF3CD7B00B5F957 /* SignalHandler.swift */; };
+		AAEAC9BF1BF3EA8200B5F957 /* SocketRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEAC9BE1BF3EA8200B5F957 /* SocketRelay.swift */; };
+		AAEAC9C11BF3EA9200B5F957 /* StdIORelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEAC9C01BF3EA9200B5F957 /* StdIORelay.swift */; };
+		AAF4A3311BF4E2B900978B3A /* LineBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF4A3301BF4E2B900978B3A /* LineBuffer.swift */; };
+		AAF4A3381BF5152700978B3A /* Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = AAF4A3371BF5152700978B3A /* Constants.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		AAEAC9BA1BF23B1700B5F957 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = Frameworks;
+			dstSubfolderSpec = 10;
+			files = (
+				AAEAC9BB1BF23BAE00B5F957 /* FBSimulatorControl.framework in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		AA93B7B01BE8351000CF6A56 /* fbsimctl */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = fbsimctl; sourceTree = BUILT_PRODUCTS_DIR; };
+		AA93B7C31BE835B100CF6A56 /* Command.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
+		AA93B7C41BE835B100CF6A56 /* Relay.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Relay.swift; sourceTree = "<group>"; };
+		AA93B7C51BE835B100CF6A56 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		AA93B7C91BE8361800CF6A56 /* FBSimulatorControl.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FBSimulatorControl.framework; path = "../../../Library/Developer/Xcode/DerivedData/fbsimctl-civpmgwytzrrawekdzefxighgiyo/Build/Products/Debug/FBSimulatorControl.framework"; sourceTree = "<group>"; };
+		AA93B7CD1BE9543000CF6A56 /* Parsers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Parsers.swift; sourceTree = "<group>"; };
+		AA93B7CF1BE9544000CF6A56 /* Runners.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Runners.swift; sourceTree = "<group>"; };
+		AA93B7D11BEA679600CF6A56 /* Help.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Help.swift; sourceTree = "<group>"; };
+		AA93B7D31BEA7ED800CF6A56 /* Arguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Arguments.swift; sourceTree = "<group>"; };
+		AA93B7D51BEA97A700CF6A56 /* Bridging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bridging.swift; sourceTree = "<group>"; };
+		AAEAC9BC1BF3CD7B00B5F957 /* SignalHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignalHandler.swift; sourceTree = "<group>"; };
+		AAEAC9BE1BF3EA8200B5F957 /* SocketRelay.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocketRelay.swift; sourceTree = "<group>"; };
+		AAEAC9C01BF3EA9200B5F957 /* StdIORelay.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StdIORelay.swift; sourceTree = "<group>"; };
+		AAF4A3301BF4E2B900978B3A /* LineBuffer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineBuffer.swift; sourceTree = "<group>"; };
+		AAF4A3351BF5152700978B3A /* fbsimctl-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "fbsimctl-Bridging-Header.h"; sourceTree = "<group>"; };
+		AAF4A3361BF5152700978B3A /* Constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Constants.h; sourceTree = "<group>"; };
+		AAF4A3371BF5152700978B3A /* Constants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Constants.m; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		AA93B7AD1BE8351000CF6A56 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AA93B7CA1BE8361800CF6A56 /* FBSimulatorControl.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		AA93B7A71BE8351000CF6A56 = {
+			isa = PBXGroup;
+			children = (
+				AA93B7C21BE835B100CF6A56 /* Sources */,
+				AA93B7CB1BE8361F00CF6A56 /* Frameworks */,
+				AA93B7B11BE8351000CF6A56 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		AA93B7B11BE8351000CF6A56 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				AA93B7B01BE8351000CF6A56 /* fbsimctl */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		AA93B7C21BE835B100CF6A56 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				AA93B7D31BEA7ED800CF6A56 /* Arguments.swift */,
+				AA93B7D51BEA97A700CF6A56 /* Bridging.swift */,
+				AA93B7C31BE835B100CF6A56 /* Command.swift */,
+				AAF4A3361BF5152700978B3A /* Constants.h */,
+				AAF4A3371BF5152700978B3A /* Constants.m */,
+				AAF4A3351BF5152700978B3A /* fbsimctl-Bridging-Header.h */,
+				AA93B7D11BEA679600CF6A56 /* Help.swift */,
+				AAF4A3301BF4E2B900978B3A /* LineBuffer.swift */,
+				AA93B7C51BE835B100CF6A56 /* main.swift */,
+				AA93B7CD1BE9543000CF6A56 /* Parsers.swift */,
+				AA93B7C41BE835B100CF6A56 /* Relay.swift */,
+				AA93B7CF1BE9544000CF6A56 /* Runners.swift */,
+				AAEAC9BC1BF3CD7B00B5F957 /* SignalHandler.swift */,
+				AAEAC9BE1BF3EA8200B5F957 /* SocketRelay.swift */,
+				AAEAC9C01BF3EA9200B5F957 /* StdIORelay.swift */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		AA93B7CB1BE8361F00CF6A56 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				AA93B7C91BE8361800CF6A56 /* FBSimulatorControl.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		AA93B7AF1BE8351000CF6A56 /* fbsimctl */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AA93B7B71BE8351000CF6A56 /* Build configuration list for PBXNativeTarget "fbsimctl" */;
+			buildPhases = (
+				AA93B7AC1BE8351000CF6A56 /* Sources */,
+				AA93B7AD1BE8351000CF6A56 /* Frameworks */,
+				AAEAC9BA1BF23B1700B5F957 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = fbsimctl;
+			productName = fbsimctl;
+			productReference = AA93B7B01BE8351000CF6A56 /* fbsimctl */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		AA93B7A81BE8351000CF6A56 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0710;
+				LastUpgradeCheck = 0710;
+				ORGANIZATIONNAME = Facebook;
+				TargetAttributes = {
+					AA93B7AF1BE8351000CF6A56 = {
+						CreatedOnToolsVersion = 7.1;
+					};
+				};
+			};
+			buildConfigurationList = AA93B7AB1BE8351000CF6A56 /* Build configuration list for PBXProject "fbsimctl" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = AA93B7A71BE8351000CF6A56;
+			productRefGroup = AA93B7B11BE8351000CF6A56 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				AA93B7AF1BE8351000CF6A56 /* fbsimctl */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		AA93B7AC1BE8351000CF6A56 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AA93B7D01BE9544000CF6A56 /* Runners.swift in Sources */,
+				AA93B7CE1BE9543000CF6A56 /* Parsers.swift in Sources */,
+				AA93B7D21BEA679600CF6A56 /* Help.swift in Sources */,
+				AA93B7D41BEA7ED800CF6A56 /* Arguments.swift in Sources */,
+				AAEAC9BF1BF3EA8200B5F957 /* SocketRelay.swift in Sources */,
+				AAF4A3381BF5152700978B3A /* Constants.m in Sources */,
+				AAF4A3311BF4E2B900978B3A /* LineBuffer.swift in Sources */,
+				AAEAC9BD1BF3CD7B00B5F957 /* SignalHandler.swift in Sources */,
+				AA93B7CC1BE8380B00CF6A56 /* Command.swift in Sources */,
+				AA93B7C71BE835B100CF6A56 /* Relay.swift in Sources */,
+				AA93B7C81BE835B100CF6A56 /* main.swift in Sources */,
+				AA93B7D61BEA97A700CF6A56 /* Bridging.swift in Sources */,
+				AAEAC9C11BF3EA9200B5F957 /* StdIORelay.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		AA93B7B51BE8351000CF6A56 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = $SRCROOT/Headers/BridgingHeader.h;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		AA93B7B61BE8351000CF6A56 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = $SRCROOT/Headers/BridgingHeader.h;
+			};
+			name = Release;
+		};
+		AA93B7B81BE8351000CF6A56 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "Sources/fbsimctl-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		AA93B7B91BE8351000CF6A56 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "Sources/fbsimctl-Bridging-Header.h";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		AA93B7AB1BE8351000CF6A56 /* Build configuration list for PBXProject "fbsimctl" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AA93B7B51BE8351000CF6A56 /* Debug */,
+				AA93B7B61BE8351000CF6A56 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AA93B7B71BE8351000CF6A56 /* Build configuration list for PBXNativeTarget "fbsimctl" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AA93B7B81BE8351000CF6A56 /* Debug */,
+				AA93B7B91BE8351000CF6A56 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = AA93B7A81BE8351000CF6A56 /* Project object */;
+}

--- a/fbsimctl/fbsimctl.xcodeproj/xcshareddata/xcschemes/fbsimctl.xcscheme
+++ b/fbsimctl/fbsimctl.xcodeproj/xcshareddata/xcschemes/fbsimctl.xcscheme
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AA93B7AF1BE8351000CF6A56"
+               BuildableName = "fbsimctl"
+               BlueprintName = "fbsimctl"
+               ReferencedContainer = "container:fbsimctl.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AA93B7AF1BE8351000CF6A56"
+            BuildableName = "fbsimctl"
+            BlueprintName = "fbsimctl"
+            ReferencedContainer = "container:fbsimctl.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AA93B7AF1BE8351000CF6A56"
+            BuildableName = "fbsimctl"
+            BlueprintName = "fbsimctl"
+            ReferencedContainer = "container:fbsimctl.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "interact"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--port"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "6000"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AA93B7AF1BE8351000CF6A56"
+            BuildableName = "fbsimctl"
+            BlueprintName = "fbsimctl"
+            ReferencedContainer = "container:fbsimctl.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/fbsimctl/fbsimctl.xcworkspace/contents.xcworkspacedata
+++ b/fbsimctl/fbsimctl.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:fbsimctl.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:../FBSimulatorControl.xcodeproj">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
This PR adds a commandline called `fbsimctl` to the repo, by using the `FBSimulatorControl.framework` from a separate workspace. It is a Swift-based mac CLI that aims to expose a bunch of the features in a way that doesn't require directly require interfacing with the framework. In is intended to be extended in the future and to do many of the things that `simctl` doesn't.

- [x] Create Umbrella header for `FBSimulatorControl` so it can be used externally in Swift
- [x] Add a new Target and CLI app called `fbsimctl` that uses `FBSimulatorControl`
- [x] Parser Combinators for the CLI commands
- [x] Query: Text representation of a Predicate for fetching simulators
- [x] Format: A Text representation of Simulators by querying for properties
- [x] `list`: Lists all Simulators by a query and a format
- [ ] `boot`: Boots Simulators by a query
- [ ] `shutdown`: Boots Simulators by a query
- [ ] `diagnose`: Shows diagnostic information in a variety of formats.
- [ ] `upload`: Uploads photos and videos to a bunch of queried Simulators.
- [ ] `interact`: An interactive mode for `fbsimctl`
- [x] `stdout`/`stderr` based interactive mode
- [x] TCP Socket-Server based interactive mode
- [ ] Hangup & `SIGTERM` tearing down simulators
- [ ] `help`: prints out help for a subcommand
- [ ] Update the `README`
