### PR TITLE
Marking FBSimulatorControl simulators

### DIFF
--- a/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.h
@@ -9,7 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
-extern NSString *const FBSimulatorControlSimulatorLaunchEnvironmentMagic;
+extern NSString *const FBSimulatorControlSimulatorLaunchEnvironmentSimulatorUDID;
 
 /**
  Environment Globals & other derived constants

--- a/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.m
@@ -13,7 +13,7 @@
 #import "FBSimulatorApplication.h"
 #import "FBTaskExecutor.h"
 
-NSString *const FBSimulatorControlSimulatorLaunchEnvironmentMagic = @"__IS_THIS_TRULY_MAGIC__";
+NSString *const FBSimulatorControlSimulatorLaunchEnvironmentSimulatorUDID = @"FBSIMULATORCONTROL_SIM_UDID";
 
 @implementation FBSimulatorControlStaticConfiguration
 

--- a/FBSimulatorControl/Management/FBSimulator.m
+++ b/FBSimulatorControl/Management/FBSimulator.m
@@ -21,6 +21,7 @@
 #import "FBSimulatorConfiguration+CoreSimulator.h"
 #import "FBSimulatorConfiguration.h"
 #import "FBSimulatorControlConfiguration.h"
+#import "FBSimulatorControlStaticConfiguration.h"
 #import "FBSimulatorError.h"
 #import "FBSimulatorLaunchInfo.h"
 #import "FBSimulatorLogs.h"
@@ -260,9 +261,10 @@ NSString *const FBSimulatorDidTerminateNotification = @"FBSimulatorDidTerminateN
   }
 
   NSRunningApplication *launchedApplication = notification.userInfo[NSWorkspaceApplicationKey];
-  id<FBProcessInfo> processInfo = [self.processQuery processInfoFor:launchedApplication.processIdentifier];
-  NSSet *arguments = [NSSet setWithArray:processInfo.arguments];
-  if (![arguments containsObject:self.udid]) {
+  id<FBProcessInfo> processInfo = [self.processQuery processInfoFor:launchedApplication.processIdentifier];  
+  NSString *UDID = processInfo.environment[FBSimulatorControlSimulatorLaunchEnvironmentSimulatorUDID];
+  const BOOL isSimulatorPreparedWithSimCtl = (UDID && [self.udid isEqualToString:UDID]);
+  if (!isSimulatorPreparedWithSimCtl) {
     return;
   }
 

--- a/FBSimulatorControl/Management/FBSimulatorInteraction.m
+++ b/FBSimulatorControl/Management/FBSimulatorInteraction.m
@@ -59,7 +59,7 @@
     id<FBTask> task = [[[[FBTaskExecutor.sharedInstance
       withLaunchPath:simulator.simulatorApplication.binary.path]
       withArguments:[arguments copy]]
-      withEnvironmentAdditions:@{FBSimulatorControlSimulatorLaunchEnvironmentMagic : @"YES"}]
+      withEnvironmentAdditions:@{FBSimulatorControlSimulatorLaunchEnvironmentSimulatorUDID : simulator.udid}]
       build];
 
     [lifecycle simulatorWillStart:simulator];

--- a/FBSimulatorControl/Utility/FBProcessQuery+Simulators.m
+++ b/FBSimulatorControl/Utility/FBProcessQuery+Simulators.m
@@ -71,17 +71,15 @@
   // since other processes could have launched with UDID arguments.
   return [NSPredicate predicateWithBlock:^ BOOL (id<FBProcessInfo> process, NSDictionary *_) {
     NSSet *argumentSet = [NSSet setWithArray:process.environment.allKeys];
-    return [argumentSet containsObject:FBSimulatorControlSimulatorLaunchEnvironmentMagic];
+    return [argumentSet containsObject:FBSimulatorControlSimulatorLaunchEnvironmentSimulatorUDID];
   }];
 }
 
 + (NSPredicate *)simulatorProcessesMatchingUDIDs:(NSArray *)udids
 {
-  NSSet *udidSet = [NSSet setWithArray:udids];
-
   return [NSPredicate predicateWithBlock:^ BOOL (id<FBProcessInfo> process, NSDictionary *_) {
-    NSSet *argumentSet = [NSSet setWithArray:process.arguments];
-    return [udidSet intersectsSet:argumentSet];
+    NSString *UDID = process.environment[FBSimulatorControlSimulatorLaunchEnvironmentSimulatorUDID];
+    return (UDID && [udids containsObject:UDID]);
   }];
 }
 


### PR DESCRIPTION
Marking FBSimulatorControl simulators with FBSIMULATORCONTROL_SIM_UDID env. It will make it easer to FBSimulatorControl with other simulator managers.