### PR TITLE
Add option to enable CoreSimulator logging

### DIFF
--- a/FBSimulatorControl/Management/FBSimulatorPool.h
+++ b/FBSimulatorControl/Management/FBSimulatorPool.h
@@ -169,3 +169,8 @@
 - (void)startLoggingSimDeviceSetInteractions:(id<FBSimulatorLogger>)logger;
 
 @end
+
+/**
+ Enable/disable CoreSimulator debug logging and any other verbose logging we can get our hands on.
+ */
+void FBSetSimulatorLoggingEnabled(BOOL enabled);

--- a/FBSimulatorControl/Management/FBSimulatorPool.m
+++ b/FBSimulatorControl/Management/FBSimulatorPool.m
@@ -10,6 +10,7 @@
 #import "FBSimulatorPool.h"
 #import "FBSimulatorPool+Private.h"
 
+#import <CoreSimulator/NSUserDefaults-SimDefaults.h>
 #import <CoreSimulator/SimDevice.h>
 #import <CoreSimulator/SimDeviceSet.h>
 #import <CoreSimulator/SimDeviceType.h>
@@ -387,3 +388,9 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
 }
 
 @end
+
+void FBSetSimulatorLoggingEnabled(BOOL enabled)
+{
+  NSUserDefaults *simulatorDefaults = [NSUserDefaults simulatorDefaults];
+  [simulatorDefaults setBool:enabled forKey:@"DebugLogging"];
+}


### PR DESCRIPTION
Added this as a C method because I couldn't find any good class that made sense for this.
Put it in the FBSimulatorPool header because that seems like the best place for it.