### PR TITLE
Add FBProcessQuery

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -22,11 +22,14 @@
 		AA017F581BD7787300F45E9D /* libShimulator.dylib in Resources */ = {isa = PBXBuildFile; fileRef = AA017F4C1BD7784700F45E9D /* libShimulator.dylib */; };
 		AA01F46D1BFF0A1B000B5939 /* FBSimulatorTerminationStrategy.h in Headers */ = {isa = PBXBuildFile; fileRef = AA01F46B1BFF0A1B000B5939 /* FBSimulatorTerminationStrategy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA01F46E1BFF0A1B000B5939 /* FBSimulatorTerminationStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = AA01F46C1BFF0A1B000B5939 /* FBSimulatorTerminationStrategy.m */; };
+		AA01F4711BFF0EE7000B5939 /* FBProcessQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = AA01F46F1BFF0EE7000B5939 /* FBProcessQuery.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA01F4721BFF0EE7000B5939 /* FBProcessQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = AA01F4701BFF0EE7000B5939 /* FBProcessQuery.m */; };
 		AA111CC21BBE662E0054AFDD /* FBTaskExecutorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA111CC11BBE662E0054AFDD /* FBTaskExecutorTests.m */; };
 		AA111CCE1BBE7C5A0054AFDD /* CoreSimulatorDoubles.m in Sources */ = {isa = PBXBuildFile; fileRef = AA111CCD1BBE7C5A0054AFDD /* CoreSimulatorDoubles.m */; };
 		AA3230CB1BDA387700C5BA01 /* FBSimulatorControlAssertions.m in Sources */ = {isa = PBXBuildFile; fileRef = AA3230CA1BDA387700C5BA01 /* FBSimulatorControlAssertions.m */; };
 		AA377CF81BB3EC9C0058E26E /* FBSimulatorWindowHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = AA377CF61BB3EC9C0058E26E /* FBSimulatorWindowHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA377CF91BB3EC9C0058E26E /* FBSimulatorWindowHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = AA377CF71BB3EC9C0058E26E /* FBSimulatorWindowHelpers.m */; };
+		AA37C92B1C062BE800E38000 /* FBProcessQueryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA37C92A1C062BE800E38000 /* FBProcessQueryTests.m */; };
 		AA4877121BAC74B9007F7D23 /* FBProcessLaunchConfiguration+Helpers.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4876C41BAC74B9007F7D23 /* FBProcessLaunchConfiguration+Helpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA4877131BAC74B9007F7D23 /* FBProcessLaunchConfiguration+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = AA4876C51BAC74B9007F7D23 /* FBProcessLaunchConfiguration+Helpers.m */; };
 		AA4877141BAC74B9007F7D23 /* FBProcessLaunchConfiguration+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4876C61BAC74B9007F7D23 /* FBProcessLaunchConfiguration+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -58,9 +61,9 @@
 		AA48772F1BAC74B9007F7D23 /* FBSimulatorPool.m in Sources */ = {isa = PBXBuildFile; fileRef = AA4876E21BAC74B9007F7D23 /* FBSimulatorPool.m */; };
 		AA4877301BAC74B9007F7D23 /* FBSimulatorApplication.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4876E41BAC74B9007F7D23 /* FBSimulatorApplication.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA4877311BAC74B9007F7D23 /* FBSimulatorApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = AA4876E51BAC74B9007F7D23 /* FBSimulatorApplication.m */; };
-		AA4877321BAC74B9007F7D23 /* FBSimulatorProcess+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4876E61BAC74B9007F7D23 /* FBSimulatorProcess+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AA4877331BAC74B9007F7D23 /* FBSimulatorProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4876E71BAC74B9007F7D23 /* FBSimulatorProcess.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AA4877341BAC74B9007F7D23 /* FBSimulatorProcess.m in Sources */ = {isa = PBXBuildFile; fileRef = AA4876E81BAC74B9007F7D23 /* FBSimulatorProcess.m */; };
+		AA4877321BAC74B9007F7D23 /* FBProcessInfo+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4876E61BAC74B9007F7D23 /* FBProcessInfo+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA4877331BAC74B9007F7D23 /* FBProcessInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4876E71BAC74B9007F7D23 /* FBProcessInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA4877341BAC74B9007F7D23 /* FBProcessInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = AA4876E81BAC74B9007F7D23 /* FBProcessInfo.m */; };
 		AA4877351BAC74B9007F7D23 /* FBCoreSimulatorNotifier.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4876EA1BAC74B9007F7D23 /* FBCoreSimulatorNotifier.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA4877361BAC74B9007F7D23 /* FBCoreSimulatorNotifier.m in Sources */ = {isa = PBXBuildFile; fileRef = AA4876EB1BAC74B9007F7D23 /* FBCoreSimulatorNotifier.m */; };
 		AA4877371BAC74B9007F7D23 /* FBDispatchSourceNotifier.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4876EC1BAC74B9007F7D23 /* FBDispatchSourceNotifier.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -197,6 +200,8 @@
 		AA017F4C1BD7784700F45E9D /* libShimulator.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libShimulator.dylib; sourceTree = "<group>"; };
 		AA01F46B1BFF0A1B000B5939 /* FBSimulatorTerminationStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorTerminationStrategy.h; sourceTree = "<group>"; };
 		AA01F46C1BFF0A1B000B5939 /* FBSimulatorTerminationStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorTerminationStrategy.m; sourceTree = "<group>"; };
+		AA01F46F1BFF0EE7000B5939 /* FBProcessQuery.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBProcessQuery.h; sourceTree = "<group>"; };
+		AA01F4701BFF0EE7000B5939 /* FBProcessQuery.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBProcessQuery.m; sourceTree = "<group>"; };
 		AA111CC11BBE662E0054AFDD /* FBTaskExecutorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBTaskExecutorTests.m; sourceTree = "<group>"; };
 		AA111CCC1BBE7C5A0054AFDD /* CoreSimulatorDoubles.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreSimulatorDoubles.h; sourceTree = "<group>"; };
 		AA111CCD1BBE7C5A0054AFDD /* CoreSimulatorDoubles.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CoreSimulatorDoubles.m; sourceTree = "<group>"; };
@@ -204,6 +209,7 @@
 		AA3230CA1BDA387700C5BA01 /* FBSimulatorControlAssertions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorControlAssertions.m; sourceTree = "<group>"; };
 		AA377CF61BB3EC9C0058E26E /* FBSimulatorWindowHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorWindowHelpers.h; sourceTree = "<group>"; };
 		AA377CF71BB3EC9C0058E26E /* FBSimulatorWindowHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorWindowHelpers.m; sourceTree = "<group>"; };
+		AA37C92A1C062BE800E38000 /* FBProcessQueryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBProcessQueryTests.m; sourceTree = "<group>"; };
 		AA4876491BAC7399007F7D23 /* FBSimulatorControl-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "FBSimulatorControl-Info.plist"; sourceTree = "<group>"; };
 		AA4876C41BAC74B9007F7D23 /* FBProcessLaunchConfiguration+Helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FBProcessLaunchConfiguration+Helpers.h"; sourceTree = "<group>"; };
 		AA4876C51BAC74B9007F7D23 /* FBProcessLaunchConfiguration+Helpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "FBProcessLaunchConfiguration+Helpers.m"; sourceTree = "<group>"; };
@@ -236,9 +242,9 @@
 		AA4876E21BAC74B9007F7D23 /* FBSimulatorPool.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorPool.m; sourceTree = "<group>"; };
 		AA4876E41BAC74B9007F7D23 /* FBSimulatorApplication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorApplication.h; sourceTree = "<group>"; };
 		AA4876E51BAC74B9007F7D23 /* FBSimulatorApplication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorApplication.m; sourceTree = "<group>"; };
-		AA4876E61BAC74B9007F7D23 /* FBSimulatorProcess+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FBSimulatorProcess+Private.h"; sourceTree = "<group>"; };
-		AA4876E71BAC74B9007F7D23 /* FBSimulatorProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorProcess.h; sourceTree = "<group>"; };
-		AA4876E81BAC74B9007F7D23 /* FBSimulatorProcess.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorProcess.m; sourceTree = "<group>"; };
+		AA4876E61BAC74B9007F7D23 /* FBProcessInfo+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FBProcessInfo+Private.h"; sourceTree = "<group>"; };
+		AA4876E71BAC74B9007F7D23 /* FBProcessInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBProcessInfo.h; sourceTree = "<group>"; };
+		AA4876E81BAC74B9007F7D23 /* FBProcessInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBProcessInfo.m; sourceTree = "<group>"; };
 		AA4876EA1BAC74B9007F7D23 /* FBCoreSimulatorNotifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBCoreSimulatorNotifier.h; sourceTree = "<group>"; };
 		AA4876EB1BAC74B9007F7D23 /* FBCoreSimulatorNotifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBCoreSimulatorNotifier.m; sourceTree = "<group>"; };
 		AA4876EC1BAC74B9007F7D23 /* FBDispatchSourceNotifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBDispatchSourceNotifier.h; sourceTree = "<group>"; };
@@ -1002,9 +1008,9 @@
 			children = (
 				AA4876E41BAC74B9007F7D23 /* FBSimulatorApplication.h */,
 				AA4876E51BAC74B9007F7D23 /* FBSimulatorApplication.m */,
-				AA4876E61BAC74B9007F7D23 /* FBSimulatorProcess+Private.h */,
-				AA4876E71BAC74B9007F7D23 /* FBSimulatorProcess.h */,
-				AA4876E81BAC74B9007F7D23 /* FBSimulatorProcess.m */,
+				AA4876E61BAC74B9007F7D23 /* FBProcessInfo+Private.h */,
+				AA4876E71BAC74B9007F7D23 /* FBProcessInfo.h */,
+				AA4876E81BAC74B9007F7D23 /* FBProcessInfo.m */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1071,6 +1077,8 @@
 				AA8DF8C61BB18B3700CC0411 /* FBInteraction.h */,
 				AA8DF8C71BB18B3700CC0411 /* FBInteraction.m */,
 				AA8DF8C81BB18B3700CC0411 /* FBInteraction+Private.h */,
+				AA01F46F1BFF0EE7000B5939 /* FBProcessQuery.h */,
+				AA01F4701BFF0EE7000B5939 /* FBProcessQuery.m */,
 				AA74B9971BB014A200C1E59C /* FBSimulatorError.h */,
 				AA74B9981BB014A200C1E59C /* FBSimulatorError.m */,
 				AA48770E1BAC74B9007F7D23 /* FBSimulatorLogger.h */,
@@ -1682,6 +1690,7 @@
 			isa = PBXGroup;
 			children = (
 				AA74B99D1BB04A4300C1E59C /* FBProcessLaunchConfigurationTests.m */,
+				AA37C92A1C062BE800E38000 /* FBProcessQueryTests.m */,
 				AA51E4901BA1CA3C0053141E /* FBSimulatorApplicationTests.m */,
 				AA51E4911BA1CA3C0053141E /* FBSimulatorControlApplicationLaunchTests.m */,
 				AA51E4921BA1CA3C0053141E /* FBSimulatorControlConfigurationTests.m */,
@@ -1839,14 +1848,14 @@
 				AA48772D1BAC74B9007F7D23 /* FBSimulatorPool+Private.h in Headers */,
 				AA48774A1BAC74B9007F7D23 /* FBSimulatorSessionStateGenerator.h in Headers */,
 				AA01F46D1BFF0A1B000B5939 /* FBSimulatorTerminationStrategy.h in Headers */,
-				AA4877331BAC74B9007F7D23 /* FBSimulatorProcess.h in Headers */,
+				AA4877331BAC74B9007F7D23 /* FBProcessInfo.h in Headers */,
 				AA4877481BAC74B9007F7D23 /* FBSimulatorSessionState.h in Headers */,
 				AA4877431BAC74B9007F7D23 /* FBSimulatorSessionLifecycle.h in Headers */,
 				AA4877541BAC74B9007F7D23 /* FBTerminationHandle.h in Headers */,
 				AA48774D1BAC74B9007F7D23 /* FBTask.h in Headers */,
 				AA4877391BAC74B9007F7D23 /* FBSimulatorSession+Convenience.h in Headers */,
 				AA4877461BAC74B9007F7D23 /* FBSimulatorSessionState+Queries.h in Headers */,
-				AA4877321BAC74B9007F7D23 /* FBSimulatorProcess+Private.h in Headers */,
+				AA4877321BAC74B9007F7D23 /* FBProcessInfo+Private.h in Headers */,
 				AA4877581BAC74B9007F7D23 /* NSRunLoop+SimulatorControlAdditions.h in Headers */,
 				AA4877171BAC74B9007F7D23 /* FBSimulatorConfiguration+Convenience.h in Headers */,
 				AADF65911BFF39E2000E3CDE /* FBSimulatorControl+Class.h in Headers */,
@@ -1880,6 +1889,7 @@
 				AA017F361BD7772D00F45E9D /* FBConcurrentCollectionOperations.h in Headers */,
 				AA377CF81BB3EC9C0058E26E /* FBSimulatorWindowHelpers.h in Headers */,
 				AA017F2F1BD7771300F45E9D /* FBSimulatorLogs.h in Headers */,
+				AA01F4711BFF0EE7000B5939 /* FBProcessQuery.h in Headers */,
 				AA017F321BD7771300F45E9D /* FBWritableLog.h in Headers */,
 				AA017F311BD7771300F45E9D /* FBWritableLog+Private.h in Headers */,
 				AA8DF8C91BB18B3700CC0411 /* FBInteraction.h in Headers */,
@@ -1994,7 +2004,7 @@
 				AA01F46E1BFF0A1B000B5939 /* FBSimulatorTerminationStrategy.m in Sources */,
 				AA74B99A1BB014A200C1E59C /* FBSimulatorError.m in Sources */,
 				AA48773A1BAC74B9007F7D23 /* FBSimulatorSession+Convenience.m in Sources */,
-				AA4877341BAC74B9007F7D23 /* FBSimulatorProcess.m in Sources */,
+				AA4877341BAC74B9007F7D23 /* FBProcessInfo.m in Sources */,
 				AA48773F1BAC74B9007F7D23 /* FBSimulatorSessionInteraction+Diagnostics.m in Sources */,
 				AA4877291BAC74B9007F7D23 /* FBSimulatorControl.m in Sources */,
 				AA4877311BAC74B9007F7D23 /* FBSimulatorApplication.m in Sources */,
@@ -2004,6 +2014,7 @@
 				AA48774E1BAC74B9007F7D23 /* FBTask.m in Sources */,
 				AA48773D1BAC74B9007F7D23 /* FBSimulatorSession.m in Sources */,
 				AA48771D1BAC74B9007F7D23 /* FBSimulatorConfiguration.m in Sources */,
+				AA01F4721BFF0EE7000B5939 /* FBProcessQuery.m in Sources */,
 				AA48772F1BAC74B9007F7D23 /* FBSimulatorPool.m in Sources */,
 				AAB4AC221BB59B790046F6A1 /* FBSimulatorWindowTilingStrategy.m in Sources */,
 				AA4877241BAC74B9007F7D23 /* FBSimulator+Queries.m in Sources */,
@@ -2042,6 +2053,7 @@
 				AA51E49A1BA1CA3C0053141E /* FBSimulatorControlApplicationLaunchTests.m in Sources */,
 				AA8DF8C01BB1698000CC0411 /* FBSimulatorSessionLifecycleTests.m in Sources */,
 				AA51E49B1BA1CA3C0053141E /* FBSimulatorControlConfigurationTests.m in Sources */,
+				AA37C92B1C062BE800E38000 /* FBProcessQueryTests.m in Sources */,
 				AAB4AC241BBBC1A60046F6A1 /* FBSimulatorTilingStrategyTests.m in Sources */,
 				AAB4AC1C1BB586860046F6A1 /* FBSimulatorVideoRecorderTests.m in Sources */,
 				AA017F271BD7770300F45E9D /* FBSimulatorLogsTests.m in Sources */,

--- a/FBSimulatorControl/FBSimulatorControl.h
+++ b/FBSimulatorControl/FBSimulatorControl.h
@@ -43,8 +43,8 @@
 
 // Model
 #import <FBSimulatorControl/FBSimulatorApplication.h>
-#import <FBSimulatorControl/FBSimulatorProcess+Private.h>
-#import <FBSimulatorControl/FBSimulatorProcess.h>
+#import <FBSimulatorControl/FBProcessInfo+Private.h>
+#import <FBSimulatorControl/FBProcessInfo.h>
 
 
 // Notifications
@@ -83,8 +83,9 @@
 
 // Utility
 #import <FBSimulatorControl/FBConcurrentCollectionOperations.h>
-#import <FBSimulatorControl/FBInteraction.h>
 #import <FBSimulatorControl/FBInteraction+Private.h>
+#import <FBSimulatorControl/FBInteraction.h>
+#import <FBSimulatorCOntrol/FBProcessQuery.h>
 #import <FBSimulatorControl/FBSimulatorError.h>
 #import <FBSimulatorControl/FBSimulatorLogger.h>
 #import <FBSimulatorControl/NSRunLoop+SimulatorControlAdditions.h>

--- a/FBSimulatorControl/Logs/FBSimulatorLogs.h
+++ b/FBSimulatorControl/Logs/FBSimulatorLogs.h
@@ -32,6 +32,11 @@
 - (FBWritableLog *)systemLog;
 
 /**
+ The Bootstrap of the Simulator's launchd_sim.
+ */
+- (FBWritableLog *)simulatorBootstrap;
+
+/**
  Crash logs of all the subprocesses that have crashed in the Simulator after the specified date.
 
  @param date the earliest to search for crash reports. If nil will find reports regardless of date.

--- a/FBSimulatorControl/Logs/FBSimulatorLogs.m
+++ b/FBSimulatorControl/Logs/FBSimulatorLogs.m
@@ -14,6 +14,7 @@
 
 #import "FBConcurrentCollectionOperations.h"
 #import "FBSimulator.h"
+#import "FBSimulator+Queries.h"
 #import "FBSimulatorSession.h"
 #import "FBSimulatorSessionState+Queries.h"
 #import "FBTaskExecutor.h"
@@ -38,6 +39,19 @@
     updatePath:self.systemLogPath]
     updateShortName:@"system_log"]
     updateHumanReadableName:@"System Log"]
+    build];
+}
+
+- (FBWritableLog *)simulatorBootstrap
+{
+  NSString *expectedPath = [[self.simulator.device.setPath
+    stringByAppendingPathComponent:self.simulator.udid]
+    stringByAppendingPathComponent:@"/data/var/run/launchd_bootstrap.plist"];
+
+  return [[[[[FBWritableLogBuilder builder]
+    updatePath:expectedPath]
+    updateShortName:@"launchd_bootstrap"]
+    updateHumanReadableName:@"Launchd Bootstrap"]
     build];
 }
 

--- a/FBSimulatorControl/Management/FBSimulator+Private.h
+++ b/FBSimulatorControl/Management/FBSimulator+Private.h
@@ -16,7 +16,7 @@
 
 @property (nonatomic, strong, readwrite) SimDevice *device;
 @property (nonatomic, weak, readwrite) FBSimulatorPool *pool;
-@property (nonatomic, assign, readwrite) NSInteger processIdentifier;
+@property (nonatomic, assign, readwrite) pid_t processIdentifier;
 @property (nonatomic, copy, readwrite) FBSimulatorConfiguration *configuration;
 
 + (instancetype)inflateFromSimDevice:(SimDevice *)device configuration:(FBSimulatorConfiguration *)configuration pool:(FBSimulatorPool *)pool;

--- a/FBSimulatorControl/Management/FBSimulator+Queries.h
+++ b/FBSimulatorControl/Management/FBSimulator+Queries.h
@@ -12,14 +12,13 @@
 @interface FBSimulator (Queries)
 
 /**
- Returns YES if the reciever has an active launchd_sim process.
- The Simulator.app is mostly a shell, with launchd_sim launching all the Simulator services.
+ The Process Identifier of the Simulator's launchd_sim. -1 if it is not running
  */
-- (BOOL)hasActiveLaunchdSim;
+@property (nonatomic, assign, readonly) pid_t launchdSimProcessIdentifier;
 
 /**
- Returns an NSArray<id<FBSimulatorProcess>> of the subprocesses of launchd_sim.
+ Returns an NSArray<id<FBProcessInfo>> of the subprocesses of launchd_sim.
  */
-- (NSArray *)launchedProcesses;
+@property (nonatomic, copy, readonly) NSArray *launchedProcesses;
 
 @end

--- a/FBSimulatorControl/Management/FBSimulator+Queries.m
+++ b/FBSimulatorControl/Management/FBSimulator+Queries.m
@@ -21,7 +21,7 @@
 
 - (NSArray *)launchedProcesses
 {
-  NSInteger launchdSimProcessIdentifier = self.launchdSimProcessIdentifier;
+  pid_t launchdSimProcessIdentifier = self.launchdSimProcessIdentifier;
   if (launchdSimProcessIdentifier < 1) {
     return @[];
   }
@@ -34,7 +34,7 @@
   NSArray *checkingResults = [self.class.longFormPgrepRegex matchesInString:allProcesses options:0 range:NSMakeRange(0, allProcesses.length)];
   NSMutableArray *processes = [NSMutableArray array];
   for (NSTextCheckingResult *result in checkingResults) {
-    NSInteger processIdentifier = [[allProcesses substringWithRange:[result rangeAtIndex:1]] integerValue];
+    pid_t processIdentifier = [[allProcesses substringWithRange:[result rangeAtIndex:1]] integerValue];
     if (processIdentifier < 1) {
       continue;
     }

--- a/FBSimulatorControl/Management/FBSimulator+Queries.m
+++ b/FBSimulatorControl/Management/FBSimulator+Queries.m
@@ -9,50 +9,63 @@
 
 #import "FBSimulator+Queries.h"
 
-#import "FBSimulatorProcess.h"
+#import <CoreSimulator/SimDevice.h>
+
+#import "FBWritableLog.h"
+#import "FBSimulatorLogs.h"
+#import "FBProcessInfo.h"
 #import "FBTaskExecutor.h"
+#import "FBProcessQuery.h"
 
 @implementation FBSimulator (Queries)
 
-- (BOOL)hasActiveLaunchdSim
+- (pid_t)launchdSimProcessIdentifier
 {
-  return self.launchdSimProcessIdentifier > 1;
+  FBProcessQuery *query = [FBProcessQuery new];
+  pid_t process = [FBSimulator launchdSimProcessIdentifierForSimulatorLogs:self.logs query:query];
+  return process;
 }
 
 - (NSArray *)launchedProcesses
 {
-  pid_t launchdSimProcessIdentifier = self.launchdSimProcessIdentifier;
+  FBProcessQuery *query = [FBProcessQuery new];
+  pid_t launchdSimProcessIdentifier = [FBSimulator launchdSimProcessIdentifierForSimulatorLogs:self.logs query:query];
   if (launchdSimProcessIdentifier < 1) {
     return @[];
   }
 
-  NSString *allProcesses = [[[FBTaskExecutor.sharedInstance
-    taskWithLaunchPath:@"/usr/bin/pgrep" arguments:@[@"-lfP", [@(launchdSimProcessIdentifier) stringValue]]]
-    startSynchronouslyWithTimeout:10]
-    stdOut];
-
-  NSArray *checkingResults = [self.class.longFormPgrepRegex matchesInString:allProcesses options:0 range:NSMakeRange(0, allProcesses.length)];
-  NSMutableArray *processes = [NSMutableArray array];
-  for (NSTextCheckingResult *result in checkingResults) {
-    pid_t processIdentifier = [[allProcesses substringWithRange:[result rangeAtIndex:1]] integerValue];
-    if (processIdentifier < 1) {
-      continue;
-    }
-    NSString *launchPath = [allProcesses substringWithRange:[result rangeAtIndex:2]];
-    [processes addObject:[FBFoundProcess withProcessIdentifier:processIdentifier launchPath:launchPath]];
-  }
-  return [processes copy];
+  return [query subprocessesOf:launchdSimProcessIdentifier];
 }
 
-+ (NSRegularExpression *)longFormPgrepRegex
+#pragma mark Helpers
+
++ (pid_t)launchdSimProcessIdentifierForSimulatorLogs:(FBSimulatorLogs *)logs query:(FBProcessQuery *)query
 {
-  static dispatch_once_t onceToken;
-  static NSRegularExpression *regex;
-  dispatch_once(&onceToken, ^{
-    regex = [NSRegularExpression regularExpressionWithPattern:@"(\\d+) (.+)" options:0 error:nil];
-    NSCAssert(regex, @"Regex should compile");
-  });
-  return regex;
+  NSString *path = logs.simulatorBootstrap.asPath;
+  if (!path) {
+    return [self launchdSimProcessIdentifierForSystemLog:logs query:query];
+  }
+
+  pid_t pid = [query processWithOpenFileTo:path.UTF8String];
+  if (pid < 1) {
+    return [self launchdSimProcessIdentifierForSystemLog:logs query:query];
+  }
+  return pid;
+}
+
++ (pid_t)launchdSimProcessIdentifierForSystemLog:(FBSimulatorLogs *)logs query:(FBProcessQuery *)query
+{
+  NSString *path = logs.systemLog.asPath;
+  if (!path) {
+    return -1;
+  }
+
+  pid_t syslogdPid = [query processWithOpenFileTo:path.UTF8String];
+  if (syslogdPid < 1) {
+    return -1;
+  }
+
+  return [query parentOf:syslogdPid];
 }
 
 @end

--- a/FBSimulatorControl/Management/FBSimulator.h
+++ b/FBSimulatorControl/Management/FBSimulator.h
@@ -84,17 +84,6 @@ typedef NS_ENUM(NSInteger, FBSimulatorState) {
 @property (nonatomic, copy, readonly) NSString *dataDirectory;
 
 /**
- The Path to this Simulator's launchd_sim plist. Returns nil if the path does not exist.
- Expected to return a path when the Simulator is in the Booted state.
- */
-@property (nonatomic, copy, readonly) NSString *launchdBootstrapPath;
-
-/**
- The Process Identifier of the Simulator's launchd_sim. -1 if it is not running
- */
-@property (nonatomic, assign, readonly) pid_t launchdSimProcessIdentifier;
-
-/**
  The Application that the Simulator should be launched with.
  */
 @property (nonatomic, copy, readonly) FBSimulatorApplication *simulatorApplication;

--- a/FBSimulatorControl/Management/FBSimulator.h
+++ b/FBSimulatorControl/Management/FBSimulator.h
@@ -76,7 +76,7 @@ typedef NS_ENUM(NSInteger, FBSimulatorState) {
 /**
  The Process Identifier of the Simulator. -1 if it is not running
  */
-@property (nonatomic, assign, readonly) NSInteger processIdentifier;
+@property (nonatomic, assign, readonly) pid_t processIdentifier;
 
 /**
  The Directory that Contains the Simulator's Data
@@ -92,7 +92,7 @@ typedef NS_ENUM(NSInteger, FBSimulatorState) {
 /**
  The Process Identifier of the Simulator's launchd_sim. -1 if it is not running
  */
-@property (nonatomic, assign, readonly) NSInteger launchdSimProcessIdentifier;
+@property (nonatomic, assign, readonly) pid_t launchdSimProcessIdentifier;
 
 /**
  The Application that the Simulator should be launched with.

--- a/FBSimulatorControl/Management/FBSimulator.m
+++ b/FBSimulatorControl/Management/FBSimulator.m
@@ -14,6 +14,7 @@
 #import <CoreSimulator/SimDevice.h>
 #import <CoreSimulator/SimDeviceSet.h>
 
+#import "FBProcessQuery.h"
 #import "FBSimulatorConfiguration+CoreSimulator.h"
 #import "FBSimulatorConfiguration.h"
 #import "FBSimulatorControlConfiguration.h"
@@ -84,37 +85,6 @@ NSTimeInterval const FBSimulatorDefaultTimeout = 20;
 - (NSString *)dataDirectory
 {
   return self.device.dataPath;
-}
-
-- (NSString *)launchdBootstrapPath
-{
-  NSString *expectedPath = [[self.pool.deviceSet.setPath
-    stringByAppendingPathComponent:self.udid]
-    stringByAppendingPathComponent:@"/data/var/run/launchd_bootstrap.plist"];
-
-  if (![NSFileManager.defaultManager fileExistsAtPath:expectedPath]) {
-    return nil;
-  }
-  return expectedPath;
-}
-
-- (pid_t)launchdSimProcessIdentifier
-{
-  NSString *bootstrapPath = self.launchdBootstrapPath;
-  if (!bootstrapPath) {
-    return -1;
-  }
-
-  pid_t processIdentifier = [[[[FBTaskExecutor.sharedInstance
-    taskWithLaunchPath:@"/usr/bin/pgrep" arguments:@[@"-f", bootstrapPath]]
-    startSynchronouslyWithTimeout:5]
-    stdOut]
-    integerValue];
-
-  if (processIdentifier < 2) {
-    return -1;
-  }
-  return processIdentifier;
 }
 
 - (pid_t)processIdentifier

--- a/FBSimulatorControl/Management/FBSimulator.m
+++ b/FBSimulatorControl/Management/FBSimulator.m
@@ -98,14 +98,14 @@ NSTimeInterval const FBSimulatorDefaultTimeout = 20;
   return expectedPath;
 }
 
-- (NSInteger)launchdSimProcessIdentifier
+- (pid_t)launchdSimProcessIdentifier
 {
   NSString *bootstrapPath = self.launchdBootstrapPath;
   if (!bootstrapPath) {
     return -1;
   }
 
-  NSInteger processIdentifier = [[[[FBTaskExecutor.sharedInstance
+  pid_t processIdentifier = [[[[FBTaskExecutor.sharedInstance
     taskWithLaunchPath:@"/usr/bin/pgrep" arguments:@[@"-f", bootstrapPath]]
     startSynchronouslyWithTimeout:5]
     stdOut]
@@ -117,12 +117,12 @@ NSTimeInterval const FBSimulatorDefaultTimeout = 20;
   return processIdentifier;
 }
 
-- (NSInteger)processIdentifier
+- (pid_t)processIdentifier
 {
   return _processIdentifier > 1 ? _processIdentifier : [self inferredProcessIdentifier];
 }
 
-- (void)setProcessIdentifier:(NSInteger)processIdentifier
+- (void)setProcessIdentifier:(pid_t)processIdentifier
 {
   _processIdentifier = processIdentifier;
 }
@@ -255,13 +255,13 @@ NSTimeInterval const FBSimulatorDefaultTimeout = 20;
 
 #pragma mark Private
 
-- (NSInteger)inferredProcessIdentifier
+- (pid_t)inferredProcessIdentifier
 {
   // It's possible to find Simulators that have been launched with 'CurrentDeviceUDID' but not otherwise.
   // Simulators launched via Xcode have some sort of token with an argument such as '-psn_0_2466394'.
   // Finding these Simulators is currently unimplemented.
   NSString *expectedArgument = [NSString stringWithFormat:@"CurrentDeviceUDID %@", self.udid];
-  NSInteger processIdentifier = [[[[FBTaskExecutor.sharedInstance
+  pid_t processIdentifier = [[[[FBTaskExecutor.sharedInstance
     taskWithLaunchPath:@"/usr/bin/pgrep" arguments:@[@"-f", expectedArgument]]
     startSynchronouslyWithTimeout:5]
     stdOut]

--- a/FBSimulatorControl/Management/FBSimulatorPredicates.m
+++ b/FBSimulatorControl/Management/FBSimulatorPredicates.m
@@ -14,6 +14,7 @@
 #import <CoreSimulator/SimRuntime.h>
 
 #import "FBSimulator.h"
+#import "FBSimulator+Queries.h"
 #import "FBSimulatorConfiguration+CoreSimulator.h"
 #import "FBSimulatorControlConfiguration.h"
 #import "FBSimulatorPool+Private.h"

--- a/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.m
+++ b/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.m
@@ -25,6 +25,7 @@
 #import "FBSimulatorInteraction.h"
 #import "FBSimulatorLogger.h"
 #import "FBSimulatorPredicates.h"
+#import "FBProcessQuery.h"
 #import "FBTaskExecutor+Convenience.h"
 #import "FBTaskExecutor.h"
 #import "NSRunLoop+SimulatorControlAdditions.h"

--- a/FBSimulatorControl/Model/FBProcessInfo+Private.h
+++ b/FBSimulatorControl/Model/FBProcessInfo+Private.h
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <FBSimulatorControl/FBSimulatorProcess.h>
+#import <FBSimulatorControl/FBProcessInfo.h>
 
 @interface FBUserLaunchedProcess ()
 
@@ -22,5 +22,7 @@
 
 @property (nonatomic, assign, readwrite) pid_t processIdentifier;
 @property (nonatomic, copy, readwrite) NSString *launchPath;
+@property (nonatomic, copy, readwrite) NSArray *arguments;
+@property (nonatomic, copy, readwrite) NSDictionary *environment;
 
 @end

--- a/FBSimulatorControl/Model/FBProcessInfo.h
+++ b/FBSimulatorControl/Model/FBProcessInfo.h
@@ -11,7 +11,7 @@
 
 @class FBProcessLaunchConfiguration;
 
-@protocol FBSimulatorProcess <NSObject>
+@protocol FBProcessInfo <NSObject>
 
 /**
  The Process Identifier for the running process
@@ -23,13 +23,23 @@
  */
 @property (nonatomic, copy, readonly) NSString *launchPath;
 
+/**
+ An NSArray<NSString *> of the launch arguments of the process.
+ */
+@property (nonatomic, copy, readonly) NSArray *arguments;
+
+/**
+ An NSDictionary<NSString *, NSString *> of the environment of the process.
+ */
+@property (nonatomic, copy, readonly) NSDictionary *environment;
+
 @end
 
 /**
  An Object representing the current state of a process launched via FBSimulatorControl
  Implements equality to uniquely identify a launched process.
  */
-@interface FBUserLaunchedProcess : NSObject <FBSimulatorProcess, NSCopying>
+@interface FBUserLaunchedProcess : NSObject <FBProcessInfo, NSCopying>
 
 /**
  The Date the Process was launched
@@ -37,8 +47,7 @@
 @property (nonatomic, copy, readonly) NSDate *launchDate;
 
 /**
- The Launch Config of the Launched Process
- */
+  */
 @property (nonatomic, copy, readonly) FBProcessLaunchConfiguration *launchConfiguration;
 
 /**
@@ -52,8 +61,6 @@
  An Object representing the current state of a process launched automatically by the Simulator.
  Implements equality to uniquely identify a launched process.
  */
-@interface FBFoundProcess : NSObject <FBSimulatorProcess, NSCopying>
-
-+ (instancetype)withProcessIdentifier:(pid_t)processIdentifier launchPath:(NSString *)launchPath;
+@interface FBFoundProcess : NSObject <FBProcessInfo, NSCopying>
 
 @end

--- a/FBSimulatorControl/Model/FBProcessInfo.m
+++ b/FBSimulatorControl/Model/FBProcessInfo.m
@@ -7,8 +7,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import "FBSimulatorProcess.h"
-#import "FBSimulatorProcess+Private.h"
+#import "FBProcessInfo.h"
+#import "FBProcessInfo+Private.h"
 
 #import "FBProcessLaunchConfiguration.h"
 
@@ -29,6 +29,16 @@
   state.launchDate = self.launchDate;
   state.diagnostics = self.diagnostics;
   return state;
+}
+
+- (NSArray *)arguments
+{
+  return self.launchConfiguration.arguments;
+}
+
+- (NSDictionary *)environment
+{
+  return self.launchConfiguration.environment;
 }
 
 - (NSUInteger)hash
@@ -78,23 +88,22 @@
 
 @synthesize launchPath = _launchPath;
 @synthesize processIdentifier = _processIdentifier;
-
-+ (instancetype)withProcessIdentifier:(pid_t)processIdentifier launchPath:(NSString *)launchPath
-{
-  FBFoundProcess *process = [self new];
-  process.processIdentifier = processIdentifier;
-  process.launchPath = launchPath;
-  return process;
-}
+@synthesize arguments = _arguments;
+@synthesize environment = _environment;
 
 - (instancetype)copyWithZone:(NSZone *)zone
 {
-  return [FBFoundProcess withProcessIdentifier:self.processIdentifier launchPath:self.launchPath];
+  FBFoundProcess *process = [self.class new];
+  process.processIdentifier = self.processIdentifier;
+  process.launchPath = self.launchPath;
+  process.arguments = self.arguments;
+  process.environment = self.environment;
+  return process;
 }
 
 - (NSUInteger)hash
 {
-  return self.processIdentifier | self.launchPath.hash;
+  return self.processIdentifier | self.launchPath.hash | self.arguments.hash | self.environment.hash;
 }
 
 - (BOOL)isEqual:(FBUserLaunchedProcess *)object
@@ -103,15 +112,19 @@
     return NO;
   }
   return self.processIdentifier == object.processIdentifier &&
-         [self.launchPath isEqual:object.launchPath];
+         [self.launchPath isEqualToString:object.launchPath] &&
+         [self.arguments isEqualToArray:object.arguments] &&
+         [self.environment isEqualToDictionary:object.environment];
 }
 
 - (NSString *)description
 {
   return [NSString stringWithFormat:
-    @"Process %@ | PID %ld",
+    @"Process %@ | PID %ld | Arguments %@ | Environment %@",
     self.launchPath,
-    self.processIdentifier
+    self.processIdentifier,
+    self.arguments,
+    self.environment
   ];
 }
 

--- a/FBSimulatorControl/Model/FBSimulatorProcess+Private.h
+++ b/FBSimulatorControl/Model/FBSimulatorProcess+Private.h
@@ -11,7 +11,7 @@
 
 @interface FBUserLaunchedProcess ()
 
-@property (nonatomic, assign, readwrite) NSInteger processIdentifier;
+@property (nonatomic, assign, readwrite) pid_t processIdentifier;
 @property (nonatomic, copy, readwrite) NSDate *launchDate;
 @property (nonatomic, copy, readwrite) FBProcessLaunchConfiguration *launchConfiguration;
 @property (nonatomic, copy, readwrite) NSDictionary *diagnostics;
@@ -20,7 +20,7 @@
 
 @interface FBFoundProcess ()
 
-@property (nonatomic, assign, readwrite) NSInteger processIdentifier;
+@property (nonatomic, assign, readwrite) pid_t processIdentifier;
 @property (nonatomic, copy, readwrite) NSString *launchPath;
 
 @end

--- a/FBSimulatorControl/Model/FBSimulatorProcess.h
+++ b/FBSimulatorControl/Model/FBSimulatorProcess.h
@@ -16,7 +16,7 @@
 /**
  The Process Identifier for the running process
  */
-@property (nonatomic, assign, readonly) NSInteger processIdentifier;
+@property (nonatomic, assign, readonly) pid_t processIdentifier;
 
 /**
  The Launch Path of the running process
@@ -54,6 +54,6 @@
  */
 @interface FBFoundProcess : NSObject <FBSimulatorProcess, NSCopying>
 
-+ (instancetype)withProcessIdentifier:(NSInteger)processIdentifier launchPath:(NSString *)launchPath;
++ (instancetype)withProcessIdentifier:(pid_t)processIdentifier launchPath:(NSString *)launchPath;
 
 @end

--- a/FBSimulatorControl/Model/FBSimulatorProcess.m
+++ b/FBSimulatorControl/Model/FBSimulatorProcess.m
@@ -79,7 +79,7 @@
 @synthesize launchPath = _launchPath;
 @synthesize processIdentifier = _processIdentifier;
 
-+ (instancetype)withProcessIdentifier:(NSInteger)processIdentifier launchPath:(NSString *)launchPath
++ (instancetype)withProcessIdentifier:(pid_t)processIdentifier launchPath:(NSString *)launchPath
 {
   FBFoundProcess *process = [self new];
   process.processIdentifier = processIdentifier;

--- a/FBSimulatorControl/Notifications/FBDispatchSourceNotifier.h
+++ b/FBSimulatorControl/Notifications/FBDispatchSourceNotifier.h
@@ -22,6 +22,6 @@
  @param processIdentifier the Process Identifier of the Process to Monitor
  @param handler the handler to call when the process exits
  */
-+ (instancetype)processTerminationNotifierForProcessIdentifier:(NSInteger)processIdentifier handler:(void (^)(FBDispatchSourceNotifier *))handler;
++ (instancetype)processTerminationNotifierForProcessIdentifier:(pid_t)processIdentifier handler:(void (^)(FBDispatchSourceNotifier *))handler;
 
 @end

--- a/FBSimulatorControl/Notifications/FBDispatchSourceNotifier.m
+++ b/FBSimulatorControl/Notifications/FBDispatchSourceNotifier.m
@@ -17,7 +17,7 @@
 
 @implementation FBDispatchSourceNotifier
 
-+ (instancetype)processTerminationNotifierForProcessIdentifier:(NSInteger)processIdentifier handler:(void (^)(FBDispatchSourceNotifier *))handler
++ (instancetype)processTerminationNotifierForProcessIdentifier:(pid_t)processIdentifier handler:(void (^)(FBDispatchSourceNotifier *))handler
 {
   dispatch_source_t dispatchSource = dispatch_source_create(
     DISPATCH_SOURCE_TYPE_PROC,

--- a/FBSimulatorControl/Session/FBSimulatorSessionInteraction+Diagnostics.m
+++ b/FBSimulatorControl/Session/FBSimulatorSessionInteraction+Diagnostics.m
@@ -18,13 +18,13 @@
 #import "FBSimulatorSessionState+Queries.h"
 #import "FBTaskExecutor.h"
 
-typedef id<FBTask>(^FBDiagnosticTaskFactory)(FBTaskExecutor *executor, NSInteger processIdentifier);
+typedef id<FBTask>(^FBDiagnosticTaskFactory)(FBTaskExecutor *executor, pid_t processIdentifier);
 
 @implementation FBSimulatorSessionInteraction (Diagnostics)
 
 - (instancetype)sampleApplication:(FBSimulatorApplication *)application withDuration:(NSInteger)durationInSeconds frequency:(NSInteger)frequencyInMilliseconds
 {
-  return [self asyncDiagnosticOnApplication:application name:@"stack_sample" taskFactory:^ id<FBTask> (FBTaskExecutor *executor, NSInteger processIdentifier) {
+  return [self asyncDiagnosticOnApplication:application name:@"stack_sample" taskFactory:^ id<FBTask> (FBTaskExecutor *executor, pid_t processIdentifier) {
     return [executor
       taskWithLaunchPath:@"/usr/bin/sample"
       arguments:@[@(processIdentifier).stringValue, @(durationInSeconds).stringValue, @(frequencyInMilliseconds).stringValue]];
@@ -35,7 +35,7 @@ typedef id<FBTask>(^FBDiagnosticTaskFactory)(FBTaskExecutor *executor, NSInteger
 {
   NSParameterAssert(command);
 
-  return [self syncDiagnosticOnApplication:application name:@"lldb_command" taskFactory:^id<FBTask>(FBTaskExecutor *executor, NSInteger processIdentifier) {
+  return [self syncDiagnosticOnApplication:application name:@"lldb_command" taskFactory:^id<FBTask>(FBTaskExecutor *executor, pid_t processIdentifier) {
     return [[[[executor
       withLaunchPath:@"/usr/bin/lldb"]
       withArguments:@[@"-p", @(processIdentifier).stringValue, @"-o", command, @"-o", @"script import os; os._exit(1)"]]
@@ -52,7 +52,7 @@ typedef id<FBTask>(^FBDiagnosticTaskFactory)(FBTaskExecutor *executor, NSInteger
   NSParameterAssert(name);
   FBSimulatorSessionLifecycle *lifecycle = self.session.lifecycle;
 
-  return [self application:application interact:^ BOOL (NSInteger processIdentifier, NSError **error) {
+  return [self application:application interact:^ BOOL (pid_t processIdentifier, NSError **error) {
     id<FBTask> task = taskFactory(FBTaskExecutor.sharedInstance, processIdentifier);
     NSCAssert(task, @"Task should not be nil");
 
@@ -78,7 +78,7 @@ typedef id<FBTask>(^FBDiagnosticTaskFactory)(FBTaskExecutor *executor, NSInteger
   NSParameterAssert(name);
   FBSimulatorSessionLifecycle *lifecycle = self.session.lifecycle;
 
-  return [self application:application interact:^ BOOL (NSInteger processIdentifier, NSError **error) {
+  return [self application:application interact:^ BOOL (pid_t processIdentifier, NSError **error) {
     id<FBTask> task = taskFactory(FBTaskExecutor.sharedInstance, processIdentifier);
     NSCAssert(task, @"Task should not be nil");
 

--- a/FBSimulatorControl/Session/FBSimulatorSessionInteraction+Private.h
+++ b/FBSimulatorControl/Session/FBSimulatorSessionInteraction+Private.h
@@ -20,6 +20,6 @@ extern NSTimeInterval const FBSimulatorInteractionDefaultTimeout;
 /**
  Chains an interaction on an application process, for the given application.
  */
-- (instancetype)application:(FBSimulatorApplication *)application interact:(BOOL (^)(NSInteger processIdentifier, NSError **error))block;
+- (instancetype)application:(FBSimulatorApplication *)application interact:(BOOL (^)(pid_t processIdentifier, NSError **error))block;
 
 @end

--- a/FBSimulatorControl/Session/FBSimulatorSessionInteraction.m
+++ b/FBSimulatorControl/Session/FBSimulatorSessionInteraction.m
@@ -214,7 +214,7 @@ NSTimeInterval const FBSimulatorInteractionDefaultTimeout = 30;
       return [FBSimulatorError failBoolWithError:innerError errorOut:error];
     }
 
-    NSInteger processIdentifier = [simulator.device launchApplicationWithID:appLaunch.application.bundleID options:options error:&innerError];
+    pid_t processIdentifier = [simulator.device launchApplicationWithID:appLaunch.application.bundleID options:options error:&innerError];
     if (processIdentifier <= 0) {
       return [[[[FBSimulatorError describe:@"Failed to launch application"] causedBy:innerError] inSimulator:simulator] failBool:error];
     }
@@ -236,7 +236,7 @@ NSTimeInterval const FBSimulatorInteractionDefaultTimeout = 30;
   FBSimulatorSessionLifecycle *lifecycle = self.session.lifecycle;
   FBSimulator *simulator = self.session.simulator;
 
-  return [self application:application interact:^ BOOL (NSInteger processIdentifier, NSError **error) {
+  return [self application:application interact:^ BOOL (pid_t processIdentifier, NSError **error) {
     [lifecycle applicationWillTerminate:application];
     int returnCode = kill(processIdentifier, signo);
     if (returnCode != 0) {
@@ -266,7 +266,7 @@ NSTimeInterval const FBSimulatorInteractionDefaultTimeout = 30;
       return [FBSimulatorError failBoolWithError:innerError errorOut:error];
     }
 
-    NSInteger processIdentifier = [simulator.device
+    pid_t processIdentifier = [simulator.device
       spawnWithPath:agentLaunch.agentBinary.path
       options:options
       terminationHandler:NULL
@@ -378,7 +378,7 @@ NSTimeInterval const FBSimulatorInteractionDefaultTimeout = 30;
   return [options copy];
 }
 
-- (instancetype)application:(FBSimulatorApplication *)application interact:(BOOL (^)(NSInteger processIdentifier, NSError **error))block
+- (instancetype)application:(FBSimulatorApplication *)application interact:(BOOL (^)(pid_t processIdentifier, NSError **error))block
 {
   FBSimulatorSession *session = self.session;
   FBSimulator *simulator = self.session.simulator;

--- a/FBSimulatorControl/Session/FBSimulatorSessionLifecycle.h
+++ b/FBSimulatorControl/Session/FBSimulatorSessionLifecycle.h
@@ -112,7 +112,7 @@ extern NSString *const FBSimulatorSessionExpectedKey;
 /**
  Called when the Simulator starts.
  */
-- (void)simulator:(FBSimulator *)simulator didStartWithProcessIdentifier:(NSInteger)processIdentifier terminationHandle:(id<FBTerminationHandle>)terminationHandle;
+- (void)simulator:(FBSimulator *)simulator didStartWithProcessIdentifier:(pid_t)processIdentifier terminationHandle:(id<FBTerminationHandle>)terminationHandle;
 
 /**
  Called just before the Simulator is manually terminated.
@@ -122,7 +122,7 @@ extern NSString *const FBSimulatorSessionExpectedKey;
 /**
  Called when an agent has starts.
  */
-- (void)agentDidLaunch:(FBAgentLaunchConfiguration *)launchConfig didStartWithProcessIdentifier:(NSInteger)processIdentifier stdOut:(NSFileHandle *)stdOut stdErr:(NSFileHandle *)stdErr;
+- (void)agentDidLaunch:(FBAgentLaunchConfiguration *)launchConfig didStartWithProcessIdentifier:(pid_t)processIdentifier stdOut:(NSFileHandle *)stdOut stdErr:(NSFileHandle *)stdErr;
 
 /**
  Called just before the agent is manually terminated.
@@ -132,7 +132,7 @@ extern NSString *const FBSimulatorSessionExpectedKey;
 /**
  Called when an Application starts.
  */
-- (void)applicationDidLaunch:(FBApplicationLaunchConfiguration *)launchConfig didStartWithProcessIdentifier:(NSInteger)processIdentifier stdOut:(NSFileHandle *)stdOut stdErr:(NSFileHandle *)stdErr;
+- (void)applicationDidLaunch:(FBApplicationLaunchConfiguration *)launchConfig didStartWithProcessIdentifier:(pid_t)processIdentifier stdOut:(NSFileHandle *)stdOut stdErr:(NSFileHandle *)stdErr;
 
 /**
  Called just before an Application is manually terminated.

--- a/FBSimulatorControl/Session/FBSimulatorSessionLifecycle.m
+++ b/FBSimulatorControl/Session/FBSimulatorSessionLifecycle.m
@@ -78,7 +78,7 @@ NSString *const FBSimulatorSessionExpectedKey = @"expected";
   [self registerSimDeviceNotifier:simulator];
 }
 
-- (void)simulator:(FBSimulator *)simulator didStartWithProcessIdentifier:(NSInteger)processIdentifier terminationHandle:(id<FBTerminationHandle>)terminationHandle
+- (void)simulator:(FBSimulator *)simulator didStartWithProcessIdentifier:(pid_t)processIdentifier terminationHandle:(id<FBTerminationHandle>)terminationHandle
 {
   NSParameterAssert(terminationHandle);
   NSParameterAssert(self.simulatorTerminationHandle == nil);
@@ -123,7 +123,7 @@ NSString *const FBSimulatorSessionExpectedKey = @"expected";
 
 #pragma mark Agent
 
-- (void)agentDidLaunch:(FBAgentLaunchConfiguration *)launchConfig didStartWithProcessIdentifier:(NSInteger)processIdentifier stdOut:(NSFileHandle *)stdOut stdErr:(NSFileHandle *)stdErr
+- (void)agentDidLaunch:(FBAgentLaunchConfiguration *)launchConfig didStartWithProcessIdentifier:(pid_t)processIdentifier stdOut:(NSFileHandle *)stdOut stdErr:(NSFileHandle *)stdErr
 {
   NSParameterAssert(launchConfig);
   NSParameterAssert(processIdentifier > 0);
@@ -163,7 +163,7 @@ NSString *const FBSimulatorSessionExpectedKey = @"expected";
 
 #pragma mark Application
 
-- (void)applicationDidLaunch:(FBApplicationLaunchConfiguration *)launchConfig didStartWithProcessIdentifier:(NSInteger)processIdentifier stdOut:(NSFileHandle *)stdOut stdErr:(NSFileHandle *)stdErr
+- (void)applicationDidLaunch:(FBApplicationLaunchConfiguration *)launchConfig didStartWithProcessIdentifier:(pid_t)processIdentifier stdOut:(NSFileHandle *)stdOut stdErr:(NSFileHandle *)stdErr
 {
   NSParameterAssert(launchConfig);
   NSParameterAssert(processIdentifier > 0);
@@ -283,7 +283,7 @@ NSString *const FBSimulatorSessionExpectedKey = @"expected";
 
 #pragma mark Notifiers
 
-- (void)createNotifierForBinary:(FBSimulatorBinary *)binary onProcessIdentifier:(NSInteger)processIdentifier withHandler:( void(^)(FBSimulatorSessionLifecycle *) )handler
+- (void)createNotifierForBinary:(FBSimulatorBinary *)binary onProcessIdentifier:(pid_t)processIdentifier withHandler:( void(^)(FBSimulatorSessionLifecycle *) )handler
 {
   NSParameterAssert(self.notifiers[binary] == nil);
 

--- a/FBSimulatorControl/Session/FBSimulatorSessionState+Queries.h
+++ b/FBSimulatorControl/Session/FBSimulatorSessionState+Queries.h
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <FBSImulatorControl/FBSimulatorProcess.h>
+#import <FBSImulatorControl/FBProcessInfo.h>
 
 #import <FBSimulatorControl/FBSimulatorSessionState.h>
 

--- a/FBSimulatorControl/Session/FBSimulatorSessionStateGenerator.h
+++ b/FBSimulatorControl/Session/FBSimulatorSessionStateGenerator.h
@@ -40,7 +40,7 @@
 /**
  Creates Process State for the given launch config.
  */
-- (instancetype)update:(FBProcessLaunchConfiguration *)launchConfig withProcessIdentifier:(NSInteger)processIdentifier;
+- (instancetype)update:(FBProcessLaunchConfiguration *)launchConfig withProcessIdentifier:(pid_t)processIdentifier;
 
 /**
  Updates the diagnostic information about for a given launched process.

--- a/FBSimulatorControl/Session/FBSimulatorSessionStateGenerator.m
+++ b/FBSimulatorControl/Session/FBSimulatorSessionStateGenerator.m
@@ -50,7 +50,7 @@
   }];
 }
 
-- (instancetype)update:(FBProcessLaunchConfiguration *)launchConfig withProcessIdentifier:(NSInteger)processIdentifier
+- (instancetype)update:(FBProcessLaunchConfiguration *)launchConfig withProcessIdentifier:(pid_t)processIdentifier
 {
   return [self updateCurrentState:^ FBSimulatorSessionState * (FBSimulatorSessionState *state) {
     NSCParameterAssert(state.lifecycle != FBSimulatorSessionLifecycleStateNotStarted);

--- a/FBSimulatorControl/Session/FBSimulatorSessionStateGenerator.m
+++ b/FBSimulatorControl/Session/FBSimulatorSessionStateGenerator.m
@@ -11,7 +11,7 @@
 
 #import "FBSimulator.h"
 #import "FBSimulatorApplication.h"
-#import "FBSimulatorProcess+Private.h"
+#import "FBProcessInfo+Private.h"
 #import "FBSimulatorSessionState+Private.h"
 #import "FBSimulatorSessionState+Queries.h"
 

--- a/FBSimulatorControl/Tasks/FBTask.h
+++ b/FBSimulatorControl/Tasks/FBTask.h
@@ -47,7 +47,7 @@ extern NSTimeInterval const FBTaskDefaultTimeout;
 /**
  Returns the Process Identifier of the Launched Process.
  */
-- (NSInteger)processIdentifier;
+- (pid_t)processIdentifier;
 
 /**
  Returns a copy of the current state of stdout. May be called from any thread.

--- a/FBSimulatorControl/Tasks/FBTask.m
+++ b/FBSimulatorControl/Tasks/FBTask.m
@@ -102,7 +102,7 @@ NSTimeInterval const FBTaskDefaultTimeout = 30;
 
 #pragma mark Accessors
 
-- (NSInteger)processIdentifier
+- (pid_t)processIdentifier
 {
   return self.task.processIdentifier;
 }

--- a/FBSimulatorControl/Utility/FBProcessQuery.h
+++ b/FBSimulatorControl/Utility/FBProcessQuery.h
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+@protocol FBProcessInfo;
+
+/**
+ Queries for Processes running on the Host.
+ Should not be called from multiple threads since buffers are re-used internally.
+
+ Sharing a Query object and guaranteeing serialization of method calls
+ can be an effective way to reduce the number of allocations that are required.
+ */
+@interface FBProcessQuery : NSObject
+
+/**
+ A Query for obtaining all of the process information for a given processIdentifier.
+ */
+- (id<FBProcessInfo>)processInfoFor:(pid_t)processIdentifier;
+
+/**
+ Returns an NSArray<FBFoundProcess> of the parent.
+ */
+- (NSArray *)subprocessesOf:(pid_t)parent;
+
+/**
+ A Query for returning the processes with a given subtring in their launch path.
+ */
+- (NSArray *)processesWithLaunchPathSubstring:(NSString *)substring;
+
+/**
+ A Query for returning the first named child process of the provided parent.
+ */
+- (pid_t)subprocessOf:(pid_t)parent withName:(NSString *)name;
+
+/**
+ A Query for returning the parent of the provided child process
+ */
+- (pid_t)parentOf:(pid_t)child;
+
+/**
+ A Query for returning the process identifier of the first found process with an open file of filename.
+ */
+- (pid_t)processWithOpenFileTo:(const char *)filename;
+
+@end

--- a/FBSimulatorControl/Utility/FBProcessQuery.m
+++ b/FBSimulatorControl/Utility/FBProcessQuery.m
@@ -1,0 +1,277 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBProcessQuery.h"
+
+#import "FBProcessInfo.h"
+#import "FBProcessInfo+Private.h"
+
+#include <sys/sysctl.h>
+#include <libproc.h>
+#include <limits.h>
+
+#define PID_MAX 99999
+
+#pragma mark Calling libproc
+
+typedef BOOL(^ProcessIterator)(pid_t pid);
+typedef size_t(^LibProcCaller)(size_t pidBufferSize, pid_t *pidBuffer);
+
+static void IterateWith(pid_t *pidBuffer, size_t pidBufferSize, ProcessIterator iterator, LibProcCaller caller)
+{
+  size_t actualSize = caller(pidBufferSize, pidBuffer);
+  if (actualSize < 1) {
+    return;
+  }
+
+  for (pid_t index = 0; index < actualSize; index++) {
+    pid_t processIdentifier = *(pidBuffer + index);
+    if (!iterator(processIdentifier)) {
+      break;
+    }
+  }
+}
+
+static void IterateAllProcesses(pid_t *pidBuffer, size_t pidBufferSize, ProcessIterator iterator)
+{
+  IterateWith(pidBuffer, pidBufferSize, iterator, ^size_t(size_t pidBufferSize, pid_t *pidBuffer) {
+    return proc_listallpids(pidBuffer, pidBufferSize);
+  });
+}
+
+static void IterateSubprocessesOf(pid_t *pidBuffer, size_t pidBufferSize, pid_t parent, ProcessIterator iterator)
+{
+  IterateWith(pidBuffer, pidBufferSize, iterator, ^size_t(size_t pidBufferSize, pid_t *pidBuffer) {
+    return proc_listchildpids(parent, pidBuffer, pidBufferSize);
+  });
+}
+
+static void IterateOpenFiles(pid_t *pidBuffer, size_t pidBufferSize, const char *path, ProcessIterator iterator)
+{
+  IterateWith(pidBuffer, pidBufferSize, iterator, ^size_t(size_t pidBufferSize, pid_t *pidBuffer) {
+    return proc_listpidspath(
+      PROC_LISTPIDSPATH_PATH_IS_VOLUME,
+      PROC_ALL_PIDS,
+      path,
+      0,
+      pidBuffer,
+      pidBufferSize
+    );
+  });
+}
+
+static inline NSString *ProcessNameForProcessIdentifier(pid_t processIdentifier, char *buffer, size_t bufferSize)
+{
+  size_t actualSize = proc_name(processIdentifier, buffer, bufferSize);
+  if (actualSize == -1) {
+    return nil;
+  }
+  NSString *string = [[NSString alloc] initWithCString:buffer encoding:NSASCIIStringEncoding];
+  return string;
+}
+
+static inline FBFoundProcess *ProcessInfoForProcessIdentifier(pid_t processIdentifier, char *buffer, size_t bufferSize)
+{
+  // Much of the layout information here comes from libtop.c in Apple's top(1) Open Source implementation.
+  int name[3] = {CTL_KERN, KERN_PROCARGS2, processIdentifier};
+
+  size_t actualSize = bufferSize;
+  if (sysctl(name, 3, buffer, &actualSize, NULL, 0) == -1) {
+    return nil;
+  }
+  if (actualSize == 0) {
+    return nil;
+  }
+
+  // First Position is argc.
+  const char *startPosition = buffer;
+  const int argc = *startPosition;
+
+  // If argc isn't 1 or more, something is wrong
+  if (argc < 1) {
+    return nil;
+  }
+
+  // launch path starts above argc
+  char *currentPosition = (char *) startPosition + sizeof(int);
+  NSString *launchPath = [[NSString alloc] initWithCString:currentPosition encoding:NSASCIIStringEncoding];
+  currentPosition += strlen(currentPosition);
+  currentPosition += 1;
+
+  // Move through the padding to get to the the argv
+  while (*currentPosition == '\0') {
+    currentPosition++;
+  }
+
+  // Enumerate up to the value of argc
+  NSMutableArray *arguments = [NSMutableArray array];
+  for (int index = 0; index < argc; index++) {
+    // Create Objective-C String from current position.
+    NSString *argument = [[NSString alloc] initWithCString:currentPosition encoding:NSASCIIStringEncoding];
+    [arguments addObject:argument];
+
+    // Move the current string position passed the null-character.
+    currentPosition += strlen(currentPosition);
+    currentPosition += 1;
+  }
+
+  // Now the environment is here
+  NSMutableDictionary *environment = [NSMutableDictionary dictionary];
+  while (currentPosition != '\0') {
+    NSString *string = [[NSString alloc] initWithCString:currentPosition encoding:NSASCIIStringEncoding];
+    NSArray *tokens = [string componentsSeparatedByString:@"="];
+    // If we don't get 2 tokens, something is malformed.
+    if (tokens.count != 2) {
+      break;
+    }
+    environment[tokens[0]] = tokens[1];
+
+    // Move the current string position passed the null-character.
+    currentPosition += strlen(currentPosition);
+    currentPosition += 1;
+  }
+
+  FBFoundProcess *process = [FBFoundProcess new];
+  process.launchPath = launchPath;
+  process.processIdentifier = processIdentifier;
+  process.arguments = [arguments copy];
+  process.environment = [environment copy];
+
+  return process;
+}
+
+static inline BOOL ProcInfoForProcessIdentifier(pid_t processIdentifier, struct kinfo_proc* procOut)
+{
+  size_t size = sizeof(struct kinfo_proc);
+  int name[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, processIdentifier };
+  if (sysctl(name, 4, procOut, &size, NULL, 0) == -1) {
+    return NO;
+  }
+
+  return YES;
+}
+
+@interface FBProcessQuery ()
+
+@property (nonatomic, assign, readonly) size_t argumentBufferSize;
+@property (nonatomic, assign, readonly) char *argumentBuffer;
+
+@property (nonatomic, assign, readonly) size_t pidBufferSize;
+@property (nonatomic, assign, readonly) pid_t *pidBuffer;
+
+
+@end
+
+@implementation FBProcessQuery
+
+#pragma mark Lifecycle
+
+- (instancetype)init
+{
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  _argumentBufferSize = sizeof(char) * ARG_MAX;
+  _argumentBuffer = malloc(_argumentBufferSize);
+
+  _pidBufferSize = sizeof(pid_t) * PID_MAX;
+  _pidBuffer = malloc(_pidBufferSize);
+
+  return self;
+}
+
+- (void)dealloc
+{
+  free(_argumentBuffer);
+  free(_pidBuffer);
+}
+
+#pragma mark Queries
+
+- (id<FBProcessInfo>)processInfoFor:(pid_t)processIdentifier
+{
+  return ProcessInfoForProcessIdentifier(
+    processIdentifier,
+    self.argumentBuffer,
+    self.argumentBufferSize
+  );
+}
+
+- (NSArray *)subprocessesOf:(pid_t)parent
+{
+  NSMutableArray *subprocesses = [NSMutableArray array];
+
+  IterateSubprocessesOf(self.pidBuffer, self.pidBufferSize, parent, ^ BOOL (pid_t pid) {
+    id<FBProcessInfo> info = [self processInfoFor:pid];
+    if (info) {
+      [subprocesses addObject:info];
+    }
+    return YES;
+  });
+
+  return [subprocesses copy];
+}
+
+- (NSArray *)processesWithLaunchPathSubstring:(NSString *)substring
+{
+  NSMutableArray *subprocesses = [NSMutableArray array];
+
+  IterateAllProcesses(self.pidBuffer, self.pidBufferSize, ^ BOOL (pid_t pid) {
+    id<FBProcessInfo> info = [self processInfoFor:pid];
+    if ([info.launchPath containsString:substring]) {
+      [subprocesses addObject:info];
+    }
+    return YES;
+  });
+}
+
+- (pid_t)subprocessOf:(pid_t)parent withName:(NSString *)needleString
+{
+  __block pid_t foundProcess = -1;
+  size_t argumentBufferSize = self.argumentBufferSize;
+  char *argumentBuffer = self.argumentBuffer;
+  const char *needle = needleString.UTF8String;
+
+  IterateSubprocessesOf(self.pidBuffer, self.pidBufferSize, parent, ^ BOOL (pid_t pid) {
+    if (proc_name(pid, argumentBuffer, argumentBufferSize) == -1) {
+      return YES;
+    }
+    if (strstr(argumentBuffer, needle) == NULL) {
+      return YES;
+    }
+
+    foundProcess = pid;
+    return NO;
+  });
+
+  return foundProcess;
+}
+
+- (pid_t)processWithOpenFileTo:(const char *)filename
+{
+  __block pid_t processIdentifier = -1;
+  IterateOpenFiles(self.pidBuffer, self.pidBufferSize, filename, ^ BOOL (pid_t pid) {
+    processIdentifier = pid;
+    return NO;
+  });;
+  return processIdentifier;
+}
+
+- (pid_t)parentOf:(pid_t)child
+{
+  struct kinfo_proc proc;
+  if (!ProcInfoForProcessIdentifier(child, &proc)) {
+    return -1;
+  }
+  return proc.kp_eproc.e_ppid;
+}
+
+@end

--- a/FBSimulatorControl/Utility/FBSimulatorError.m
+++ b/FBSimulatorControl/Utility/FBSimulatorError.m
@@ -113,7 +113,7 @@ NSString *const FBSimulatorControlErrorDomain = @"com.facebook.FBSimulatorContro
 - (instancetype)inSimulator:(FBSimulator *)simulator
 {
   return [[self
-    extraInfo:@"launchd_is_running" value:@(simulator.hasActiveLaunchdSim)]
+    extraInfo:@"launchd_is_running" value:@(simulator.launchdSimProcessIdentifier > 1)]
     extraInfo:@"launchd_subprocesses" value:[simulator launchedProcesses]];
 }
 

--- a/FBSimulatorControlTests/Tests/FBProcessQueryTests.m
+++ b/FBSimulatorControlTests/Tests/FBProcessQueryTests.m
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <FBSimulatorControl/FBSimulatorControl.h>
+
+#import "FBSimulatorControlAssertions.h"
+#import "FBSimulatorControlFixtures.h"
+#import "FBSimulatorControlTestCase.h"
+
+@interface FBProcessQueryTests : FBSimulatorControlTestCase
+
+@property (nonatomic, strong, readwrite) FBProcessQuery *query;
+
+@end
+
+@implementation FBProcessQueryTests
+
+- (void)setUp
+{
+  [super setUp];
+  self.query = [FBProcessQuery new];
+}
+
+- (void)testGetsUDIDOfBootedSimulator
+{
+  FBSimulatorSession *session = [self createBootedSession];
+  id<FBProcessInfo> process = [self.query processInfoFor:session.simulator.processIdentifier];
+  XCTAssertNotNil(process);
+  NSSet *arguments = [NSSet setWithArray:process.arguments];
+  XCTAssertTrue([arguments containsObject:session.simulator.udid]);
+}
+
+@end

--- a/FBSimulatorControlTests/Tests/FBSimulatorControlSimulatorLaunchTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorControlSimulatorLaunchTests.m
@@ -45,7 +45,6 @@
   XCTAssertEqual(session.state.runningAgents.count, 0);
   XCTAssertEqual(session.state.runningApplications.count, 0);
   XCTAssertNotEqual(session.simulator.processIdentifier, -1);
-  XCTAssertNotNil(session.simulator.launchdBootstrapPath);
   XCTAssertNotNil(session.simulator.launchedProcesses);
 
   XCTAssertTrue([session terminateWithError:&error]);


### PR DESCRIPTION
Adds `FBProcessQuery` which is a wrapper around the somewhat-complicated usage of `libproc` and `sysctl`. 

`libproc` is used as a simple interface to accessing basic information about running processes and the files that they access. `sysctl` is used for it's very handy `KERN_PROCARGS2` call, which allows the caller to access information about the launch path, environment and args of any process that the current user has permission to look at.

This class will enable `FBSimulatorControl` to:
- Kill off the janky `pgrep`ing that requires a subshell for simple tasks
- Infer the process identifier of arbitrarily launched simulators.
- Inspect the launch environment of all `launchd_sim` subprocesses.