### PR TITLE
Build fbsimctl on Travis

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 47;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -2055,7 +2055,9 @@
 		96C84793390C419500000000 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				CLASSPREFIX = FB;
 				LastUpgradeCheck = 0710;
+				ORGANIZATIONNAME = Facebook;
 				TargetAttributes = {
 					AA819DB11B9FB40D002F58CA = {
 						CreatedOnToolsVersion = 7.0;
@@ -2063,7 +2065,7 @@
 				};
 			};
 			buildConfigurationList = 218C37090000000000000002 /* Build configuration list for PBXProject "FBSimulatorControl" */;
-			compatibilityVersion = "Xcode 3.2";
+			compatibilityVersion = "Xcode 6.3";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (

--- a/build.sh
+++ b/build.sh
@@ -11,15 +11,26 @@ set -eu
 
 MODE=$1
 
-function ci() {
+function framework() {
+  NAME='FBSimulatorControl'
   xctool \
-      -project $1.xcodeproj \
-      -scheme $1 \
+      -project $NAME.xcodeproj \
+      -scheme $NAME \
       -sdk macosx \
-      $2
+      $1
+}
+
+function cli() {
+  NAME='fbsimctl'
+  xctool \
+      -workspace $NAME/$NAME.xcworkspace \
+      -scheme $NAME \
+      -sdk macosx \
+      $1
 }
 
 if [ "$MODE" = "ci" ]; then
-  ci FBSimulatorControl test
+  framework test
+  cli build
 fi
 

--- a/fbsimctl/fbsimctl.xcodeproj/project.pbxproj
+++ b/fbsimctl/fbsimctl.xcodeproj/project.pbxproj
@@ -3,39 +3,25 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 47;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		AA302DD71C1F3C1800E77B51 /* CommandParsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA302DD61C1F3C1800E77B51 /* CommandParsers.swift */; };
 		AA93B7C71BE835B100CF6A56 /* Relay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA93B7C41BE835B100CF6A56 /* Relay.swift */; };
 		AA93B7C81BE835B100CF6A56 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA93B7C51BE835B100CF6A56 /* main.swift */; };
-		AA93B7CA1BE8361800CF6A56 /* FBSimulatorControl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA93B7C91BE8361800CF6A56 /* FBSimulatorControl.framework */; };
 		AA93B7CC1BE8380B00CF6A56 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA93B7C31BE835B100CF6A56 /* Command.swift */; };
 		AA93B7CE1BE9543000CF6A56 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA93B7CD1BE9543000CF6A56 /* Parser.swift */; };
 		AA93B7D01BE9544000CF6A56 /* Runners.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA93B7CF1BE9544000CF6A56 /* Runners.swift */; };
 		AA93B7D21BEA679600CF6A56 /* Help.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA93B7D11BEA679600CF6A56 /* Help.swift */; };
 		AA93B7D61BEA97A700CF6A56 /* Bridging.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA93B7D51BEA97A700CF6A56 /* Bridging.swift */; };
-		AAEAC9BB1BF23BAE00B5F957 /* FBSimulatorControl.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = AA93B7C91BE8361800CF6A56 /* FBSimulatorControl.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		AAE35A591C2860980073CC70 /* FBSimulatorControl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA93B7C91BE8361800CF6A56 /* FBSimulatorControl.framework */; };
 		AAEAC9BD1BF3CD7B00B5F957 /* SignalHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEAC9BC1BF3CD7B00B5F957 /* SignalHandler.swift */; };
 		AAEAC9BF1BF3EA8200B5F957 /* SocketRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEAC9BE1BF3EA8200B5F957 /* SocketRelay.swift */; };
 		AAEAC9C11BF3EA9200B5F957 /* StdIORelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEAC9C01BF3EA9200B5F957 /* StdIORelay.swift */; };
 		AAF4A3311BF4E2B900978B3A /* LineBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF4A3301BF4E2B900978B3A /* LineBuffer.swift */; };
 		AAF4A3381BF5152700978B3A /* Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = AAF4A3371BF5152700978B3A /* Constants.m */; };
 /* End PBXBuildFile section */
-
-/* Begin PBXCopyFilesBuildPhase section */
-		AAEAC9BA1BF23B1700B5F957 /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = Frameworks;
-			dstSubfolderSpec = 10;
-			files = (
-				AAEAC9BB1BF23BAE00B5F957 /* FBSimulatorControl.framework in CopyFiles */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		AA302DD41C1F39FC00E77B51 /* Arguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Arguments.swift; sourceTree = "<group>"; };
@@ -44,7 +30,7 @@
 		AA93B7C31BE835B100CF6A56 /* Command.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
 		AA93B7C41BE835B100CF6A56 /* Relay.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Relay.swift; sourceTree = "<group>"; };
 		AA93B7C51BE835B100CF6A56 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
-		AA93B7C91BE8361800CF6A56 /* FBSimulatorControl.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FBSimulatorControl.framework; path = "../../../Library/Developer/Xcode/DerivedData/fbsimctl-civpmgwytzrrawekdzefxighgiyo/Build/Products/Debug/FBSimulatorControl.framework"; sourceTree = "<group>"; };
+		AA93B7C91BE8361800CF6A56 /* FBSimulatorControl.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = FBSimulatorControl.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA93B7CD1BE9543000CF6A56 /* Parser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
 		AA93B7CF1BE9544000CF6A56 /* Runners.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Runners.swift; sourceTree = "<group>"; };
 		AA93B7D11BEA679600CF6A56 /* Help.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Help.swift; sourceTree = "<group>"; };
@@ -59,11 +45,11 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		AA93B7AD1BE8351000CF6A56 /* Frameworks */ = {
+		AAE35A521C285F150073CC70 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AA93B7CA1BE8361800CF6A56 /* FBSimulatorControl.framework in Frameworks */,
+				AAE35A591C2860980073CC70 /* FBSimulatorControl.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -126,8 +112,7 @@
 			buildConfigurationList = AA93B7B71BE8351000CF6A56 /* Build configuration list for PBXNativeTarget "fbsimctl" */;
 			buildPhases = (
 				AA93B7AC1BE8351000CF6A56 /* Sources */,
-				AA93B7AD1BE8351000CF6A56 /* Frameworks */,
-				AAEAC9BA1BF23B1700B5F957 /* CopyFiles */,
+				AAE35A521C285F150073CC70 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -144,6 +129,7 @@
 		AA93B7A81BE8351000CF6A56 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				CLASSPREFIX = FB;
 				LastSwiftUpdateCheck = 0710;
 				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = Facebook;
@@ -154,7 +140,7 @@
 				};
 			};
 			buildConfigurationList = AA93B7AB1BE8351000CF6A56 /* Build configuration list for PBXProject "fbsimctl" */;
-			compatibilityVersion = "Xcode 3.2";
+			compatibilityVersion = "Xcode 6.3";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (

--- a/fbsimctl/fbsimctl.xcodeproj/xcshareddata/xcschemes/fbsimctl.xcscheme
+++ b/fbsimctl/fbsimctl.xcodeproj/xcshareddata/xcschemes/fbsimctl.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AA93B7AF1BE8351000CF6A56"
+               BuildableName = "fbsimctl"
+               BlueprintName = "fbsimctl"
+               ReferencedContainer = "container:fbsimctl.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AA93B7AF1BE8351000CF6A56"
+            BuildableName = "fbsimctl"
+            BlueprintName = "fbsimctl"
+            ReferencedContainer = "container:fbsimctl.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AA93B7AF1BE8351000CF6A56"
+            BuildableName = "fbsimctl"
+            BlueprintName = "fbsimctl"
+            ReferencedContainer = "container:fbsimctl.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "list"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "&quot;iPhone 5&quot;"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AA93B7AF1BE8351000CF6A56"
+            BuildableName = "fbsimctl"
+            BlueprintName = "fbsimctl"
+            ReferencedContainer = "container:fbsimctl.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Now that we have Xcode 7.1 magically working on Travis, we can build `fbsimctl` there to make sure that we're not breaking `fbsimctl` changes with Framework changes.