### PR TITLE
Add Killing of CoreSimulatorService

### DIFF
--- a/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.h
@@ -24,6 +24,7 @@ typedef NS_OPTIONS(NSUInteger, FBSimulatorManagementOptions){
   FBSimulatorManagementOptionsDeleteOnFree = 1 << 4,
   FBSimulatorManagementOptionsEraseOnFree = 1 << 5,
   FBSimulatorManagementOptionsUseProcessKilling = 1 << 6,
+  FBSimulatorManagementOptionsKillSpuriousCoreSimulatorServices = 1 << 7,
 };
 
 /**

--- a/FBSimulatorControl/Management/FBSimulatorControl.m
+++ b/FBSimulatorControl/Management/FBSimulatorControl.m
@@ -95,6 +95,13 @@
     return [FBSimulatorError failBoolWithError:innerError description:@"Failed to load DVTPlatform" errorOut:error];
   }
 
+  BOOL killSpuriousCoreSimulatorServices = (self.configuration.options & FBSimulatorManagementOptionsKillSpuriousCoreSimulatorServices) == FBSimulatorManagementOptionsKillSpuriousCoreSimulatorServices;
+  if (killSpuriousCoreSimulatorServices) {
+    if (![self.simulatorPool.terminationStrategy killSpuriousCoreSimulatorServicesWithError:&innerError]) {
+      return [[[FBSimulatorError describe:@"Failed to kill spurious CoreSimulatorServices"] causedBy:innerError] failBool:error];
+    }
+  }
+
   if (self.configuration.deviceSetPath != nil) {
     if (![NSFileManager.defaultManager createDirectoryAtPath:self.configuration.deviceSetPath withIntermediateDirectories:YES attributes:nil error:&innerError]) {
       return [[[FBSimulatorError describeFormat:@"Failed to create custom SimDeviceSet directory at %@", self.configuration.deviceSetPath] causedBy:innerError] failBool:error];
@@ -110,10 +117,10 @@
     return [[[[FBSimulatorError describe:@"Failed to teardown previous simulators"] causedBy:innerError] recursiveDescription] failBool:error];
   }
 
-  BOOL killSpurious = (self.configuration.options & FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart) == FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart;
-  if (killSpurious) {
+  BOOL killSpuriousSimulators = (self.configuration.options & FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart) == FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart;
+  if (killSpuriousSimulators) {
     BOOL failOnSpuriousKillFail = (self.configuration.options & FBSimulatorManagementOptionsIgnoreSpuriousKillFail) != FBSimulatorManagementOptionsIgnoreSpuriousKillFail;
-    if (![self.simulatorPool killSpuriousSimulatorsWithError:&innerError] && failOnSpuriousKillFail) {
+    if (![self.simulatorPool.terminationStrategy killSpuriousSimulatorsWithError:&innerError] && failOnSpuriousKillFail) {
       return [[[[FBSimulatorError describe:@"Failed to kill spurious simulators"] causedBy:innerError] recursiveDescription] failBool:error];
     }
   }

--- a/FBSimulatorControl/Management/FBSimulatorPool.h
+++ b/FBSimulatorControl/Management/FBSimulatorPool.h
@@ -13,6 +13,7 @@
 @class FBSimulatorConfiguration;
 @class FBSimulatorControlConfiguration;
 @class FBSimulatorPool;
+@class FBSimulatorTerminationStrategy;
 @class SimDevice;
 @class SimDeviceSet;
 
@@ -44,6 +45,11 @@
  Is an NSOrderedSet<FBSimulator>
  */
 @property (nonatomic, copy, readonly) NSOrderedSet *allSimulators;
+
+/**
+ Returns the Simulator Termination Strategy associated with the reciever.
+ */
+@property (nonatomic, strong, readonly) FBSimulatorTerminationStrategy *terminationStrategy;
 
 /**
  Returns a device matching the UDID, if one exists.
@@ -78,14 +84,6 @@
  @returns an array of the Simulators that this were killed if successful, nil otherwise.
  */
 - (NSArray *)killAllWithError:(NSError **)error;
-
-/**
- Kills all of the Simulators that are not launched by `FBSimulatorControl`. These can be Simulators launched via Xcode or Instruments.
-
- @param error an error out if any error occured.
- @returns an YES if successful, nil otherwise.
- */
-- (BOOL)killSpuriousSimulatorsWithError:(NSError **)error;
 
 /**
  Erases the Simulators that this Pool is responsible for.

--- a/FBSimulatorControl/Management/FBSimulatorPool.m
+++ b/FBSimulatorControl/Management/FBSimulatorPool.m
@@ -60,6 +60,12 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
   return [simulators copy];
 }
 
+- (FBSimulatorTerminationStrategy *)terminationStrategy
+{
+  // `self.allSimulators` is not a constant for the lifetime of self, so should be fetched on all usages.
+  return [FBSimulatorTerminationStrategy withConfiguration:self.configuration allSimulators:[self.allSimulators.array copy]];
+}
+
 #pragma mark - Public Methods
 
 - (FBSimulator *)simulatorWithUDID:(NSString *)udidString
@@ -294,11 +300,6 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
   }
 
   return YES;
-}
-
-- (FBSimulatorTerminationStrategy *)terminationStrategy
-{
-  return [FBSimulatorTerminationStrategy withConfiguration:self.configuration allSimulators:[self.allSimulators.array copy]];
 }
 
 #pragma mark - Helpers

--- a/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.h
+++ b/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.h
@@ -49,4 +49,13 @@
  */
 - (BOOL)killSpuriousSimulatorsWithError:(NSError **)error;
 
+/**
+ Kills all of the 'com.apple.CoreSimulatorService' processes that are not used by the current `FBSimulatorControl` configuration.
+ Running multiple versions of the Service on the same machine can lead to instability such as Simulator statuses not updating.
+
+ @param error an error out if any error occured.
+ @returns an YES if successful, nil otherwise.
+ */
+- (BOOL)killSpuriousCoreSimulatorServicesWithError:(NSError **)error;
+
 @end

--- a/FBSimulatorControl/Utility/FBProcessQuery+Simulators.h
+++ b/FBSimulatorControl/Utility/FBProcessQuery+Simulators.h
@@ -24,17 +24,22 @@
 - (NSArray *)simulatorProcesses;
 
 /**
+ Fetches an NSArray<id<FBProcessInfo>> of all com.apple.CoreSimulator.CoreSimulatorService.
+ */
+- (NSArray *)coreSimulatorServiceProcesses;
+
+/**
  Returns a Predicate that matches simulator processes only from the Xcode version in the provided configuration.
  
  @param configuration the configuration to match against.
- @return an NSPredicate that operates on an Collection of FBSimulators
+ @return an NSPredicate that operates on an Collection of id<FBProcessInfo>.
  */
 + (NSPredicate *)simulatorsProcessesLaunchedUnderConfiguration:(FBSimulatorControlConfiguration *)configuration;
 
 /**
  Returns a Predicate that matches simulator processes launched by FBSimulatorControl
  
- @return an NSPredicate that operates on an Collection of FBSimulators
+ @return an NSPredicate that operates on an Collection of id<FBProcessInfo>.
  */
 + (NSPredicate *)simulatorProcessesLaunchedBySimulatorControl;
 
@@ -42,7 +47,7 @@
  Constructs a Predicate that matches processes with any of the Simulators in an collection of FBSimulators.
  
  @param simulators an NSArray<FBSimulator *> of the Simulators to match.
- @return an NSPredicate that operates on an Collection of FBSimulators
+ @return an NSPredicate that operates on an Collection of id<FBProcessInfo>.
  */
 + (NSPredicate *)simulatorProcessesMatchingSimulators:(NSArray *)simulators;
 
@@ -50,8 +55,15 @@
  Constructs a Predicate that matches processes with any of the Simulators in an collection String UDIDS.
 
  @param simulators an NSArray<NSString *> of the Simulator UDIDs to match.
- @return an NSPredicate that operates on an Collection of FBSimulators
+ @return an NSPredicate that operates on an Collection of id<FBProcessInfo>.
  */
 + (NSPredicate *)simulatorProcessesMatchingUDIDs:(NSArray *)simulators;
+
+/**
+ Constructs a Predicate that matches CoreSimulatorService Processes for the current xcode versions
+
+ @return an NSPredicate that operates on an Collection of id<FBProcessInfo>.
+ */
++ (NSPredicate *)coreSimulatorProcessesForCurrentXcode;
 
 @end

--- a/FBSimulatorControl/Utility/FBProcessQuery+Simulators.m
+++ b/FBSimulatorControl/Utility/FBProcessQuery+Simulators.m
@@ -24,6 +24,11 @@
   return [self processesWithLaunchPathSubstring:@"Simulator.app"];
 }
 
+- (NSArray *)coreSimulatorServiceProcesses
+{
+  return [self processesWithLaunchPathSubstring:@"Contents/MacOS/com.apple.CoreSimulator.CoreSimulatorService"];
+}
+
 + (NSPredicate *)simulatorsProcessesLaunchedUnderConfiguration:(FBSimulatorControlConfiguration *)configuration
 {
   // If it's from a different Xcode version, the binary path will be different.
@@ -56,6 +61,13 @@
   return [NSPredicate predicateWithBlock:^ BOOL (id<FBProcessInfo> process, NSDictionary *_) {
     NSSet *argumentSet = [NSSet setWithArray:process.arguments];
     return [udidSet intersectsSet:argumentSet];
+  }];
+}
+
++ (NSPredicate *)coreSimulatorProcessesForCurrentXcode
+{
+  return [NSPredicate predicateWithBlock:^ BOOL (id<FBProcessInfo> processInfo, NSDictionary *_) {
+    return [processInfo.launchPath rangeOfString:FBSimulatorControlStaticConfiguration.developerDirectory].location != NSNotFound;
   }];
 }
 

--- a/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
@@ -80,7 +80,7 @@
 
 - (void)setUp
 {
-  self.managementOptions = FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart | FBSimulatorManagementOptionsIgnoreSpuriousKillFail | FBSimulatorManagementOptionsDeleteOnFree;
+  self.managementOptions = FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart | FBSimulatorManagementOptionsIgnoreSpuriousKillFail | FBSimulatorManagementOptionsDeleteOnFree | FBSimulatorManagementOptionsKillSpuriousCoreSimulatorServices;
   self.simulatorConfiguration = FBSimulatorConfiguration.iPhone5;
   self.deviceSetPath = nil;
 }


### PR DESCRIPTION
Having versions of `com.apple.CoreSimulator.CoreSimulatorService` hanging around can lead to issues when switching versions of xcode locally (and not rebooting). Using `xcode-select` will not kill the service, so this startup option adds another (optional) precondition.