### PR TITLE
Get Process Info on Process Launch

### DIFF
--- a/FBSimulatorControl/Management/FBSimulatorInteraction+Agents.m
+++ b/FBSimulatorControl/Management/FBSimulatorInteraction+Agents.m
@@ -19,6 +19,8 @@
 #import "FBProcessLaunchConfiguration.h"
 #import "FBSimulatorSessionLifecycle.h"
 #import "FBSimulator.h"
+#import "FBSimulator+Private.h"
+#import "FBSimDeviceWrapper.h"
 #import "FBProcessInfo.h"
 #import "FBSimulatorError.h"
 
@@ -44,17 +46,17 @@
       return [FBSimulatorError failBoolWithError:innerError errorOut:error];
     }
 
-    pid_t processIdentifier = [simulator.device
+    id<FBProcessInfo> process = [[FBSimDeviceWrapper withSimDevice:simulator.device processQuery:simulator.processQuery]
       spawnWithPath:agentLaunch.agentBinary.path
       options:options
       terminationHandler:NULL
       error:&innerError];
 
-    if (processIdentifier <= 0) {
+    if (!process) {
       return [[[[FBSimulatorError describeFormat:@"Failed to start Agent %@", agentLaunch] causedBy:innerError] inSimulator:simulator] failBool:error];
     }
 
-    [lifecycle agentDidLaunch:agentLaunch didStartWithProcessIdentifier:processIdentifier stdOut:stdOut stdErr:stdErr];
+    [lifecycle agentDidLaunch:agentLaunch didStartWithProcessIdentifier:process.processIdentifier stdOut:stdOut stdErr:stdErr];
     return YES;
   }];
 }

--- a/FBSimulatorControl/Session/FBSimDeviceWrapper.h
+++ b/FBSimulatorControl/Session/FBSimDeviceWrapper.h
@@ -9,13 +9,53 @@
 
 #import <Foundation/Foundation.h>
 
+@protocol FBProcessInfo;
 @class SimDevice;
+@class FBProcessQuery;
 
+/**
+ Augments SimDevice.
+ */
 @interface FBSimDeviceWrapper : NSObject
 
-- (instancetype)initWithSimDevice:(SimDevice *)device;
+/**
+ Creates a SimDevice Wrapper.
 
-- (int)launchApplicationWithID:(NSString *)appID options:(NSDictionary *)options error:(NSError **)error;
+ @param device the device to wrap
+ @param processQuery the Process Query to obtain process information.
+ @return a new SimDevice wrapper.
+ */
++ (instancetype)withSimDevice:(SimDevice *)device processQuery:(FBProcessQuery *)processQuery;
+
+/**
+ Boots an Application, timing out if CoreSimulator gets stuck in a semaphore.
+
+ @param appID the Application ID to use.
+ @param options the Options to use in the launch.
+ @param error an error out for any error that occured.
+ @return the Process Identifier of the launched process, -1 otherwise.
+ */
+- (id<FBProcessInfo>)launchApplicationWithID:(NSString *)appID options:(NSDictionary *)options error:(NSError **)error;
+
+/**
+ Installs an Application, timing out if CoreSimulator gets stuck in a semaphore.
+
+ @param appURL the Application URL to use.
+ @param options the Options to use in the launch.
+ @param error an error out for any error that occured.
+ @return YES if the Application was installed successfully, NO otherwise.
+ */
 - (BOOL)installApplication:(NSURL *)appURL withOptions:(NSDictionary *)options error:(NSError **)error;
+
+/**
+ Spawns a binary, timing out if CoreSimulator gets stuck in a semaphore.
+
+ @param launchPath the path to the binary.
+ @param options the Options to use in the launch.
+ @param terminationHandler ?????
+ @param error an error out for any error that occured.
+ @return the Process Identifier of the launched process, -1 otherwise.
+ */
+- (id<FBProcessInfo>)spawnWithPath:(NSString *)launchPath options:(NSDictionary *)options terminationHandler:(id)terminationHandler error:(NSError **)error;
 
 @end

--- a/FBSimulatorControl/Session/FBSimDeviceWrapper.m
+++ b/FBSimulatorControl/Session/FBSimDeviceWrapper.m
@@ -11,25 +11,35 @@
 
 #import <CoreSimulator/SimDevice.h>
 
+#import "FBProcessInfo.h"
+#import "FBProcessQuery.h"
 #import "FBSimulatorError.h"
+#import "NSRunLoop+SimulatorControlAdditions.h"
 
 const long kFBSimDeviceCommandTimeout = 30;
 
 @interface FBSimDeviceWrapper ()
 
-@property (atomic, assign) SimDevice *device;
+@property (nonatomic, strong, readonly) SimDevice *device;
+@property (nonatomic, strong, readonly) FBProcessQuery *query;
 
 @end
 
 @implementation FBSimDeviceWrapper
 
-- (instancetype)initWithSimDevice:(SimDevice *)device
++ (instancetype)withSimDevice:(SimDevice *)device processQuery:(FBProcessQuery *)processQuery
+{
+  return [[self alloc] initWithSimDevice:device processQuery:processQuery];
+}
+
+- (instancetype)initWithSimDevice:(SimDevice *)device processQuery:(FBProcessQuery *)query
 {
   if (!(self = [self init])) {
     return nil;
   }
 
   _device = device;
+  _query = query;
 
   return self;
 }
@@ -56,7 +66,7 @@ const long kFBSimDeviceCommandTimeout = 30;
   dispatch_semaphore_signal(semaphore);
 }
 
-- (int)launchApplicationWithID:(NSString *)appID options:(NSDictionary *)options error:(NSError **)error
+- (id<FBProcessInfo>)launchApplicationWithID:(NSString *)appID options:(NSDictionary *)options error:(NSError **)error
 {
   NSAssert([NSThread isMainThread], @"Must be called from the main thread.");
 
@@ -68,13 +78,12 @@ const long kFBSimDeviceCommandTimeout = 30;
   [invocation setArgument:&error atIndex:4];
 
   if (![self runInvocationInBackgroundUntilTimeout:invocation]) {
-    [[FBSimulatorError describe:@"Timed out calling launchApplicationWithID"] fail:error];
-    return 0;
+    return [[FBSimulatorError describe:@"Timed out calling launchApplicationWithID"] fail:error];
   }
 
   pid_t pid;
   [invocation getReturnValue:&pid];
-  return pid;
+  return [self processInfoForProcessIdentifier:pid error:error];
 }
 
 - (BOOL)installApplication:(NSURL *)appURL withOptions:(NSDictionary *)options error:(NSError **)error
@@ -89,13 +98,35 @@ const long kFBSimDeviceCommandTimeout = 30;
   [invocation setArgument:&error atIndex:4];
 
   if (![self runInvocationInBackgroundUntilTimeout:invocation]) {
-    [[FBSimulatorError describe:@"Timed out calling installApplication"] fail:error];
-    return NO;
+    return [[FBSimulatorError describe:@"Timed out calling installApplication"] failBool:error];
   }
 
   BOOL rv;
   [invocation getReturnValue:&rv];
   return rv;
+}
+
+- (id<FBProcessInfo>)spawnWithPath:(NSString *)launchPath options:(NSDictionary *)options terminationHandler:(id)terminationHandler error:(NSError **)error
+{
+  pid_t processIdentifier = [self.device spawnWithPath:launchPath options:options terminationHandler:terminationHandler error:error];
+  return [self processInfoForProcessIdentifier:processIdentifier error:error];
+}
+
+#pragma mark Private
+
+- (id<FBProcessInfo>)processInfoForProcessIdentifier:(pid_t)processIdentifier error:(NSError **)error
+{
+  if (processIdentifier <= -1) {
+    return nil;
+  }
+
+  id<FBProcessInfo> processInfo = [NSRunLoop.currentRunLoop spinRunLoopWithTimeout:5 untilExists:^ id<FBProcessInfo> {
+    return [self.query processInfoFor:processIdentifier];
+  }];
+  if (!processInfo) {
+    return [[FBSimulatorError describeFormat:@"Timed out waiting for process info for pid %d", processIdentifier] fail:error];
+  }
+  return processInfo;
 }
 
 @end

--- a/FBSimulatorControl/Utility/NSRunLoop+SimulatorControlAdditions.h
+++ b/FBSimulatorControl/Utility/NSRunLoop+SimulatorControlAdditions.h
@@ -23,4 +23,13 @@
  */
 - (BOOL)spinRunLoopWithTimeout:(NSTimeInterval)timeout untilTrue:( BOOL (^)(void) )untilTrue;
 
+/**
+ Spins the Run Loop until `untilTrue` returns a value, or a timeout is reached.
+
+ @oaram timeout the Timeout in Seconds.
+ @param untilExists the mapping to a value.
+ @returns the return value of untilTrue, or nil if a timeout was reached.
+ */
+- (id)spinRunLoopWithTimeout:(NSTimeInterval)timeout untilExists:( id (^)(void) )untilExists;
+
 @end

--- a/FBSimulatorControl/Utility/NSRunLoop+SimulatorControlAdditions.m
+++ b/FBSimulatorControl/Utility/NSRunLoop+SimulatorControlAdditions.m
@@ -26,4 +26,17 @@
   return YES;
 }
 
+- (id)spinRunLoopWithTimeout:(NSTimeInterval)timeout untilExists:( id (^)(void) )untilExists
+{
+  __block id value = nil;
+  BOOL success = [self spinRunLoopWithTimeout:timeout untilTrue:^ BOOL {
+    value = untilExists();
+    return value != nil;
+  }];
+  if (!success) {
+    return nil;
+  }
+  return value;
+}
+
 @end


### PR DESCRIPTION
This can be used to update Simulator state and confirm the app has actually launched. This may also help weed out processes that are short-lived and die too-soon.