### PR TITLE
Umbrella Header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 build/
 DerivedData
 
+## Filesystem
+*.DS_Store
+
 ## Various settings
 *.pbxuser
 !default.pbxuser

--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		877123F01BDA78AA00530B1E /* FBSimulatorVideoUploader.h in Headers */ = {isa = PBXBuildFile; fileRef = 877123EE1BDA78AA00530B1E /* FBSimulatorVideoUploader.h */; };
+		877123F01BDA78AA00530B1E /* FBSimulatorVideoUploader.h in Headers */ = {isa = PBXBuildFile; fileRef = 877123EE1BDA78AA00530B1E /* FBSimulatorVideoUploader.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		877123F11BDA78AA00530B1E /* FBSimulatorVideoUploader.m in Sources */ = {isa = PBXBuildFile; fileRef = 877123EF1BDA78AA00530B1E /* FBSimulatorVideoUploader.m */; };
 		877123F31BDA797800530B1E /* video0.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 877123F21BDA797800530B1E /* video0.mp4 */; };
 		AA017F271BD7770300F45E9D /* FBSimulatorLogsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA017F251BD7770300F45E9D /* FBSimulatorLogsTests.m */; };
@@ -142,6 +142,7 @@
 		AAD305191BD4CE020047376E /* FBSimulatorSessionInteractionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD305181BD4CE020047376E /* FBSimulatorSessionInteractionTests.m */; };
 		AAD3051F1BD4D5B10047376E /* photo0.png in Resources */ = {isa = PBXBuildFile; fileRef = AAD3051D1BD4D5B10047376E /* photo0.png */; };
 		AAD305201BD4D5B10047376E /* photo1.png in Resources */ = {isa = PBXBuildFile; fileRef = AAD3051E1BD4D5B10047376E /* photo1.png */; };
+		AADF65911BFF39E2000E3CDE /* FBSimulatorControl+Class.h in Headers */ = {isa = PBXBuildFile; fileRef = AADF65901BFF39E2000E3CDE /* FBSimulatorControl+Class.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E7A30F041AC72D1E00000000 /* DVTiPhoneSimulatorRemoteClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E291AC72D1E00000000 /* DVTiPhoneSimulatorRemoteClient.framework */; };
 		E7A30F0476B173B900000000 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E2976B173B900000000 /* Cocoa.framework */; };
 		E7A30F04A6018C7A00000000 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E29A6018C7A00000000 /* CoreGraphics.framework */; };
@@ -884,6 +885,7 @@
 		AAD305181BD4CE020047376E /* FBSimulatorSessionInteractionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorSessionInteractionTests.m; sourceTree = "<group>"; };
 		AAD3051D1BD4D5B10047376E /* photo0.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = photo0.png; sourceTree = "<group>"; };
 		AAD3051E1BD4D5B10047376E /* photo1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = photo1.png; sourceTree = "<group>"; };
+		AADF65901BFF39E2000E3CDE /* FBSimulatorControl+Class.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FBSimulatorControl+Class.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -980,6 +982,7 @@
 				AA4876D71BAC74B9007F7D23 /* FBSimulator+Queries.m */,
 				AA4876DB1BAC74B9007F7D23 /* FBSimulatorControl.h */,
 				AA4876DC1BAC74B9007F7D23 /* FBSimulatorControl.m */,
+				AADF65901BFF39E2000E3CDE /* FBSimulatorControl+Class.h */,
 				AA4876DA1BAC74B9007F7D23 /* FBSimulatorControl+Private.h */,
 				AA4876DE1BAC74B9007F7D23 /* FBSimulatorInteraction.h */,
 				AA4876DF1BAC74B9007F7D23 /* FBSimulatorInteraction.m */,
@@ -1846,6 +1849,7 @@
 				AA4877321BAC74B9007F7D23 /* FBSimulatorProcess+Private.h in Headers */,
 				AA4877581BAC74B9007F7D23 /* NSRunLoop+SimulatorControlAdditions.h in Headers */,
 				AA4877171BAC74B9007F7D23 /* FBSimulatorConfiguration+Convenience.h in Headers */,
+				AADF65911BFF39E2000E3CDE /* FBSimulatorControl+Class.h in Headers */,
 				AA48772A1BAC74B9007F7D23 /* FBSimulatorInteraction+Private.h in Headers */,
 				AA48772E1BAC74B9007F7D23 /* FBSimulatorPool.h in Headers */,
 				AA4877151BAC74B9007F7D23 /* FBProcessLaunchConfiguration.h in Headers */,

--- a/FBSimulatorControl/Management/FBSimulatorControl+Class.h
+++ b/FBSimulatorControl/Management/FBSimulatorControl+Class.h
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class FBSimulatorApplication;
+@class FBSimulatorConfiguration;
+@class FBSimulatorControlConfiguration;
+@class FBSimulatorPool;
+@class FBSimulatorSession;
+
+/**
+ An Abstraction over the mechanics of creating, launching and cleaning-up Simulators.
+ Currently only manages one Simulator.
+ */
+@interface FBSimulatorControl : NSObject
+
+/**
+ Returns the Singleton `FBSimulatorControl` instance. Takes a Mandatory bucket id in setup.
+
+ @param configuration the Configuration to setup the instance with.
+ @returns a shared instance with the first configuration.
+ */
++ (instancetype)sharedInstanceWithConfiguration:(FBSimulatorControlConfiguration *)configuration;
+
+/**
+ Creates and returns a new FBSimulatorSession instance. Does not launch the Simulator or any Applications.
+
+ @param configuration the Configuration of the Simulator to Launch.
+ @param error an outparam for describing any error that occured during the creation of the Session.
+ @returns A new `FBSimulatorSession` instance, or nil if an error occured.
+ */
+- (FBSimulatorSession *)createSessionForSimulatorConfiguration:(FBSimulatorConfiguration *)simulatorConfiguration error:(NSError **)error;
+
+@property (nonatomic, readonly) FBSimulatorPool *simulatorPool;
+
+@end

--- a/FBSimulatorControl/Management/FBSimulatorControl.h
+++ b/FBSimulatorControl/Management/FBSimulatorControl.h
@@ -7,37 +7,46 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <Foundation/Foundation.h>
-
-@class FBSimulatorApplication;
-@class FBSimulatorConfiguration;
-@class FBSimulatorControlConfiguration;
-@class FBSimulatorPool;
-@class FBSimulatorSession;
-
-/**
- An Abstraction over the mechanics of creating, launching and cleaning-up Simulators.
- Currently only manages one Simulator.
- */
-@interface FBSimulatorControl : NSObject
-
-/**
- Returns the Singleton `FBSimulatorControl` instance. Takes a Mandatory bucket id in setup.
-
- @param configuration the Configuration to setup the instance with.
- @returns a shared instance with the first configuration.
- */
-+ (instancetype)sharedInstanceWithConfiguration:(FBSimulatorControlConfiguration *)configuration;
-
-/**
- Creates and returns a new FBSimulatorSession instance. Does not launch the Simulator or any Applications.
-
- @param configuration the Configuration of the Simulator to Launch.
- @param error an outparam for describing any error that occured during the creation of the Session.
- @returns A new `FBSimulatorSession` instance, or nil if an error occured.
- */
-- (FBSimulatorSession *)createSessionForSimulatorConfiguration:(FBSimulatorConfiguration *)simulatorConfiguration error:(NSError **)error;
-
-@property (nonatomic, readonly) FBSimulatorPool *simulatorPool;
-
-@end
+#import <FBSimulatorControl/FBConcurrentCollectionOperations.h>
+#import <FBSimulatorControl/FBCoreSimulatorNotifier.h>
+#import <FBSimulatorControl/FBDispatchSourceNotifier.h>
+#import <FBSimulatorControl/FBInteraction.h>
+#import <FBSimulatorControl/FBProcessLaunchConfiguration+Helpers.h>
+#import <FBSimulatorControl/FBProcessLaunchConfiguration.h>
+#import <FBSimulatorControl/FBSimulator+Private.h>
+#import <FBSimulatorControl/FBSimulator+Queries.h>
+#import <FBSimulatorControl/FBSimulator.h>
+#import <FBSimulatorControl/FBSimulatorApplication.h>
+#import <FBSimulatorControl/FBSimulatorConfiguration+Convenience.h>
+#import <FBSimulatorControl/FBSimulatorConfiguration+CoreSimulator.h>
+#import <FBSimulatorControl/FBSimulatorConfiguration+Private.h>
+#import <FBSimulatorControl/FBSimulatorConfiguration.h>
+#import <FBSimulatorControl/FBSimulatorControl+Class.h>
+#import <FBSimulatorControl/FBSimulatorControlConfiguration.h>
+#import <FBSimulatorControl/FBSimulatorControlStaticConfiguration.h>
+#import <FBSimulatorControl/FBSimulatorError.h>
+#import <FBSimulatorControl/FBSimulatorInteraction.h>
+#import <FBSimulatorControl/FBSimulatorLogger.h>
+#import <FBSimulatorControl/FBSimulatorLogs.h>
+#import <FBSimulatorControl/FBSimulatorPool+Private.h>
+#import <FBSimulatorControl/FBSimulatorPool.h>
+#import <FBSimulatorControl/FBSimulatorPredicates.h>
+#import <FBSimulatorControl/FBSimulatorProcess.h>
+#import <FBSimulatorControl/FBSimulatorSession+Convenience.h>
+#import <FBSimulatorControl/FBSimulatorSession+Private.h>
+#import <FBSimulatorControl/FBSimulatorSession.h>
+#import <FBSimulatorControl/FBSimulatorSessionInteraction.h>
+#import <FBSimulatorControl/FBSimulatorSessionLifecycle.h>
+#import <FBSimulatorControl/FBSimulatorSessionState+Private.h>
+#import <FBSimulatorControl/FBSimulatorSessionState+Queries.h>
+#import <FBSimulatorControl/FBSimulatorSessionState.h>
+#import <FBSimulatorControl/FBSimulatorSessionStateGenerator.h>
+#import <FBSimulatorControl/FBSimulatorVideoRecorder.h>
+#import <FBSimulatorControl/FBSimulatorWindowTiler.h>
+#import <FBSimulatorControl/FBSimulatorWindowTilingStrategy.h>
+#import <FBSimulatorControl/FBTask.h>
+#import <FBSimulatorControl/FBTaskExecutor+Convenience.h>
+#import <FBSimulatorControl/FBTaskExecutor.h>
+#import <FBSimulatorControl/FBTerminationHandle.h>
+#import <FBSimulatorControl/FBWritableLog.h>
+#import <FBSimulatorControl/NSRunLoop+SimulatorControlAdditions.h>

--- a/FBSimulatorControl/Management/FBSimulatorControl.m
+++ b/FBSimulatorControl/Management/FBSimulatorControl.m
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import "FBSimulatorControl.h"
+#import "FBSimulatorControl+Class.h"
 #import "FBSimulatorControl+Private.h"
 
 #import "FBProcessLaunchConfiguration.h"

--- a/FBSimulatorControlTests/Fixtures/FBSimulatorControlFixtures.m
+++ b/FBSimulatorControlTests/Fixtures/FBSimulatorControlFixtures.m
@@ -9,9 +9,7 @@
 
 #import "FBSimulatorControlFixtures.h"
 
-#import <FBSImulatorControl/FBProcessLaunchConfiguration.h>
-
-#import <FBSimulatorControl/FBSimulatorApplication.h>
+#import <FBSimulatorControl/FBSimulatorControl.h>
 
 @implementation FBSimulatorControlFixtures
 

--- a/FBSimulatorControlTests/Tests/FBProcessLaunchConfigurationTests.m
+++ b/FBSimulatorControlTests/Tests/FBProcessLaunchConfigurationTests.m
@@ -9,8 +9,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import <FBSimulatorControl/FBProcessLaunchConfiguration.h>
-#import <FBSimulatorControl/FBSimulatorApplication.h>
+#import <FBSimulatorControl/FBSimulatorControl.h>
 
 @interface FBProcessLaunchConfigurationTests : XCTestCase
 

--- a/FBSimulatorControlTests/Tests/FBSimulatorApplicationTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorApplicationTests.m
@@ -9,7 +9,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import <FBSimulatorControl/FBSimulatorApplication.h>
+#import <FBSimulatorControl/FBSimulatorControl.h>
 
 #import "FBSimulatorControlFixtures.h"
 

--- a/FBSimulatorControlTests/Tests/FBSimulatorControlApplicationLaunchTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorControlApplicationLaunchTests.m
@@ -9,17 +9,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import <FBSimulatorControl/FBProcessLaunchConfiguration.h>
-#import <FBSimulatorControl/FBSimulator.h>
-#import <FBSimulatorControl/FBSimulatorApplication.h>
-#import <FBSimulatorControl/FBSimulatorConfiguration.h>
-#import <FBSimulatorControl/FBSimulatorControl+Private.h>
 #import <FBSimulatorControl/FBSimulatorControl.h>
-#import <FBSimulatorControl/FBSimulatorControlConfiguration.h>
-#import <FBSimulatorControl/FBSimulatorPool.h>
-#import <FBSimulatorControl/FBSimulatorSession.h>
-#import <FBSimulatorControl/FBSimulatorSessionInteraction.h>
-#import <FBSimulatorControl/FBSimulatorSessionLifecycle.h>
 
 #import "FBSimulatorControlAssertions.h"
 #import "FBSimulatorControlFixtures.h"

--- a/FBSimulatorControlTests/Tests/FBSimulatorControlConfigurationTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorControlConfigurationTests.m
@@ -9,8 +9,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import <FBSimulatorControl/FBSimulatorApplication.h>
-#import <FBSimulatorControl/FBSimulatorControlConfiguration.h>
+#import <FBSimulatorControl/FBSimulatorControl.h>
 
 @interface FBSimulatorControlConfigurationTests : XCTestCase
 

--- a/FBSimulatorControlTests/Tests/FBSimulatorControlSimulatorLaunchTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorControlSimulatorLaunchTests.m
@@ -9,20 +9,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import <FBSimulatorControl/FBSimulator+Queries.h>
-#import <FBSimulatorControl/FBSimulator.h>
-#import <FBSimulatorControl/FBSimulatorApplication.h>
-#import <FBSimulatorControl/FBSimulatorConfiguration.h>
-#import <FBSimulatorControl/FBSimulatorControl+Private.h>
 #import <FBSimulatorControl/FBSimulatorControl.h>
-#import <FBSimulatorControl/FBSimulatorControlConfiguration.h>
-#import <FBSimulatorControl/FBSimulatorControlStaticConfiguration.h>
-#import <FBSimulatorControl/FBSimulatorPool.h>
-#import <FBSimulatorControl/FBSimulatorSession.h>
-#import <FBSimulatorControl/FBSimulatorSessionInteraction.h>
-#import <FBSimulatorControl/FBSimulatorSessionLifecycle.h>
-#import <FBSimulatorControl/FBSimulatorSessionState+Queries.h>
-#import <FBSimulatorControl/FBSimulatorSessionState.h>
 
 #import "FBSimulatorControlAssertions.h"
 #import "FBSimulatorControlTestCase.h"

--- a/FBSimulatorControlTests/Tests/FBSimulatorLogsTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorLogsTests.m
@@ -9,14 +9,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import <FBSimulatorControl/FBProcessLaunchConfiguration+Helpers.h>
-#import <FBSimulatorControl/FBSimulator.h>
-#import <FBSimulatorControl/FBSimulatorLogs+Private.h>
-#import <FBSimulatorControl/FBSimulatorLogs.h>
-#import <FBSimulatorControl/FBSimulatorSession.h>
-#import <FBSimulatorControl/FBSimulatorSessionInteraction.h>
-#import <FBSimulatorControl/FBWritableLog.h>
-#import <FBSimulatorControl/NSRunLoop+SimulatorControlAdditions.h>
+#import <FBSimulatorControl/FBSimulatorControl.h>
 
 #import "FBSimulatorControlAssertions.h"
 #import "FBSimulatorControlFixtures.h"

--- a/FBSimulatorControlTests/Tests/FBSimulatorPoolAllocationTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorPoolAllocationTests.m
@@ -9,15 +9,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import <FBSimulatorControl/FBSimulator.h>
-#import <FBSimulatorControl/FBSimulatorApplication.h>
-#import <FBSimulatorControl/FBSimulatorConfiguration.h>
-#import <FBSimulatorControl/FBSimulatorControl+Private.h>
 #import <FBSimulatorControl/FBSimulatorControl.h>
-#import <FBSimulatorControl/FBSimulatorControlConfiguration.h>
-#import <FBSimulatorControl/FBSimulatorPool+Private.h>
-#import <FBSimulatorControl/FBSimulatorPool.h>
-#import <FBSimulatorControl/FBSimulatorSession.h>
 
 #import "FBSimulatorControlTestCase.h"
 

--- a/FBSimulatorControlTests/Tests/FBSimulatorSessionInteractionTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorSessionInteractionTests.m
@@ -9,12 +9,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import <FBSimulatorControl/FBSimulator.h>
-#import <FBSimulatorControl/FBSimulatorApplication.h>
 #import <FBSimulatorControl/FBSimulatorControl.h>
-#import <FBSimulatorControl/FBSimulatorPool.h>
-#import <FBSimulatorControl/FBSimulatorSession.h>
-#import <FBSimulatorControl/FBSimulatorSessionInteraction.h>
 
 #import "FBSimulatorControlAssertions.h"
 #import "FBSimulatorControlFixtures.h"

--- a/FBSimulatorControlTests/Tests/FBSimulatorSessionLifecycleTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorSessionLifecycleTests.m
@@ -9,20 +9,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import <FBSimulatorControl/FBProcessLaunchConfiguration.h>
-#import <FBSimulatorControl/FBSimulator.h>
-#import <FBSimulatorControl/FBSimulatorApplication.h>
-#import <FBSimulatorControl/FBSimulatorConfiguration.h>
-#import <FBSimulatorControl/FBSimulatorControl+Private.h>
 #import <FBSimulatorControl/FBSimulatorControl.h>
-#import <FBSimulatorControl/FBSimulatorControlConfiguration.h>
-#import <FBSimulatorControl/FBSimulatorProcess.h>
-#import <FBSimulatorControl/FBSimulatorSession.h>
-#import <FBSimulatorControl/FBSimulatorSessionInteraction.h>
-#import <FBSimulatorControl/FBSimulatorSessionLifecycle.h>
-#import <FBSimulatorControl/FBSimulatorSessionState+Queries.h>
-#import <FBSimulatorControl/FBSimulatorSessionState.h>
-#import <FBSimulatorControl/NSRunLoop+SimulatorControlAdditions.h>
 
 #import "FBSimulatorControlAssertions.h"
 #import "FBSimulatorControlTestCase.h"

--- a/FBSimulatorControlTests/Tests/FBSimulatorStateTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorStateTests.m
@@ -9,16 +9,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import <FBSimulatorControl/FBProcessLaunchConfiguration.h>
-#import <FBSimulatorControl/FBSimulator.h>
-#import <FBSimulatorControl/FBSimulator+Private.h>
-#import <FBSimulatorControl/FBSimulatorApplication.h>
-#import <FBSimulatorControl/FBSimulatorControlConfiguration.h>
-#import <FBSimulatorControl/FBSimulatorPool.h>
-#import <FBSimulatorControl/FBSimulatorSession.h>
-#import <FBSimulatorControl/FBSimulatorSession+Private.h>
-#import <FBSimulatorControl/FBSimulatorSessionState+Queries.h>
-#import <FBSimulatorControl/FBSimulatorSessionStateGenerator.h>
+#import <FBSimulatorControl/FBSimulatorControl.h>
 
 #import "CoreSimulatorDoubles.h"
 

--- a/FBSimulatorControlTests/Tests/FBSimulatorTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorTests.m
@@ -9,20 +9,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import <FBSimulatorControl/FBProcessLaunchConfiguration.h>
-#import <FBSimulatorControl/FBSimulator+Private.h>
-#import <FBSimulatorControl/FBSimulator.h>
-#import <FBSimulatorControl/FBSimulatorApplication.h>
-#import <FBSimulatorControl/FBSimulatorConfiguration.h>
-#import <FBSimulatorControl/FBSimulatorControl+Private.h>
 #import <FBSimulatorControl/FBSimulatorControl.h>
-#import <FBSimulatorControl/FBSimulatorControlConfiguration.h>
-#import <FBSimulatorControl/FBSimulatorPool.h>
-#import <FBSimulatorControl/FBSimulatorSession.h>
-#import <FBSimulatorControl/FBSimulatorSessionInteraction.h>
-#import <FBSimulatorControl/FBSimulatorSessionLifecycle.h>
-#import <FBSimulatorControl/FBSimulatorSessionState+Queries.h>
-#import <FBSimulatorControl/FBSimulatorSessionState.h>
 
 #import "FBSimulatorControlTestCase.h"
 

--- a/FBSimulatorControlTests/Tests/FBSimulatorTilingStrategyTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorTilingStrategyTests.m
@@ -9,7 +9,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import <FBSimulatorControl/FBSimulatorWindowTilingStrategy.h>
+#import <FBSimulatorControl/FBSimulatorControl.h>
 
 @interface FBSimulatorTilingStrategyTests : XCTestCase
 

--- a/FBSimulatorControlTests/Tests/FBSimulatorVideoRecorderTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorVideoRecorderTests.m
@@ -9,20 +9,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import <FBSimulatorControl/FBProcessLaunchConfiguration.h>
-#import <FBSimulatorControl/FBSimulator.h>
-#import <FBSimulatorControl/FBSimulatorApplication.h>
-#import <FBSimulatorControl/FBSimulatorConfiguration.h>
-#import <FBSimulatorControl/FBSimulatorControl+Private.h>
 #import <FBSimulatorControl/FBSimulatorControl.h>
-#import <FBSimulatorControl/FBSimulatorControlConfiguration.h>
-#import <FBSimulatorControl/FBSimulatorPool+Private.h>
-#import <FBSimulatorControl/FBSimulatorPool.h>
-#import <FBSimulatorControl/FBSimulatorSession.h>
-#import <FBSimulatorControl/FBSimulatorSessionInteraction.h>
-#import <FBSimulatorControl/FBSimulatorSessionState.h>
-#import <FBSimulatorControl/FBSimulatorVideoRecorder.h>
-#import <FBSimulatorControl/NSRunLoop+SimulatorControlAdditions.h>
 
 #import "FBSimulatorControlAssertions.h"
 #import "FBSimulatorControlTestCase.h"

--- a/FBSimulatorControlTests/Tests/FBSimulatorWindowTilingTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorWindowTilingTests.m
@@ -10,21 +10,7 @@
 #import <XCTest/XCTest.h>
 #import <AppKit/AppKit.h>
 
-#import <FBSimulatorControl/FBSimulator+Queries.h>
-#import <FBSimulatorControl/FBSimulator.h>
-#import <FBSimulatorControl/FBSimulatorApplication.h>
-#import <FBSimulatorControl/FBSimulatorConfiguration.h>
-#import <FBSimulatorControl/FBSimulatorControl+Private.h>
 #import <FBSimulatorControl/FBSimulatorControl.h>
-#import <FBSimulatorControl/FBSimulatorControlConfiguration.h>
-#import <FBSimulatorControl/FBSimulatorPool.h>
-#import <FBSimulatorControl/FBSimulatorSession.h>
-#import <FBSimulatorControl/FBSimulatorSessionInteraction.h>
-#import <FBSimulatorControl/FBSimulatorSessionLifecycle.h>
-#import <FBSimulatorControl/FBSimulatorSessionState+Queries.h>
-#import <FBSimulatorControl/FBSimulatorSessionState.h>
-#import <FBSimulatorControl/FBSimulatorWindowTiler.h>
-#import <FBSimulatorControl/FBSimulatorWindowTilingStrategy.h>
 
 #import "FBSimulatorControlTestCase.h"
 

--- a/FBSimulatorControlTests/Tests/FBTaskExecutorTests.m
+++ b/FBSimulatorControlTests/Tests/FBTaskExecutorTests.m
@@ -9,7 +9,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import <FBSimulatorControl/FBTaskExecutor.h>
+#import <FBSimulatorControl/FBSimulatorControl.h>
 
 @interface FBTaskExecutorTests : XCTestCase
 

--- a/FBSimulatorControlTests/Tests/FBWritableLogTests.m
+++ b/FBSimulatorControlTests/Tests/FBWritableLogTests.m
@@ -9,7 +9,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "FBWritableLog.h"
+#import <FBSimulatorControl/FBSimulatorControl.h>
 
 @interface FBWritableLogTests : XCTestCase
 


### PR DESCRIPTION
Creates an Umbrella Header so that consumers of `FBSimulatorControl` can easily import all the good stuff. Creates a Module Map so that `FBSimulatorControl` can be used from Swift.

All headers `#import` with Framework Import style.