### PR TITLE
Add FBSimulatorTerminationStrategy

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -7,9 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		877123F01BDA78AA00530B1E /* FBSimulatorVideoUploader.h in Headers */ = {isa = PBXBuildFile; fileRef = 877123EE1BDA78AA00530B1E /* FBSimulatorVideoUploader.h */; settings = {ASSET_TAGS = (); }; };
-		877123F11BDA78AA00530B1E /* FBSimulatorVideoUploader.m in Sources */ = {isa = PBXBuildFile; fileRef = 877123EF1BDA78AA00530B1E /* FBSimulatorVideoUploader.m */; settings = {ASSET_TAGS = (); }; };
-		877123F31BDA797800530B1E /* video0.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 877123F21BDA797800530B1E /* video0.mp4 */; settings = {ASSET_TAGS = (); }; };
+		877123F01BDA78AA00530B1E /* FBSimulatorVideoUploader.h in Headers */ = {isa = PBXBuildFile; fileRef = 877123EE1BDA78AA00530B1E /* FBSimulatorVideoUploader.h */; };
+		877123F11BDA78AA00530B1E /* FBSimulatorVideoUploader.m in Sources */ = {isa = PBXBuildFile; fileRef = 877123EF1BDA78AA00530B1E /* FBSimulatorVideoUploader.m */; };
+		877123F31BDA797800530B1E /* video0.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 877123F21BDA797800530B1E /* video0.mp4 */; };
 		AA017F271BD7770300F45E9D /* FBSimulatorLogsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA017F251BD7770300F45E9D /* FBSimulatorLogsTests.m */; };
 		AA017F281BD7770300F45E9D /* FBWritableLogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA017F261BD7770300F45E9D /* FBWritableLogTests.m */; };
 		AA017F2F1BD7771300F45E9D /* FBSimulatorLogs.h in Headers */ = {isa = PBXBuildFile; fileRef = AA017F2A1BD7771300F45E9D /* FBSimulatorLogs.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -20,6 +20,8 @@
 		AA017F361BD7772D00F45E9D /* FBConcurrentCollectionOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = AA017F341BD7772D00F45E9D /* FBConcurrentCollectionOperations.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA017F371BD7772D00F45E9D /* FBConcurrentCollectionOperations.m in Sources */ = {isa = PBXBuildFile; fileRef = AA017F351BD7772D00F45E9D /* FBConcurrentCollectionOperations.m */; };
 		AA017F581BD7787300F45E9D /* libShimulator.dylib in Resources */ = {isa = PBXBuildFile; fileRef = AA017F4C1BD7784700F45E9D /* libShimulator.dylib */; };
+		AA01F46D1BFF0A1B000B5939 /* FBSimulatorTerminationStrategy.h in Headers */ = {isa = PBXBuildFile; fileRef = AA01F46B1BFF0A1B000B5939 /* FBSimulatorTerminationStrategy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA01F46E1BFF0A1B000B5939 /* FBSimulatorTerminationStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = AA01F46C1BFF0A1B000B5939 /* FBSimulatorTerminationStrategy.m */; };
 		AA111CC21BBE662E0054AFDD /* FBTaskExecutorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA111CC11BBE662E0054AFDD /* FBTaskExecutorTests.m */; };
 		AA111CCE1BBE7C5A0054AFDD /* CoreSimulatorDoubles.m in Sources */ = {isa = PBXBuildFile; fileRef = AA111CCD1BBE7C5A0054AFDD /* CoreSimulatorDoubles.m */; };
 		AA3230CB1BDA387700C5BA01 /* FBSimulatorControlAssertions.m in Sources */ = {isa = PBXBuildFile; fileRef = AA3230CA1BDA387700C5BA01 /* FBSimulatorControlAssertions.m */; };
@@ -192,6 +194,8 @@
 		AA017F341BD7772D00F45E9D /* FBConcurrentCollectionOperations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBConcurrentCollectionOperations.h; sourceTree = "<group>"; };
 		AA017F351BD7772D00F45E9D /* FBConcurrentCollectionOperations.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBConcurrentCollectionOperations.m; sourceTree = "<group>"; };
 		AA017F4C1BD7784700F45E9D /* libShimulator.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libShimulator.dylib; sourceTree = "<group>"; };
+		AA01F46B1BFF0A1B000B5939 /* FBSimulatorTerminationStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorTerminationStrategy.h; sourceTree = "<group>"; };
+		AA01F46C1BFF0A1B000B5939 /* FBSimulatorTerminationStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorTerminationStrategy.m; sourceTree = "<group>"; };
 		AA111CC11BBE662E0054AFDD /* FBTaskExecutorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBTaskExecutorTests.m; sourceTree = "<group>"; };
 		AA111CCC1BBE7C5A0054AFDD /* CoreSimulatorDoubles.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreSimulatorDoubles.h; sourceTree = "<group>"; };
 		AA111CCD1BBE7C5A0054AFDD /* CoreSimulatorDoubles.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CoreSimulatorDoubles.m; sourceTree = "<group>"; };
@@ -985,6 +989,8 @@
 				AA4876E01BAC74B9007F7D23 /* FBSimulatorPool+Private.h */,
 				AAC2411A1BB30CB30054570C /* FBSimulatorPredicates.h */,
 				AAC2411B1BB30CB30054570C /* FBSimulatorPredicates.m */,
+				AA01F46B1BFF0A1B000B5939 /* FBSimulatorTerminationStrategy.h */,
+				AA01F46C1BFF0A1B000B5939 /* FBSimulatorTerminationStrategy.m */,
 			);
 			path = Management;
 			sourceTree = "<group>";
@@ -1829,6 +1835,7 @@
 				AA48773E1BAC74B9007F7D23 /* FBSimulatorSessionInteraction+Diagnostics.h in Headers */,
 				AA48772D1BAC74B9007F7D23 /* FBSimulatorPool+Private.h in Headers */,
 				AA48774A1BAC74B9007F7D23 /* FBSimulatorSessionStateGenerator.h in Headers */,
+				AA01F46D1BFF0A1B000B5939 /* FBSimulatorTerminationStrategy.h in Headers */,
 				AA4877331BAC74B9007F7D23 /* FBSimulatorProcess.h in Headers */,
 				AA4877481BAC74B9007F7D23 /* FBSimulatorSessionState.h in Headers */,
 				AA4877431BAC74B9007F7D23 /* FBSimulatorSessionLifecycle.h in Headers */,
@@ -1980,6 +1987,7 @@
 			files = (
 				AA017F371BD7772D00F45E9D /* FBConcurrentCollectionOperations.m in Sources */,
 				AAC2411D1BB30CB30054570C /* FBSimulatorPredicates.m in Sources */,
+				AA01F46E1BFF0A1B000B5939 /* FBSimulatorTerminationStrategy.m in Sources */,
 				AA74B99A1BB014A200C1E59C /* FBSimulatorError.m in Sources */,
 				AA48773A1BAC74B9007F7D23 /* FBSimulatorSession+Convenience.m in Sources */,
 				AA4877341BAC74B9007F7D23 /* FBSimulatorProcess.m in Sources */,

--- a/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.h
@@ -20,8 +20,9 @@ typedef NS_OPTIONS(NSUInteger, FBSimulatorManagementOptions){
   FBSimulatorManagementOptionsDeleteAllOnFirstStart = 1 << 0,
   FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart = 1 << 1,
   FBSimulatorManagementOptionsIgnoreSpuriousKillFail = 1 << 2,
-  FBSimulatorManagementOptionsDeleteOnFree = 1 << 3,
-  FBSimulatorManagementOptionsEraseOnFree = 1 << 4,
+  FBSimulatorManagementOptionsAlwaysCreateWhenAllocating = 1 << 3,
+  FBSimulatorManagementOptionsDeleteOnFree = 1 << 4,
+  FBSimulatorManagementOptionsEraseOnFree = 1 << 5,
 };
 
 /**

--- a/FBSimulatorControl/Management/FBSimulator.h
+++ b/FBSimulatorControl/Management/FBSimulator.h
@@ -127,6 +127,15 @@ typedef NS_ENUM(NSInteger, FBSimulatorState) {
 - (BOOL)waitOnState:(FBSimulatorState)state timeout:(NSTimeInterval)timeout;
 
 /**
+ A Synchronous wait, with a default timeout, producing a meaningful error message.
+ 
+ @param state the state to wait on
+ @param error an error out for a timeout error if one occurred
+ @returns YES if the Simulator transitioned to the given state with the timeout, NO otherwise
+ */
+- (BOOL)waitOnState:(FBSimulatorState)state withError:(NSError **)error;
+
+/**
  Convenience method for obtaining a description of Simulator State
  */
 + (NSString *)stateStringFromSimulatorState:(FBSimulatorState)state;

--- a/FBSimulatorControl/Management/FBSimulator.m
+++ b/FBSimulatorControl/Management/FBSimulator.m
@@ -206,6 +206,17 @@ NSTimeInterval const FBSimulatorDefaultTimeout = 20;
   }];
 }
 
+- (BOOL)waitOnState:(FBSimulatorState)state withError:(NSError **)error
+{
+  if (![self waitOnState:state]) {
+    return [[[FBSimulatorError
+      describeFormat:@"Simulator was not in expected %@ state, got %@", [FBSimulator stateStringFromSimulatorState:state], self.stateString]
+      inSimulator:self]
+      failBool:error];
+  }
+  return YES;
+}
+
 - (BOOL)freeFromPoolWithError:(NSError **)error
 {
   if (!self.pool) {

--- a/FBSimulatorControl/Management/FBSimulatorPool.m
+++ b/FBSimulatorControl/Management/FBSimulatorPool.m
@@ -26,6 +26,7 @@
 #import "FBSimulatorInteraction.h"
 #import "FBSimulatorLogger.h"
 #import "FBSimulatorPredicates.h"
+#import "FBSimulatorTerminationStrategy.h"
 #import "FBTaskExecutor+Convenience.h"
 #import "FBTaskExecutor.h"
 #import "NSRunLoop+SimulatorControlAdditions.h"
@@ -72,7 +73,7 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
 
 - (FBSimulator *)allocateSimulatorWithConfiguration:(FBSimulatorConfiguration *)configuration error:(NSError **)error
 {
-  FBSimulator *simulator = [self createSimulatorWithConfiguration:configuration error:error];
+  FBSimulator *simulator = [self findOrCreateSimulatorWithConfiguration:configuration error:error];
   if (!simulator) {
     return nil;
   }
@@ -90,7 +91,7 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
 
   // Killing is a pre-requesite for deleting/erasing
   NSError *innerError = nil;
-  if (![self killSimulators:@[simulator] withError:&innerError]) {
+  if (![self.terminationStrategy killSimulators:@[simulator] withError:&innerError]) {
     return [FBSimulatorError failBoolWithError:innerError description:@"Failed to Free Device in Killing Device" errorOut:error];
   }
 
@@ -116,35 +117,12 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
 
 - (NSArray *)killAllWithError:(NSError **)error
 {
-  NSString *grepComponents = self.configuration.deviceSetPath
-   // If the path of the DeviceSet exists we can kill Simulator.app processes that contain it in their launch.
-   ? [NSString stringWithFormat:@"grep %@ |", self.configuration.deviceSetPath]
-   // If there isn't a custom set path, we have to kill all simulators that contain a CurrentDeviceUDID launch
-   : [NSString stringWithFormat:@"grep CurrentDeviceUDID | "];
-
-  NSError *innerError = nil;
-  if (![self blanketKillSimulatorAppsWithPidFilter:grepComponents error:&innerError]) {
-    return [[[FBSimulatorError describe:@"Failed to kill all with DeviceSetPath"] causedBy:innerError] fail:error];
-  }
-
-  return [self shutdownSimulators:[self.allSimulators copy] withError:error];
+  return [self.terminationStrategy killAllWithError:error];
 }
 
 - (BOOL)killSpuriousSimulatorsWithError:(NSError **)error
 {
-  // We should also kill Simulators that are in totally the wrong Simulator binary.
-  // Overlapping Xcode instances can't run on the same machine
-  NSError *innerError = nil;
-  if (![self blanketKillSimulatorsFromDifferentXcodeVersion:&innerError]) {
-    return [FBSimulatorError failBoolWithError:innerError errorOut:error];
-  }
-
-  // We want to blanket kill all the Simulator Applications that belong to the current Xcode version
-  // but aren't launched in the automated CurretnDeviceUDID way.
-  if (![self blanketKillSimulatorAppsWithPidFilter:@"grep -v CurrentDeviceUDID |" error:&innerError]) {
-    return [FBSimulatorError failBoolWithError:innerError errorOut:error];
-  }
-  return YES;
+  return [self.terminationStrategy killSpuriousSimulatorsWithError:error];
 }
 
 - (NSArray *)eraseAllWithError:(NSError **)error
@@ -164,17 +142,6 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
 }
 
 #pragma mark - Private
-
-- (BOOL)waitForSimulator:(FBSimulator *)simulator toChangeToState:(FBSimulatorState)simulatorState withError:(NSError **)error
-{
-  if (![simulator waitOnState:simulatorState]) {
-    return [[[FBSimulatorError
-      describeFormat:@"Simulator was not in expected %@ state, got %@", [FBSimulator stateStringFromSimulatorState:simulatorState], simulator.stateString]
-      inSimulator:simulator]
-      failBool:error];
-  }
-  return YES;
-}
 
 - (BOOL)eraseSimulator:(FBSimulator *)simulator withError:(NSError **)error
 {
@@ -209,17 +176,6 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
   return YES;
 }
 
-- (NSArray *)shutdownSimulators:(NSArray *)simulators withError:(NSError **)error
-{
-  NSError *innerError = nil;
-  for (FBSimulator *simulator in simulators) {
-    if (![self safeShutdown:simulator withError:&innerError]) {
-      return [FBSimulatorError failWithError:innerError errorOut:error];
-    }
-  }
-  return simulators;
-}
-
 - (NSArray *)deleteSimulators:(NSArray *)simulators withError:(NSError **)error
 {
   NSError *innerError = nil;
@@ -234,33 +190,11 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
   return [deletedSimulatorNames copy];
 }
 
-- (NSArray *)killSimulators:(NSArray *)simulators withError:(NSError **)error
-{
-  // Return early if there isn't anything to kill
-  if (simulators.count < 1) {
-    return simulators;
-  }
-
-  NSMutableString *grepComponents = [NSMutableString string];
-  [grepComponents appendFormat:@"grep CurrentDeviceUDID | grep"];
-  for (FBSimulator *simulator in simulators) {
-    [grepComponents appendFormat:@" -e %@ ", simulator.udid];
-  }
-  [grepComponents appendString:@" | "];
-
-  NSError *innerError = nil;
-  if (![self blanketKillSimulatorAppsWithPidFilter:grepComponents error:&innerError]) {
-    return [FBSimulatorError failWithError:innerError errorOut:error];
-  }
-
-  return [self shutdownSimulators:simulators withError:error];
-}
-
 - (NSArray *)eraseSimulators:(NSArray *)simulators withError:(NSError **)error
 {
   NSError *innerError = nil;
   // Kill all the simulators first
-  if (![self killSimulators:simulators withError:&innerError]) {
+  if (![self.terminationStrategy killSimulators:simulators withError:&innerError]) {
     return [FBSimulatorError failWithError:innerError errorOut:error];
   }
 
@@ -271,25 +205,6 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
     }
   }
   return simulators;
-}
-
-- (BOOL)safeShutdown:(FBSimulator *)simulator withError:(NSError **)error
-{
-  // Calling shutdown when already shutdown should be avoided (if detected).
-  if (simulator.state == FBSimulatorStateShutdown) {
-    return YES;
-  }
-
-  // Code 159 (Xcode 7) or 146 (Xcode 6) is 'Unable to shutdown device in current state: Shutdown'
-  // We can safely ignore this and then confirm that the simulator is shutdown
-  NSError *innerError = nil;
-  if (![simulator.device shutdownWithError:&innerError] && innerError.code != 159 && innerError.code != 146) {
-    return [FBSimulatorError failBoolWithError:innerError description:@"Simulator could not be shutdown" errorOut:error];
-  }
-
-  // We rely on the catch-all-non-manged kill command to do the dirty work.
-  // This will confirm that all these simulators are shutdown.
-  return [self waitForSimulator:simulator toChangeToState:FBSimulatorStateShutdown withError:error];
 }
 
 - (FBSimulator *)findOrCreateSimulatorWithConfiguration:(FBSimulatorConfiguration *)configuration error:(NSError **)error
@@ -336,14 +251,14 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
   // Xcode 7 has a 'Creating' step that we should wait on before confirming the simulator is ready.
   if (simulator.state == FBSimulatorStateCreating) {
     // Usually, the Simulator will be Shutdown after it transitions from 'Creating'. Extra cleanup if not.
-    if (![self waitForSimulator:simulator toChangeToState:FBSimulatorStateShutdown withError:&innerError]) {
+    if (![simulator waitOnState:FBSimulatorStateShutdown withError:&innerError]) {
       // In Xcode 7 we can get stuck in the 'Creating' step as well, its possible that we can recover from this by erasing
       if (![self eraseSimulator:simulator withError:&innerError]) {
         return [[[[FBSimulatorError describe:@"Failed trying to prepare simulator for usage by erasing a stuck 'Creating' simulator %@"] causedBy:innerError] inSimulator:simulator] failBool:error];
       }
 
       // If a device has been erased, we should wait for it to actually be shutdown. Ff it can't be, fail
-      if (![self waitForSimulator:simulator toChangeToState:FBSimulatorStateShutdown withError:&innerError]) {
+      if (![simulator waitOnState:FBSimulatorStateShutdown withError:&innerError]) {
         return [[[[FBSimulatorError describe:@"Failed trying to wait for a 'Creating' simulator to be shutdown after being erased"] causedBy:innerError] inSimulator:simulator] failBool:error];;
       }
     }
@@ -351,13 +266,13 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
 
   // If the device is not shutdown, kill it.
   if (simulator.state != FBSimulatorStateShutdown) {
-    if (![self killSimulators:@[simulator] withError:error]) {
+    if (![self.terminationStrategy killSimulators:@[simulator] withError:error]) {
       return [[[[FBSimulatorError describe:@"Failed to prepare simulator for usage when shutting it down"] causedBy:innerError] inSimulator:simulator] failBool:error];
     }
   }
 
   // Wait for it to be truly shutdown.
-  if (![self waitForSimulator:simulator toChangeToState:FBSimulatorStateShutdown withError:&innerError]) {
+  if (![simulator waitOnState:FBSimulatorStateShutdown withError:&innerError]) {
     return [[[[FBSimulatorError describe:@"Failed to wait for simulator preparation to shutdown device"] causedBy:innerError] inSimulator:simulator] failBool:error];
   }
 
@@ -374,54 +289,12 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
   return YES;
 }
 
+- (FBSimulatorTerminationStrategy *)terminationStrategy
+{
+  return [FBSimulatorTerminationStrategy usingKillOnConfiguration:self.configuration allSimulators:[self.allSimulators.array copy]];
+}
+
 #pragma mark - Helpers
-
-- (BOOL)blanketKillSimulatorsFromDifferentXcodeVersion:(NSError **)error
-{
-  // All Simulator Versions from Xcode 5-7, end in Simulator.app
-  // This command kills all Simulator.app binaries that *don't* match the current Simulator Binary Path.
-  NSString *simulatorBinaryPath = self.configuration.simulatorApplication.binary.path;
-  NSString *command = [NSString stringWithFormat:
-    @"pgrep -lf Simulator.app | grep -v %@ | awk '{print $1}'",
-   [FBTaskExecutor escapePathForShell:simulatorBinaryPath]
-  ];
-
-  NSError *innerError = nil;
-  if (![self blanketKillSimulatorAppsPidProducingCommand:command error:&innerError]) {
-    return [FBSimulatorError failBoolWithError:innerError description:@"Could not kill non-current xcode simulators" errorOut:error];
-  }
-  return YES;
-}
-
-- (BOOL)blanketKillSimulatorAppsWithPidFilter:(NSString *)pidFilter error:(NSError **)error
-{
-  NSString *simulatorBinaryPath = self.configuration.simulatorApplication.binary.path;
-  NSString *command = [NSString stringWithFormat:
-    @"pgrep -lf %@ | %@ awk '{print $1}'",
-    [FBTaskExecutor escapePathForShell:simulatorBinaryPath],
-    pidFilter
-  ];
-
-  NSError *innerError = nil;
-  if (![self blanketKillSimulatorAppsPidProducingCommand:command error:&innerError]) {
-    return [[[FBSimulatorError describeFormat:@"Could not kill simulators with pid filter %@", pidFilter] causedBy:innerError] failBool:error];
-  }
-  return YES;
-}
-
-- (BOOL)blanketKillSimulatorAppsPidProducingCommand:(NSString *)commandForPids error:(NSError **)error
-{
-  FBTaskExecutor *executor = FBTaskExecutor.sharedInstance;
-  NSString *command = [NSString stringWithFormat:
-    @"%@ | xargs kill",
-    commandForPids
-  ];
-  NSError *innerError = nil;
-  if (![executor executeShellCommand:command returningError:&innerError]) {
-    return [FBSimulatorError failBoolWithError:innerError description:@"Failed to Kill Simulator Process" errorOut:error];
-  }
-  return YES;
-}
 
 + (NSDictionary *)keySimulatorsByUDID:(NSOrderedSet *)simulators
 {

--- a/FBSimulatorControl/Management/FBSimulatorPool.m
+++ b/FBSimulatorControl/Management/FBSimulatorPool.m
@@ -209,6 +209,11 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
 
 - (FBSimulator *)findOrCreateSimulatorWithConfiguration:(FBSimulatorConfiguration *)configuration error:(NSError **)error
 {
+  BOOL alwaysCreate = (self.configuration.options & FBSimulatorManagementOptionsAlwaysCreateWhenAllocating) == FBSimulatorManagementOptionsAlwaysCreateWhenAllocating;
+  if (alwaysCreate) {
+    return [self createSimulatorWithConfiguration:configuration error:error];
+  }
+
   return [self findUnallocatedSimulatorWithConfiguration:configuration]
       ?: [self createSimulatorWithConfiguration:configuration error:error];
 }

--- a/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.h
+++ b/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.h
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class FBSimulatorControlConfiguration;
+
+/**
+ Strategies for Terminating Simulators
+ */
+@interface FBSimulatorTerminationStrategy : NSObject
+
+/**
+ A Strategy that uses Pgrep/Pkill.
+ */
++ (instancetype)usingKillOnConfiguration:(FBSimulatorControlConfiguration *)configuration allSimulators:(NSArray *)allSimulators;
+
+/**
+ Kills all of the Simulators the reciever's Device Set.
+
+ @param error an error out if any error occured.
+ @returns an array of the Simulators that this were killed if successful, nil otherwise.
+ */
+- (NSArray *)killAllWithError:(NSError **)error;
+
+/**
+ Kills the provided Simulators.
+
+ @param simulators the Simulators to Kill.
+ @param error an error out if any error occured.
+ @returns an array of the Simulators that this were killed if successful, nil otherwise.
+ */
+- (NSArray *)killSimulators:(NSArray *)simulators withError:(NSError **)error;
+
+/**
+ Kills all of the Simulators that are not launched by `FBSimulatorControl`. These can be Simulators launched via Xcode or Instruments.
+
+ @param error an error out if any error occured.
+ @returns an YES if successful, nil otherwise.
+ */
+- (BOOL)killSpuriousSimulatorsWithError:(NSError **)error;
+
+
+@end

--- a/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.m
+++ b/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.m
@@ -1,0 +1,220 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBSimulatorTerminationStrategy.h"
+
+#import <CoreSimulator/SimDevice.h>
+#import <CoreSimulator/SimDeviceSet.h>
+#import <CoreSimulator/SimDeviceType.h>
+#import <CoreSimulator/SimRuntime.h>
+
+#import "FBCoreSimulatorNotifier.h"
+#import "FBSimulator+Private.h"
+#import "FBSimulatorApplication.h"
+#import "FBSimulatorConfiguration+CoreSimulator.h"
+#import "FBSimulatorConfiguration.h"
+#import "FBSimulatorControl.h"
+#import "FBSimulatorControlConfiguration.h"
+#import "FBSimulatorError.h"
+#import "FBSimulatorInteraction.h"
+#import "FBSimulatorLogger.h"
+#import "FBSimulatorPredicates.h"
+#import "FBTaskExecutor+Convenience.h"
+#import "FBTaskExecutor.h"
+#import "NSRunLoop+SimulatorControlAdditions.h"
+
+@interface FBSimulatorTerminationStrategy ()
+
+- (NSArray *)safeShutdownSimulators:(NSArray *)simulators withError:(NSError **)error;
+
+@property (nonatomic, copy, readwrite) FBSimulatorControlConfiguration *configuration;
+@property (nonatomic, copy, readwrite) NSArray *allSimulators;
+
+@end
+
+@interface FBSimulatorTerminationStrategy_PKill : FBSimulatorTerminationStrategy
+
+@end
+
+@implementation FBSimulatorTerminationStrategy_PKill
+
+- (NSArray *)killAllWithError:(NSError **)error
+{
+  NSString *grepComponents = self.configuration.deviceSetPath
+    // If the path of the DeviceSet exists we can kill Simulator.app processes that contain it in their launch.
+    ? [NSString stringWithFormat:@"grep %@ |", self.configuration.deviceSetPath]
+    // If there isn't a custom set path, we have to kill all simulators that contain a CurrentDeviceUDID launch
+    : [NSString stringWithFormat:@"grep CurrentDeviceUDID | "];
+
+  NSError *innerError = nil;
+  if (![self blanketKillSimulatorAppsWithPidFilter:grepComponents error:&innerError]) {
+    return [[[FBSimulatorError describe:@"Failed to kill all with DeviceSetPath"] causedBy:innerError] fail:error];
+  }
+
+  return [self safeShutdownSimulators:[self.allSimulators copy] withError:error];
+}
+
+- (NSArray *)killSimulators:(NSArray *)simulators withError:(NSError **)error
+{
+  // Return early if there isn't anything to kill
+  if (simulators.count < 1) {
+    return simulators;
+  }
+
+  NSMutableString *grepComponents = [NSMutableString string];
+  [grepComponents appendFormat:@"grep CurrentDeviceUDID | grep"];
+  for (FBSimulator *simulator in simulators) {
+    [grepComponents appendFormat:@" -e %@ ", simulator.udid];
+  }
+  [grepComponents appendString:@" | "];
+
+  NSError *innerError = nil;
+  if (![self blanketKillSimulatorAppsWithPidFilter:grepComponents error:&innerError]) {
+    return [FBSimulatorError failWithError:innerError errorOut:error];
+  }
+
+  return [self safeShutdownSimulators:simulators withError:error];
+}
+
+- (BOOL)killSpuriousSimulatorsWithError:(NSError **)error
+{
+  // We should also kill Simulators that are in totally the wrong Simulator binary.
+  // Overlapping Xcode instances can't run on the same machine
+  NSError *innerError = nil;
+  if (![self blanketKillSimulatorsFromDifferentXcodeVersion:&innerError]) {
+    return [FBSimulatorError failBoolWithError:innerError errorOut:error];
+  }
+
+  // We want to blanket kill all the Simulator Applications that belong to the current Xcode version
+  // but aren't launched in the automated CurretnDeviceUDID way.
+  if (![self blanketKillSimulatorAppsWithPidFilter:@"grep -v CurrentDeviceUDID |" error:&innerError]) {
+    return [FBSimulatorError failBoolWithError:innerError errorOut:error];
+  }
+  return YES;
+}
+
+- (BOOL)blanketKillSimulatorsFromDifferentXcodeVersion:(NSError **)error
+{
+  // All Simulator Versions from Xcode 5-7, end in Simulator.app
+  // This command kills all Simulator.app binaries that *don't* match the current Simulator Binary Path.
+  NSString *simulatorBinaryPath = self.configuration.simulatorApplication.binary.path;
+  NSString *command = [NSString stringWithFormat:
+    @"pgrep -lf Simulator.app | grep -v %@ | awk '{print $1}'",
+    [FBTaskExecutor escapePathForShell:simulatorBinaryPath]
+  ];
+
+  NSError *innerError = nil;
+  if (![self blanketKillSimulatorAppsPidProducingCommand:command error:&innerError]) {
+    return [FBSimulatorError failBoolWithError:innerError description:@"Could not kill non-current xcode simulators" errorOut:error];
+  }
+  return YES;
+}
+
+- (BOOL)blanketKillSimulatorAppsWithPidFilter:(NSString *)pidFilter error:(NSError **)error
+{
+  NSString *simulatorBinaryPath = self.configuration.simulatorApplication.binary.path;
+  NSString *command = [NSString stringWithFormat:
+    @"pgrep -lf %@ | %@ awk '{print $1}'",
+    [FBTaskExecutor escapePathForShell:simulatorBinaryPath],
+    pidFilter
+  ];
+
+  NSError *innerError = nil;
+  if (![self blanketKillSimulatorAppsPidProducingCommand:command error:&innerError]) {
+    return [[[FBSimulatorError describeFormat:@"Could not kill simulators with pid filter %@", pidFilter] causedBy:innerError] failBool:error];
+  }
+  return YES;
+}
+
+- (BOOL)blanketKillSimulatorAppsPidProducingCommand:(NSString *)commandForPids error:(NSError **)error
+{
+  FBTaskExecutor *executor = FBTaskExecutor.sharedInstance;
+  NSString *command = [NSString stringWithFormat:
+    @"%@ | xargs kill",
+    commandForPids
+  ];
+  NSError *innerError = nil;
+  if (![executor executeShellCommand:command returningError:&innerError]) {
+    return [FBSimulatorError failBoolWithError:innerError description:@"Failed to Kill Simulator Process" errorOut:error];
+  }
+  return YES;
+}
+
+@end
+
+@implementation FBSimulatorTerminationStrategy
+
++ (instancetype)usingKillOnConfiguration:(FBSimulatorControlConfiguration *)configuration allSimulators:(NSArray *)allSimulators
+{
+  return [[FBSimulatorTerminationStrategy_PKill alloc] initWithConfiguration:configuration allSimulators:allSimulators];
+}
+
+- (instancetype)initWithConfiguration:(FBSimulatorControlConfiguration *)configuration allSimulators:(NSArray *)allSimulators
+{
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  _configuration = configuration;
+  _allSimulators = allSimulators;
+  return self;
+}
+
+- (NSArray *)killAllWithError:(NSError **)error
+{
+  NSAssert(NO, @"-[%@ %@] is abstract and should be overridden", NSStringFromClass(self.class), NSStringFromSelector(_cmd));
+  return nil;
+}
+
+- (NSArray *)killSimulators:(NSArray *)simulators withError:(NSError **)error
+{
+  NSAssert(NO, @"-[%@ %@] is abstract and should be overridden", NSStringFromClass(self.class), NSStringFromSelector(_cmd));
+  return nil;
+}
+
+- (BOOL)killSpuriousSimulatorsWithError:(NSError **)error
+{
+  NSAssert(NO, @"-[%@ %@] is abstract and should be overridden", NSStringFromClass(self.class), NSStringFromSelector(_cmd));
+  return NO;
+}
+
+#pragma mark Private
+
+- (NSArray *)safeShutdownSimulators:(NSArray *)simulators withError:(NSError **)error
+{
+  NSError *innerError = nil;
+  for (FBSimulator *simulator in simulators) {
+    if (![self safeShutdown:simulator withError:&innerError]) {
+      return [FBSimulatorError failWithError:innerError errorOut:error];
+    }
+  }
+  return simulators;
+}
+
+- (BOOL)safeShutdown:(FBSimulator *)simulator withError:(NSError **)error
+{
+  // Calling shutdown when already shutdown should be avoided (if detected).
+  if (simulator.state == FBSimulatorStateShutdown) {
+    return YES;
+  }
+
+  // Code 159 (Xcode 7) or 146 (Xcode 6) is 'Unable to shutdown device in current state: Shutdown'
+  // We can safely ignore this and then confirm that the simulator is shutdown
+  NSError *innerError = nil;
+  if (![simulator.device shutdownWithError:&innerError] && innerError.code != 159 && innerError.code != 146) {
+    return [FBSimulatorError failBoolWithError:innerError description:@"Simulator could not be shutdown" errorOut:error];
+  }
+
+  // We rely on the catch-all-non-manged kill command to do the dirty work.
+  // This will confirm that all these simulators are shutdown.
+  return [simulator waitOnState:FBSimulatorStateShutdown withError:error];
+}
+
+@end


### PR DESCRIPTION
Terminating Simulators is Hard™. This pulls out the nuts-and-bolts to a separate `FBSimulatorTerminationStrategy` class. The immediate effect is that `FBSimulatorPool` has a smaller footprint. Longer-term I'd like to look at using `sysctl` and `NSWorkspace` to terminate simulators in a more reasonable way.