### PR TITLE
Add timeout to launching and installing applications on SimDevice

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		877123F01BDA78AA00530B1E /* FBSimulatorVideoUploader.h in Headers */ = {isa = PBXBuildFile; fileRef = 877123EE1BDA78AA00530B1E /* FBSimulatorVideoUploader.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		877123F11BDA78AA00530B1E /* FBSimulatorVideoUploader.m in Sources */ = {isa = PBXBuildFile; fileRef = 877123EF1BDA78AA00530B1E /* FBSimulatorVideoUploader.m */; };
 		877123F31BDA797800530B1E /* video0.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 877123F21BDA797800530B1E /* video0.mp4 */; };
+		911001651C0DDF150054722C /* FBSimDeviceWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 911001631C0DDF150054722C /* FBSimDeviceWrapper.h */; };
+		911001661C0DDF150054722C /* FBSimDeviceWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 911001641C0DDF150054722C /* FBSimDeviceWrapper.m */; };
 		AA017F271BD7770300F45E9D /* FBSimulatorLogsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA017F251BD7770300F45E9D /* FBSimulatorLogsTests.m */; };
 		AA017F281BD7770300F45E9D /* FBWritableLogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA017F261BD7770300F45E9D /* FBWritableLogTests.m */; };
 		AA017F2F1BD7771300F45E9D /* FBSimulatorLogs.h in Headers */ = {isa = PBXBuildFile; fileRef = AA017F2A1BD7771300F45E9D /* FBSimulatorLogs.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -188,6 +190,8 @@
 		877123EE1BDA78AA00530B1E /* FBSimulatorVideoUploader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorVideoUploader.h; sourceTree = "<group>"; };
 		877123EF1BDA78AA00530B1E /* FBSimulatorVideoUploader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorVideoUploader.m; sourceTree = "<group>"; };
 		877123F21BDA797800530B1E /* video0.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = video0.mp4; sourceTree = "<group>"; };
+		911001631C0DDF150054722C /* FBSimDeviceWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimDeviceWrapper.h; sourceTree = "<group>"; };
+		911001641C0DDF150054722C /* FBSimDeviceWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimDeviceWrapper.m; sourceTree = "<group>"; };
 		AA017F251BD7770300F45E9D /* FBSimulatorLogsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorLogsTests.m; sourceTree = "<group>"; };
 		AA017F261BD7770300F45E9D /* FBWritableLogTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBWritableLogTests.m; sourceTree = "<group>"; };
 		AA017F2A1BD7771300F45E9D /* FBSimulatorLogs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorLogs.h; sourceTree = "<group>"; };
@@ -1030,6 +1034,8 @@
 		AA4876EE1BAC74B9007F7D23 /* Session */ = {
 			isa = PBXGroup;
 			children = (
+				911001631C0DDF150054722C /* FBSimDeviceWrapper.h */,
+				911001641C0DDF150054722C /* FBSimDeviceWrapper.m */,
 				AA4876EF1BAC74B9007F7D23 /* FBSimulatorSession+Convenience.h */,
 				AA4876F01BAC74B9007F7D23 /* FBSimulatorSession+Convenience.m */,
 				AA4876F11BAC74B9007F7D23 /* FBSimulatorSession+Private.h */,
@@ -1846,6 +1852,7 @@
 				AA7B7BB51BDA4B9100CD028C /* FBSimulatorLogs+Private.h in Headers */,
 				AA48771E1BAC74B9007F7D23 /* FBSimulatorControlConfiguration.h in Headers */,
 				AA48774C1BAC74B9007F7D23 /* FBTask+Private.h in Headers */,
+				911001651C0DDF150054722C /* FBSimDeviceWrapper.h in Headers */,
 				AA48773E1BAC74B9007F7D23 /* FBSimulatorSessionInteraction+Diagnostics.h in Headers */,
 				AA48772D1BAC74B9007F7D23 /* FBSimulatorPool+Private.h in Headers */,
 				AA48774A1BAC74B9007F7D23 /* FBSimulatorSessionStateGenerator.h in Headers */,
@@ -2006,6 +2013,7 @@
 				AA01F46E1BFF0A1B000B5939 /* FBSimulatorTerminationStrategy.m in Sources */,
 				AA74B99A1BB014A200C1E59C /* FBSimulatorError.m in Sources */,
 				AA48773A1BAC74B9007F7D23 /* FBSimulatorSession+Convenience.m in Sources */,
+				911001661C0DDF150054722C /* FBSimDeviceWrapper.m in Sources */,
 				AA4877341BAC74B9007F7D23 /* FBProcessInfo.m in Sources */,
 				AA48773F1BAC74B9007F7D23 /* FBSimulatorSessionInteraction+Diagnostics.m in Sources */,
 				AA4877291BAC74B9007F7D23 /* FBSimulatorControl.m in Sources */,

--- a/FBSimulatorControl/Session/FBSimDeviceWrapper.h
+++ b/FBSimulatorControl/Session/FBSimDeviceWrapper.h
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class SimDevice;
+
+@interface FBSimDeviceWrapper : NSObject
+
+- (instancetype)initWithSimDevice:(SimDevice *)device;
+
+- (int)launchApplicationWithID:(NSString *)appID options:(NSDictionary *)options error:(NSError **)error;
+- (BOOL)installApplication:(NSURL *)appURL withOptions:(NSDictionary *)options error:(NSError **)error;
+
+@end

--- a/FBSimulatorControl/Session/FBSimDeviceWrapper.m
+++ b/FBSimulatorControl/Session/FBSimDeviceWrapper.m
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBSimDeviceWrapper.h"
+
+#import <CoreSimulator/SimDevice.h>
+
+#import "FBSimulatorError.h"
+
+const long kFBSimDeviceCommandTimeout = 30;
+
+@interface FBSimDeviceWrapper ()
+
+@property SimDevice *device;
+
+@end
+
+@implementation FBSimDeviceWrapper
+
+- (instancetype)initWithSimDevice:(SimDevice *)device
+{
+  if (!(self = [self init])) {
+    return nil;
+  }
+
+  _device = device;
+
+  return self;
+}
+
+- (BOOL)runInvocationInBackgroundUntilTimeout:(NSInvocation *)invocation
+{
+  dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+  NSInvocation *newInvocation = [NSInvocation invocationWithMethodSignature:[self methodSignatureForSelector:@selector(runInvocation:withSemaphore:)]];
+  [newInvocation setTarget:self];
+  [newInvocation setSelector:@selector(runInvocation:withSemaphore:)];
+  [newInvocation setArgument:&invocation atIndex:2];
+  [newInvocation setArgument:&semaphore atIndex:3];
+  [NSThread detachNewThreadSelector:@selector(invoke) toTarget:newInvocation withObject:nil];
+
+  return dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, kFBSimDeviceCommandTimeout * NSEC_PER_SEC)) == 0;
+}
+
+- (void)runInvocation:(NSInvocation *)invocation withSemaphore:(dispatch_semaphore_t)semaphore
+{
+  NSAssert(![NSThread isMainThread], @"Should be on a background thread");
+
+  [invocation invoke];
+  dispatch_semaphore_signal(semaphore);
+}
+
+- (int)launchApplicationWithID:(NSString *)appID options:(NSDictionary *)options error:(NSError **)error
+{
+  NSAssert([NSThread isMainThread], @"Must be called from the main thread.");
+
+  NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[self methodSignatureForSelector:@selector(launchApplicationWithID:options:error:)]];
+  [invocation setTarget:self.device];
+  [invocation setSelector:@selector(launchApplicationWithID:options:error:)];
+  [invocation setArgument:&appID atIndex:2];
+  [invocation setArgument:&options atIndex:3];
+  [invocation setArgument:&error atIndex:4];
+
+  if (![self runInvocationInBackgroundUntilTimeout:invocation]) {
+    [[FBSimulatorError describe:@"Timed out calling launchApplicationWithID"] fail:error];
+    return 0;
+  }
+
+  pid_t pid;
+  [invocation getReturnValue:&pid];
+  return pid;
+}
+
+- (BOOL)installApplication:(NSURL *)appURL withOptions:(NSDictionary *)options error:(NSError **)error
+{
+  NSAssert([NSThread isMainThread], @"Must be called from the main thread.");
+
+  NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[self methodSignatureForSelector:@selector(installApplication:withOptions:error:)]];
+  [invocation setTarget:self.device];
+  [invocation setSelector:@selector(installApplication:withOptions:error:)];
+  [invocation setArgument:&appURL atIndex:2];
+  [invocation setArgument:&options atIndex:3];
+  [invocation setArgument:&error atIndex:4];
+
+  if (![self runInvocationInBackgroundUntilTimeout:invocation]) {
+    [[FBSimulatorError describe:@"Timed out calling installApplication"] fail:error];
+    return NO;
+  }
+
+  BOOL rv;
+  [invocation getReturnValue:&rv];
+  return rv;
+}
+
+@end

--- a/FBSimulatorControl/Session/FBSimulatorSessionInteraction.m
+++ b/FBSimulatorControl/Session/FBSimulatorSessionInteraction.m
@@ -21,6 +21,7 @@
 #import "FBSimulatorControl.h"
 #import "FBSimulatorControlConfiguration.h"
 #import "FBSimulatorControlStaticConfiguration.h"
+#import "FBSimDeviceWrapper.h"
 #import "FBSimulatorError.h"
 #import "FBSimulatorPool.h"
 #import "FBSimulatorSession+Private.h"
@@ -180,7 +181,8 @@ NSTimeInterval const FBSimulatorInteractionDefaultTimeout = 30;
 
   return [self interact:^ BOOL (NSError **error, id _) {
     NSError *innerError = nil;
-    if (![simulator.device installApplication:[NSURL fileURLWithPath:application.path] withOptions:@{@"CFBundleIdentifier" : application.bundleID} error:error]) {
+    FBSimDeviceWrapper *wrapper = [[FBSimDeviceWrapper alloc] initWithSimDevice:simulator.device];
+    if (![wrapper installApplication:[NSURL fileURLWithPath:application.path] withOptions:@{@"CFBundleIdentifier" : application.bundleID} error:error]) {
       return [[[FBSimulatorError describeFormat:@"Failed to install Application %@", application] causedBy:innerError] failBool:error];
     }
 
@@ -220,7 +222,8 @@ NSTimeInterval const FBSimulatorInteractionDefaultTimeout = 30;
       return [FBSimulatorError failBoolWithError:innerError errorOut:error];
     }
 
-    pid_t processIdentifier = [simulator.device launchApplicationWithID:appLaunch.application.bundleID options:options error:&innerError];
+    FBSimDeviceWrapper *wrapper = [[FBSimDeviceWrapper alloc] initWithSimDevice:simulator.device];
+    pid_t processIdentifier = [wrapper launchApplicationWithID:appLaunch.application.bundleID options:options error:&innerError];
     if (processIdentifier <= 0) {
       return [[[[FBSimulatorError describeFormat:@"Failed to launch application %@", appLaunch] causedBy:innerError] inSimulator:simulator] failBool:error];
     }


### PR DESCRIPTION
We've seen these methods hang on Xcode 7.1, so let's make them timeout instead.
Because the API doesn't actually error out when anything goes wrong, we run them from a background thread and shuttle the results back to the main thread.

I also tested locally with FBSimulatorControlApplicationLaunchTests.