### PR TITLE
Remove prgep usage from FBSimulatorTerminationStrategy

### DIFF
--- a/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.h
@@ -9,6 +9,8 @@
 
 #import <Foundation/Foundation.h>
 
+extern NSString *const FBSimulatorControlSimulatorLaunchEnvironmentMagic;
+
 /**
  Environment Globals & other derived constants
  */

--- a/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.m
@@ -14,6 +14,8 @@
 #import "FBSimulatorControl+Private.h"
 #import "FBTaskExecutor.h"
 
+NSString *const FBSimulatorControlSimulatorLaunchEnvironmentMagic = @"__IS_THIS_TRULY_MAGIC__";
+
 @implementation FBSimulatorControlStaticConfiguration
 
 + (NSString *)developerDirectory

--- a/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.h
+++ b/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.h
@@ -12,17 +12,20 @@
 @class FBSimulatorControlConfiguration;
 
 /**
- Strategies for Terminating Simulators
+ A class for terminating Simulators.
  */
 @interface FBSimulatorTerminationStrategy : NSObject
 
 /**
- A Strategy that uses Pgrep/Pkill.
+ A Strategy that uses FBProcessQuery & kill(2).
+
+ @param configuration the Configuration of FBSimulatorControl.
+ @param allSimulators the Simulators that are permitted to be terminated.
  */
 + (instancetype)usingKillOnConfiguration:(FBSimulatorControlConfiguration *)configuration allSimulators:(NSArray *)allSimulators;
 
 /**
- Kills all of the Simulators the reciever's Device Set.
+ Kills all of the Simulators associated with the reciever.
 
  @param error an error out if any error occured.
  @returns an array of the Simulators that this were killed if successful, nil otherwise.

--- a/FBSimulatorControl/Session/FBSimulatorSessionInteraction.m
+++ b/FBSimulatorControl/Session/FBSimulatorSessionInteraction.m
@@ -64,9 +64,11 @@ NSTimeInterval const FBSimulatorInteractionDefaultTimeout = 30;
       [arguments addObjectsFromArray:@[@"-DeviceSetPath", simulator.pool.configuration.deviceSetPath]];
     }
 
-    id<FBTask> task = [FBTaskExecutor.sharedInstance
-      taskWithLaunchPath:simulator.simulatorApplication.binary.path
-      arguments:[arguments copy]];
+    id<FBTask> task = [[[[FBTaskExecutor.sharedInstance
+      withLaunchPath:simulator.simulatorApplication.binary.path]
+      withArguments:[arguments copy]]
+      withEnvironmentAdditions:@{FBSimulatorControlSimulatorLaunchEnvironmentMagic : @"YES"}]
+      build];
 
     [lifecycle simulatorWillStart:simulator];
     [task startAsynchronously];

--- a/FBSimulatorControl/Utility/FBProcessQuery.m
+++ b/FBSimulatorControl/Utility/FBProcessQuery.m
@@ -216,9 +216,13 @@ static inline BOOL ProcInfoForProcessIdentifier(pid_t processIdentifier, struct 
 
   IterateAllProcesses(self.pidBuffer, self.pidBufferSize, ^ BOOL (pid_t pid) {
     id<FBProcessInfo> info = [self processInfoFor:pid];
-    if ([info.launchPath containsString:substring]) {
-      [subprocesses addObject:info];
+    if (!info) {
+      return YES;
     }
+    if ([info.launchPath rangeOfString:substring].location == NSNotFound) {
+      return YES;
+    }
+    [subprocesses addObject:info];
     return YES;
   });
 


### PR DESCRIPTION
Updates `FBSimulatorTerminationStrategy` to not be terrible anymore and use `FBProcessQuery` directly. This should make it substantially easier to maintain and vastly simplifies the code. I would expect performance is better in the startup path now as a bunch of syscalls are going to be a lot faster than subshelling out multiple times (with each subshell process making a bunch of syscalls).

Now that we know about the environment of launched `Simulator.app` processes it's also easier to determine which processes were launched by `FBSimulatorControl` by inserting a :tophat: magic :tophat: string into the environment. This is better than using arguments to the process, since we can't reasonably assume they will be ignored in the implementation of the Simulator Application.