### PR TITLE
Add NSWorkspace-based termination strategy

### DIFF
--- a/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.h
@@ -23,6 +23,7 @@ typedef NS_OPTIONS(NSUInteger, FBSimulatorManagementOptions){
   FBSimulatorManagementOptionsAlwaysCreateWhenAllocating = 1 << 3,
   FBSimulatorManagementOptionsDeleteOnFree = 1 << 4,
   FBSimulatorManagementOptionsEraseOnFree = 1 << 5,
+  FBSimulatorManagementOptionsUseProcessKilling = 1 << 6,
 };
 
 /**

--- a/FBSimulatorControl/Management/FBSimulatorPool.m
+++ b/FBSimulatorControl/Management/FBSimulatorPool.m
@@ -297,7 +297,7 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
 
 - (FBSimulatorTerminationStrategy *)terminationStrategy
 {
-  return [FBSimulatorTerminationStrategy usingKillOnConfiguration:self.configuration allSimulators:[self.allSimulators.array copy]];
+  return [FBSimulatorTerminationStrategy withConfiguration:self.configuration allSimulators:[self.allSimulators.array copy]];
 }
 
 #pragma mark - Helpers

--- a/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.h
+++ b/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.h
@@ -17,12 +17,12 @@
 @interface FBSimulatorTerminationStrategy : NSObject
 
 /**
- A Strategy that uses FBProcessQuery & kill(2).
+ Creates a FBSimulatorTerminationStrategy using the provided configuration.
 
  @param configuration the Configuration of FBSimulatorControl.
  @param allSimulators the Simulators that are permitted to be terminated.
  */
-+ (instancetype)usingKillOnConfiguration:(FBSimulatorControlConfiguration *)configuration allSimulators:(NSArray *)allSimulators;
++ (instancetype)withConfiguration:(FBSimulatorControlConfiguration *)configuration allSimulators:(NSArray *)allSimulators;
 
 /**
  Kills all of the Simulators associated with the reciever.
@@ -48,6 +48,5 @@
  @returns an YES if successful, nil otherwise.
  */
 - (BOOL)killSpuriousSimulatorsWithError:(NSError **)error;
-
 
 @end

--- a/FBSimulatorControl/Utility/FBProcessQuery.h
+++ b/FBSimulatorControl/Utility/FBProcessQuery.h
@@ -58,4 +58,10 @@
  */
 - (pid_t)processWithOpenFileTo:(const char *)filename;
 
+/**
+ Creates a mapping of NSDictionary<id<FBProcessInfo>, NSRunningApplication>> from id<FBProcessInfo>.
+ Any Applications that could not be found will be replaced with NSNull.null.
+ */
+- (NSDictionary *)runningApplicationsForProcesses:(NSArray *)processes;
+
 @end

--- a/FBSimulatorControl/Utility/FBProcessQuery.m
+++ b/FBSimulatorControl/Utility/FBProcessQuery.m
@@ -9,6 +9,8 @@
 
 #import "FBProcessQuery.h"
 
+#import <AppKit/AppKit.h>
+
 #include <libproc.h>
 #include <limits.h>
 #include <string.h>
@@ -298,6 +300,21 @@ static BOOL ProcessNameForProcessIdentifier(pid_t processIdentifier, char *buffe
     return -1;
   }
   return proc.kp_eproc.e_ppid;
+}
+
+- (NSDictionary *)runningApplicationsForProcesses:(NSArray *)processes
+{
+  NSArray *applications = [self.processIdentifiersToApplications objectsForKeys:[processes valueForKey:@"processIdentifier"] notFoundMarker:NSNull.null];
+  return [NSDictionary dictionaryWithObjects:applications forKeys:processes];
+}
+
+#pragma mark Private
+
+- (NSDictionary *)processIdentifiersToApplications
+{
+  NSArray *applications = NSWorkspace.sharedWorkspace.runningApplications;
+  NSArray *processIdentifiers = [applications valueForKey:@"processIdentifier"];
+  return [NSDictionary dictionaryWithObjects:applications forKeys:processIdentifiers];
 }
 
 @end


### PR DESCRIPTION
Much less severe than using `kill`, add an option to select the termination strategy.