### PR TITLE
Share FBSimulator instances

### DIFF
--- a/FBSimulatorControl/Management/FBSimulatorPool+Private.h
+++ b/FBSimulatorControl/Management/FBSimulatorPool+Private.h
@@ -9,12 +9,14 @@
 
 #import <FBSimulatorControl/FBSimulatorPool.h>
 
+@class FBProcessQuery;
+
 @interface FBSimulatorPool ()
 
-@property (nonatomic, copy, readwrite) FBSimulatorControlConfiguration *configuration;
+@property (nonatomic, strong, readonly) SimDeviceSet *deviceSet;
+@property (nonatomic, strong, readonly) FBProcessQuery *processQuery;
 
-@property (nonatomic, strong, readwrite) SimDeviceSet *deviceSet;
-@property (nonatomic, strong, readwrite) NSMutableOrderedSet *allocatedUDIDs;
-@property (nonatomic, strong, readwrite) NSRegularExpression *managedSimulatorPoolOffsetRegex;
+@property (nonatomic, strong, readonly) NSMutableOrderedSet *allocatedUDIDs;
+@property (nonatomic, strong, readonly) NSMutableDictionary *inflatedSimulators;
 
 @end

--- a/FBSimulatorControl/Management/FBSimulatorPool.h
+++ b/FBSimulatorControl/Management/FBSimulatorPool.h
@@ -20,7 +20,7 @@
 @protocol FBSimulatorLogger;
 
 /**
- A wrapper around the DeviceSet, to support meaningful queries.
+ A container for a collection of Simulators.
  */
 @interface FBSimulatorPool : NSObject
 
@@ -44,7 +44,7 @@
  Ordering is based on the ordering of SimDeviceSet.
  Is an NSOrderedSet<FBSimulator>
  */
-@property (nonatomic, copy, readonly) NSOrderedSet *allSimulators;
+@property (nonatomic, copy, readonly) NSArray *allSimulators;
 
 /**
  Returns the Simulator Termination Strategy associated with the reciever.
@@ -110,30 +110,11 @@
 @interface FBSimulatorPool (Fetchers)
 
 /**
- Finds the Device UDID for the given device name and SDK version combination.
- If a simulatorSDK is not provided, the first device matching the given deviceName will be returned.
- This will search for all devices in the set, whether the Pool will manage them or not.
-
- @param deviceName the Device Name to search for. Must not be nil.
- @param simulatorSDK the SDK Runtime of the Simulator. May be nil.
- @returns The Device UDID that matches the parameters, nil if no match could be found.
- */
-- (NSString *)deviceUDIDWithName:(NSString *)deviceName simulatorSDK:(NSString *)simulatorSDK;
-
-/**
- Returns the first Simulator allocated by FBSimulatorPool, based on the device type alone.
-
- @param deviceType the Device Type of the Device to search for. Must not be nil.
- @return The Allocated device created by FBSimulatorPool.
- */
-- (FBSimulator *)allocatedSimulatorWithDeviceType:(NSString *)deviceType;
-
-/**
  An Ordered Set of the Simulators that this Pool has allocated.
  This includes only allocated simulators.
  Is an NSOrderedSet<FBSimulator>
  */
-@property (nonatomic, copy, readonly) NSOrderedSet *allocatedSimulators;
+@property (nonatomic, copy, readonly) NSArray *allocatedSimulators;
 
 /**
  An Ordered Set of the Simulators that this Pool has allocated.
@@ -141,13 +122,13 @@
  Ordering is based on the recency of the allocation: the most recent allocated Simulator is at the end of the Set.
  Is an NSOrderedSet<FBSimulator>
  */
-@property (nonatomic, copy, readonly) NSOrderedSet *unallocatedSimulators;
+@property (nonatomic, copy, readonly) NSArray *unallocatedSimulators;
 
 /**
  An Ordered Set of the Simulators that have been launched by any pool, or not by FBSimulatorControl at all.
  Is an NSOrderedSet<FBSimulator>
  */
-@property (nonatomic, copy, readonly) NSOrderedSet *launchedSimulators;
+@property (nonatomic, copy, readonly) NSArray *launchedSimulators;
 
 @end
 

--- a/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.h
+++ b/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.h
@@ -10,6 +10,7 @@
 #import <Foundation/Foundation.h>
 
 @class FBSimulatorControlConfiguration;
+@class FBProcessQuery;
 
 /**
  A class for terminating Simulators.
@@ -21,8 +22,11 @@
 
  @param configuration the Configuration of FBSimulatorControl.
  @param allSimulators the Simulators that are permitted to be terminated.
+ @param processQuery the process query object to use. If nil, one will be created
+
+ @return a configured FBSimulatorTerminationStrategy instance.
  */
-+ (instancetype)withConfiguration:(FBSimulatorControlConfiguration *)configuration allSimulators:(NSArray *)allSimulators;
++ (instancetype)withConfiguration:(FBSimulatorControlConfiguration *)configuration allSimulators:(NSArray *)allSimulators processQuery:(FBProcessQuery *)processQuery;
 
 /**
  Kills all of the Simulators associated with the reciever.

--- a/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.m
+++ b/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.m
@@ -82,15 +82,16 @@
 
 #pragma mark Initialization
 
-+ (instancetype)withConfiguration:(FBSimulatorControlConfiguration *)configuration allSimulators:(NSArray *)allSimulators;
++ (instancetype)withConfiguration:(FBSimulatorControlConfiguration *)configuration allSimulators:(NSArray *)allSimulators processQuery:(FBProcessQuery *)processQuery
 {
   BOOL useKill = (configuration.options & FBSimulatorManagementOptionsUseProcessKilling) == FBSimulatorManagementOptionsUseProcessKilling;
+  processQuery = processQuery ?: [FBProcessQuery new];
   return useKill
-    ? [[FBSimulatorTerminationStrategy_Kill alloc] initWithConfiguration:configuration allSimulators:allSimulators]
-    : [[FBSimulatorTerminationStrategy_WorkspaceQuit alloc] initWithConfiguration:configuration allSimulators:allSimulators];
+    ? [[FBSimulatorTerminationStrategy_Kill alloc] initWithConfiguration:configuration allSimulators:allSimulators processQuery:processQuery]
+    : [[FBSimulatorTerminationStrategy_WorkspaceQuit alloc] initWithConfiguration:configuration allSimulators:allSimulators processQuery:processQuery];
 }
 
-- (instancetype)initWithConfiguration:(FBSimulatorControlConfiguration *)configuration allSimulators:(NSArray *)allSimulators
+- (instancetype)initWithConfiguration:(FBSimulatorControlConfiguration *)configuration allSimulators:(NSArray *)allSimulators processQuery:(FBProcessQuery *)processQuery
 {
   self = [super init];
   if (!self) {
@@ -99,7 +100,7 @@
 
   _configuration = configuration;
   _allSimulators = allSimulators;
-  _processQuery = [FBProcessQuery new];
+  _processQuery = processQuery;
 
   return self;
 }

--- a/FBSimulatorControl/Tiling/FBSimulatorWindowHelpers.h
+++ b/FBSimulatorControl/Tiling/FBSimulatorWindowHelpers.h
@@ -29,10 +29,10 @@
  Creates and returns an NSArray<NSDictionary> of Simulator.app Windows that belong to the Ordered Set of Simulator.
  The Dictionary contains Windows in format from 'Quartz Window Services'
 
- @param simulators the Simulators to find Windows For.
+ @param simulators the array of Simulators to find Windows For.
  @return array an Array of the windows that could be found for the provided Simulators.
  */
-+ (NSArray *)windowsForSimulators:(NSOrderedSet *)simulators;
++ (NSArray *)windowsForSimulators:(NSArray *)simulators;
 
 /**
  Returns the CGDirectDisplayID for the provided Simulator.

--- a/FBSimulatorControl/Tiling/FBSimulatorWindowHelpers.m
+++ b/FBSimulatorControl/Tiling/FBSimulatorWindowHelpers.m
@@ -33,7 +33,7 @@ static void EnsureCGIsInitialized(void)
     [FBSimulatorPredicates launched],
     [NSCompoundPredicate notPredicateWithSubpredicate:[FBSimulatorPredicates only:simulator]],
   ]];
-  NSOrderedSet *simulators = [simulator.pool.allSimulators filteredOrderedSetUsingPredicate:predicate];
+  NSArray *simulators = [simulator.pool.allSimulators filteredArrayUsingPredicate:predicate];
   NSArray *windows = [self windowsForSimulators:simulators];
 
   NSMutableArray *boundsValues = [NSMutableArray array];
@@ -48,7 +48,7 @@ static void EnsureCGIsInitialized(void)
   return [boundsValues copy];
 }
 
-+ (NSArray *)windowsForSimulators:(NSOrderedSet *)simulators
++ (NSArray *)windowsForSimulators:(NSArray *)simulators
 {
   NSArray *windows = CFBridgingRelease(CGWindowListCopyWindowInfo(kCGWindowListOptionAll, kCGNullWindowID));
 
@@ -76,7 +76,7 @@ static void EnsureCGIsInitialized(void)
 {
   EnsureCGIsInitialized();
 
-  NSDictionary *window = [[self windowsForSimulators:[NSOrderedSet orderedSetWithObject:simulator]] firstObject];
+  NSDictionary *window = [[self windowsForSimulators:@[simulator]] firstObject];
   if (!window) {
     return 0;
   }

--- a/FBSimulatorControlTests/Tests/FBSimulatorPoolAllocationTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorPoolAllocationTests.m
@@ -94,8 +94,8 @@
   XCTAssertTrue([self.control.simulatorPool deleteAllWithError:&error]);
   XCTAssertNil(error);
 
-  NSOrderedSet *uuidSet = [self.control.simulatorPool.allSimulators valueForKey:@"udid"];
-  [simulatorUUIDs intersectSet:uuidSet.set];
+  NSSet *uuidSet = [NSSet setWithArray:[self.control.simulatorPool.allSimulators valueForKey:@"udid"]];
+  [simulatorUUIDs intersectSet:uuidSet];
   XCTAssertEqual(simulatorUUIDs.count, 0u);
 }
 

--- a/FBSimulatorControlTests/Tests/FBSimulatorPoolTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorPoolTests.m
@@ -95,7 +95,7 @@
     @{@"name" : @"iPad", @"state" : @(FBSimulatorStateBooted)}
   ]];
 
-  NSOrderedSet *simulators = self.pool.allSimulators;
+  NSArray *simulators = self.pool.allSimulators;
   XCTAssertEqual(simulators.count, 8u);
 
   XCTAssertEqualObjects([simulators[0] name], @"iPad 2");
@@ -149,7 +149,7 @@
     [mockedSimulators[3] UDID]
   ]];
 
-  NSOrderedSet *simulators = self.pool.allocatedSimulators;
+  NSArray *simulators = self.pool.allocatedSimulators;
   XCTAssertEqual(simulators.count, 2u);
 
   XCTAssertEqualObjects([simulators[0] name], @"iPad 2");
@@ -186,6 +186,29 @@
   XCTAssertEqualObjects([simulators[5] name], @"iPad");
   XCTAssertEqual([simulators[5] state], FBSimulatorStateBooted);
   XCTAssertEqual([simulators[5] pool], self.pool);
+}
+
+- (void)testReferencesForSimulatorsAreTheSame
+{
+  [self createPoolWithExistingSimDeviceSpecs:@[
+    @{@"name" : @"iPad 2", @"state" : @(FBSimulatorStateBooted)},
+    @{@"name" : @"iPhone 5", @"state" : @(FBSimulatorStateCreating)},
+    @{@"name" : @"iPhone 5", @"state" : @(FBSimulatorStateShutdown)},
+    @{@"name" : @"iPad 3", @"state" : @(FBSimulatorStateCreating)},
+    @{@"name" : @"iPhone 6S", @"state" : @(FBSimulatorStateShuttingDown) },
+    @{@"name" : @"iPhone 5", @"state" : @(FBSimulatorStateBooted)},
+    @{@"name" : @"iPhone 5", @"state" : @(FBSimulatorStateShutdown)},
+    @{@"name" : @"iPad", @"state" : @(FBSimulatorStateBooted)}
+  ]];
+
+  NSArray *firstFetch = self.pool.allSimulators;
+  NSArray *secondFetch = self.pool.allSimulators;
+  XCTAssertEqualObjects(firstFetch, secondFetch);
+
+  // Reference equality.
+  for (NSUInteger index = 0; index < firstFetch.count; index++) {
+    XCTAssertEqual(firstFetch[index], secondFetch[index]);
+  }
 }
 
 @end

--- a/fbsimctl/Sources/Command.swift
+++ b/fbsimctl/Sources/Command.swift
@@ -46,8 +46,8 @@ public indirect enum Format {
 public indirect enum Query {
   case UDID(String)
   case State(FBSimulatorState)
-  case Compound([Query])
   case Configured(FBSimulatorConfiguration)
+  case Compound([Query])
 }
 
 /**


### PR DESCRIPTION
We are creating `FBSimulator` instances every time that the `allSimulators` property of `FBSimulatorPool` is called. In reality these objects are references and not values, as we want the process information to be updated in-place. This solves two issues:
1) Process Launch Info is only calculated once per Simulator
2) Notifications for Process lifecycle can be uniqued based on a single simulator instance, this means that notifications for Simulator and Simulator Subprocess launch can come from the Simulator itself.