### PR TITLE
More performant search for launchd_sim

### DIFF
--- a/FBSimulatorControl/Management/FBSimulator+Queries.m
+++ b/FBSimulatorControl/Management/FBSimulator+Queries.m
@@ -41,7 +41,7 @@
 
 + (pid_t)launchdSimProcessIdentifierForUDID:(NSString *)udid query:(FBProcessQuery *)query
 {
-  for (id<FBProcessInfo> info in [query processesWithLaunchPathSubstring:@"sbin/launchd_sim"]) {
+  for (id<FBProcessInfo> info in [query processesWithProcessName:@"launchd_sim"]) {
     NSString *udidContainingString = info.environment[@"XPC_SIMULATOR_LAUNCHD_NAME"];
     if ([udidContainingString rangeOfString:udid].location != NSNotFound) {
       return info.processIdentifier;

--- a/FBSimulatorControl/Utility/FBProcessQuery.h
+++ b/FBSimulatorControl/Utility/FBProcessQuery.h
@@ -36,6 +36,14 @@
 - (NSArray *)processesWithLaunchPathSubstring:(NSString *)substring;
 
 /**
+ A Query for returning the processes with a given name.
+
+ Note that this is more optimal than `processesWithLaunchPathSubstring:`
+ since only the process name is fetched in the syscall.
+ */
+- (NSArray *)processesWithProcessName:(NSString *)processName;
+
+/**
  A Query for returning the first named child process of the provided parent.
  */
 - (pid_t)subprocessOf:(pid_t)parent withName:(NSString *)name;


### PR DESCRIPTION
Searching for `launchd_sim` by using paths is not performant and far too complicated than it needs to be. Finding the open processes for a file path is also orders of magnitude slower than getting simulator by launch path. It's also possible to optimise `processesWithLaunchPathSubstring:` later since `libproc` can provide all of them without the need for multiple syscalls.

Fortunately there are plenty of arguments and environment variables in the `launchd_sim` process that do contain the UDID of the Simulator, so we can use those instead.