### PR TITLE
Avoid confusing launchservicesd with fast multi-app termination

### DIFF
--- a/FBSimulatorControl/Utility/FBProcessQuery+Simulators.h
+++ b/FBSimulatorControl/Utility/FBProcessQuery+Simulators.h
@@ -14,11 +14,14 @@
 #import <FBSimulatorControl/FBProcessQuery.h>
 
 @class FBSimulatorControlConfiguration;
+@class SimDevice;
 
 /**
- FBProcessQuery to NSPredicate.
+ Extension for obtaining Simulator Process information.
  */
 @interface FBProcessQuery (Simulators)
+
+#pragma mark Process Fetching
 
 /**
  Fetches an NSArray<id<FBProcessInfo>> of all Simulator Application Processes.
@@ -29,6 +32,29 @@
  Fetches an NSArray<id<FBProcessInfo>> of all com.apple.CoreSimulator.CoreSimulatorService.
  */
 - (NSArray *)coreSimulatorServiceProcesses;
+
+/**
+ Fetches an NSArray<id<FBProcessInfo>> of all launchd_sim processes.
+ */
+- (NSArray *)launchdSimProcesses;
+
+/**
+ Fetches the Process Info for a given Simulator.
+ 
+ @param simDevice the Simulator to fetch Process Info for.
+ @return Process Info if any could be obtained, nil otherwise.
+ */
+- (id<FBProcessInfo>)simulatorApplicationProcessForSimDevice:(SimDevice *)simDevice;
+
+/**
+ Fetches the Process Info for a given Simulator's launchd_sim.
+
+ @param simDevice the Simulator to fetch Process Info for.
+ @return Process Info if any could be obtained, nil otherwise.
+ */
+- (id<FBProcessInfo>)launchdSimProcessForSimDevice:(SimDevice *)simDevice;
+
+#pragma mark Predicates
 
 /**
  Returns a Predicate that matches simulator processes only from the Xcode version in the provided configuration.
@@ -46,20 +72,20 @@
 + (NSPredicate *)simulatorProcessesLaunchedBySimulatorControl;
 
 /**
- Constructs a Predicate that matches processes with any of the Simulators in an collection of FBSimulators.
+ Constructs a Predicate that matches Process Info for Simulator Applications for the given UDIDs.
 
- @param simulators an NSArray<FBSimulator *> of the Simulators to match.
+ @param udids an NSArray<NSString *> of the Simulator UDIDs to match.
  @return an NSPredicate that operates on an Collection of id<FBProcessInfo>.
  */
-+ (NSPredicate *)simulatorProcessesMatchingSimulators:(NSArray *)simulators;
++ (NSPredicate *)simulatorProcessesMatchingUDIDs:(NSArray *)udids;
 
 /**
- Constructs a Predicate that matches processes with any of the Simulators in an collection String UDIDS.
+ Constructs a Predicate that matches Process Info for launchd_sim process for the given UDIDs.
 
- @param simulators an NSArray<NSString *> of the Simulator UDIDs to match.
+ @param udids an NSArray<NSString *> of the Simulator UDIDs to match.
  @return an NSPredicate that operates on an Collection of id<FBProcessInfo>.
  */
-+ (NSPredicate *)simulatorProcessesMatchingUDIDs:(NSArray *)simulators;
++ (NSPredicate *)launchdSimProcessesMatchingUDIDs:(NSArray *)udids;
 
 /**
  Constructs a Predicate that matches CoreSimulatorService Processes for the current xcode versions

--- a/FBSimulatorControl/Utility/FBProcessQuery.h
+++ b/FBSimulatorControl/Utility/FBProcessQuery.h
@@ -9,6 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
+@class NSRunningApplication;
 @protocol FBProcessInfo;
 
 /**
@@ -59,9 +60,15 @@
 - (pid_t)processWithOpenFileTo:(const char *)filename;
 
 /**
- Returns an an Array of NSRunningApplications for the provided array of FBProcessInfo.
+ Returns an Array of NSRunningApplications for the provided array of FBProcessInfo.
  Any Applications that could not be found will be replaced with NSNull.null.
  */
 - (NSArray *)runningApplicationsForProcesses:(NSArray *)processes;
+
+/**
+ Returns the NSRunningApplication for the provided id<FBProcessInfo>.
+ Any Applications that could not be found will be replaced with NSNull.null.
+ */
+- (NSRunningApplication *)runningApplicationForProcess:(id<FBProcessInfo>)process;
 
 @end

--- a/FBSimulatorControl/Utility/FBProcessQuery.m
+++ b/FBSimulatorControl/Utility/FBProcessQuery.m
@@ -307,6 +307,19 @@ static BOOL ProcessNameForProcessIdentifier(pid_t processIdentifier, char *buffe
   return [self.processIdentifiersToApplications objectsForKeys:[processes valueForKey:@"processIdentifier"] notFoundMarker:NSNull.null];
 }
 
+- (NSRunningApplication *)runningApplicationForProcess:(id<FBProcessInfo>)process
+{
+  NSRunningApplication *application = [[self
+    runningApplicationsForProcesses:@[process]]
+    firstObject];
+
+  if (![application isKindOfClass:NSRunningApplication.class]) {
+    return nil;
+  }
+
+  return application;
+}
+
 #pragma mark Private
 
 - (NSDictionary *)processIdentifiersToApplications

--- a/FBSimulatorControlTests/Tests/FBSimulatorControlSimulatorLaunchTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorControlSimulatorLaunchTests.m
@@ -81,16 +81,20 @@
   [self.assert interactionSuccessful:session2.interact.bootSimulator];
   [self.assert interactionSuccessful:session3.interact.bootSimulator];
 
-  NSMutableSet *simulatorPIDs = [NSMutableSet set];
-  for (FBSimulatorSession *session in @[session1, session2, session3]) {
+  NSArray *sessions = @[session1, session2, session3];
+  for (FBSimulatorSession *session in sessions) {
     XCTAssertEqual(session.simulator.state, FBSimulatorStateBooted);
     XCTAssertEqual(session.state.lifecycle, FBSimulatorSessionLifecycleStateStarted);
     XCTAssertEqual(session.state.runningApplications.count, 0u);
     XCTAssertEqual(session.state.runningAgents.count, 0u);
     XCTAssertNotNil(session.simulator.launchInfo);
+  }
 
-    [simulatorPIDs addObject:@(session.simulator.launchInfo.simulatorProcess.processIdentifier)];
+  XCTAssertEqual([NSSet setWithArray:[sessions valueForKeyPath:@"simulator.launchInfo.simulatorProcess.processIdentifier"]].count, 3u);
+  XCTAssertEqual([NSSet setWithArray:[sessions valueForKeyPath:@"simulator.launchInfo.launchdProcess.processIdentifier"]].count, 3u);
+  XCTAssertEqual([NSSet setWithArray:[sessions valueForKeyPath:@"simulator.launchInfo.simulatorApplication"]].count, 3u);
 
+  for (FBSimulatorSession *session in sessions) {
     XCTAssertTrue([session terminateWithError:&error]);
     XCTAssertNil(error);
     XCTAssertNil(session.simulator.launchInfo);
@@ -98,7 +102,6 @@
   }
 
   XCTAssertEqual(self.control.simulatorPool.allocatedSimulators.count, 0u);
-  XCTAssertEqual(simulatorPIDs.count, 3u);
 }
 
 @end


### PR DESCRIPTION
It's possible to get `launchdservicesd` into a funk by shutting down Simulators too fast. Killing 2 or more simulators at the same time requires some time between kill/termination. By altering the way that multiple simulators are killed, we can ensure that there is sufficient time between kills to not get the dock in a funk.