### PR TITLE
Optionally persist Simulator history to file

### DIFF
--- a/FBSimulatorControl/Events/FBSimulatorHistoryGenerator.h
+++ b/FBSimulatorControl/Events/FBSimulatorHistoryGenerator.h
@@ -41,6 +41,8 @@
 /**
  If set to YES: History will be serialized to file.
  If set to NO: History will not be serialized to file.
+ 
+ When setting this to NO, persistent history will be deleted from the filesystem.
  */
 @property (nonatomic, assign, readonly, getter=isPersistenceEnabled) BOOL peristenceEnabled;
 

--- a/FBSimulatorControl/Events/FBSimulatorHistoryGenerator.h
+++ b/FBSimulatorControl/Events/FBSimulatorHistoryGenerator.h
@@ -20,17 +20,28 @@
 /**
  An Object responsible for building `FBSimulatorHistory` be converting events into state.
  Links are maintained to previous states, so the entire history of the Simulator can be interrogated at any time.
+
+ Is also responsible for serializing/deserializing prior history to file.
  */
 @interface FBSimulatorHistoryGenerator : NSObject <FBSimulatorEventSink>
 
 /**
- Creates and returns a State Event Sink for the given Simulator
+ Creates and returns a History Generator for the Provided Simulator.
+ 
+ @param simulator the Simulator to generate history for. Will not be retained. Must not be nil.
+ @return a new FBSimulatorHistoryGenerator instance
  */
-+ (instancetype)withSimulator:(FBSimulator *)simulator;
++ (instancetype)forSimulator:(FBSimulator *)simulator;
 
 /**
- The Current History.
+ The Current History, will be updated as events are recieved.
  */
 @property (nonatomic, strong, readonly) FBSimulatorHistory *history;
+
+/**
+ If set to YES: History will be serialized to file.
+ If set to NO: History will not be serialized to file.
+ */
+@property (nonatomic, assign, readonly, getter=isPersistenceEnabled) BOOL peristenceEnabled;
 
 @end

--- a/FBSimulatorControl/Events/FBSimulatorHistoryGenerator.h
+++ b/FBSimulatorControl/Events/FBSimulatorHistoryGenerator.h
@@ -44,6 +44,6 @@
  
  When setting this to NO, persistent history will be deleted from the filesystem.
  */
-@property (nonatomic, assign, readonly, getter=isPersistenceEnabled) BOOL peristenceEnabled;
+@property (nonatomic, assign, readwrite, getter=isPersistenceEnabled) BOOL peristenceEnabled;
 
 @end

--- a/FBSimulatorControl/Events/FBSimulatorHistoryGenerator.m
+++ b/FBSimulatorControl/Events/FBSimulatorHistoryGenerator.m
@@ -25,6 +25,7 @@
 @implementation FBSimulatorHistoryGenerator
 
 @synthesize peristenceEnabled = _peristenceEnabled;
+@synthesize history = _history;
 
 #pragma mark Initializers
 
@@ -64,6 +65,19 @@
   _peristenceEnabled = peristenceEnabled;
 }
 
+- (FBSimulatorHistory *)history
+{
+  return _history;
+}
+
+- (void)setHistory:(FBSimulatorHistory *)history
+{
+  if (![history isEqual:_history]) {
+    [self persist];
+  }
+  _history = history;
+}
+
 #pragma mark Public
 
 - (FBSimulatorHistory *)currentState
@@ -96,6 +110,14 @@
 {
   return [NSKeyedUnarchiver unarchiveObjectWithFile:[self pathForPerisistantHistory:simulator]]
       ?: [self freshHistoryForSimulator:simulator];
+}
+
+- (BOOL)persist
+{
+  if (!self.isPersistenceEnabled) {
+    return YES;
+  }
+  return [NSKeyedArchiver archiveRootObject:self.history toFile:self.persistencePath];
 }
 
 #pragma mark FBSimulatorEventSink Implementation

--- a/FBSimulatorControl/Events/FBSimulatorHistoryGenerator.m
+++ b/FBSimulatorControl/Events/FBSimulatorHistoryGenerator.m
@@ -24,6 +24,8 @@
 
 @implementation FBSimulatorHistoryGenerator
 
+@synthesize peristenceEnabled = _peristenceEnabled;
+
 #pragma mark Initializers
 
 + (instancetype)forSimulator:(FBSimulator *)simulator
@@ -45,6 +47,21 @@
   _persistencePath = persistencePath;
 
   return self;
+}
+
+#pragma mark Accessors
+
+- (BOOL)isPeristenceEnabled
+{
+  return _peristenceEnabled;
+}
+
+- (void)setPeristenceEnabled:(BOOL)peristenceEnabled
+{
+  if (peristenceEnabled == NO) {
+    [self removePersistentHistory];
+  }
+  _peristenceEnabled = peristenceEnabled;
 }
 
 #pragma mark Public

--- a/FBSimulatorControl/Events/FBSimulatorHistoryGenerator.m
+++ b/FBSimulatorControl/Events/FBSimulatorHistoryGenerator.m
@@ -219,16 +219,4 @@
   return nextSessionState;
 }
 
-+ (FBProcessInfo *)updateProcessState:(FBProcessInfo *)processState withBlock:( FBProcessInfo *(^)(FBProcessInfo *processState) )block
-{
-  FBProcessInfo *nextProcessState = block([processState copy]);
-  if (!nextProcessState) {
-    return processState;
-  }
-  if ([nextProcessState isEqual:processState]) {
-    return processState;
-  }
-  return nextProcessState;
-}
-
 @end

--- a/FBSimulatorControl/Management/FBSimulator+Private.h
+++ b/FBSimulatorControl/Management/FBSimulator+Private.h
@@ -25,6 +25,6 @@
 @property (nonatomic, weak, readwrite) FBSimulatorSession *session;
 
 + (instancetype)fromSimDevice:(SimDevice *)device configuration:(FBSimulatorConfiguration *)configuration pool:(FBSimulatorPool *)pool query:(FBProcessQuery *)query logger:(id<FBSimulatorLogger>)logger;
-- (instancetype)initWithDevice:(SimDevice *)device configuration:(FBSimulatorConfiguration *)configuration pool:(FBSimulatorPool *)pool query:(FBProcessQuery *)query logger:(id<FBSimulatorLogger>)logger;
+- (instancetype)initWithDevice:(SimDevice *)device configuration:(FBSimulatorConfiguration *)configuration pool:(FBSimulatorPool *)pool query:(FBProcessQuery *)query;
 
 @end

--- a/FBSimulatorControl/Management/FBSimulator.m
+++ b/FBSimulatorControl/Management/FBSimulator.m
@@ -42,15 +42,15 @@
 
 + (instancetype)fromSimDevice:(SimDevice *)device configuration:(FBSimulatorConfiguration *)configuration pool:(FBSimulatorPool *)pool query:(FBProcessQuery *)query logger:(id<FBSimulatorLogger>)logger
 {
-  return [[FBSimulator alloc]
+  return [[[FBSimulator alloc]
     initWithDevice:device
     configuration:configuration ?: [FBSimulatorConfiguration inferSimulatorConfigurationFromDevice:device error:nil]
     pool:pool
-    query:query
-    logger:logger];
+    query:query]
+    attachEventSinkComposition:logger];
 }
 
-- (instancetype)initWithDevice:(SimDevice *)device configuration:(FBSimulatorConfiguration *)configuration pool:(FBSimulatorPool *)pool query:(FBProcessQuery *)query logger:(id<FBSimulatorLogger>)logger
+- (instancetype)initWithDevice:(SimDevice *)device configuration:(FBSimulatorConfiguration *)configuration pool:(FBSimulatorPool *)pool query:(FBProcessQuery *)query
 {
   self = [super init];
   if (!self) {
@@ -62,11 +62,16 @@
   _pool = pool;
   _processQuery = query;
 
-  FBSimulatorHistoryGenerator *historyGenerator = [FBSimulatorHistoryGenerator withSimulator:self];
+  return self;
+}
+
+- (instancetype)attachEventSinkComposition:(id<FBSimulatorLogger>)logger
+{
+  FBSimulatorHistoryGenerator *historyGenerator = [FBSimulatorHistoryGenerator forSimulator:self];
   FBSimulatorNotificationEventSink *notificationSink = [FBSimulatorNotificationEventSink withSimulator:self];
   FBSimulatorLoggingEventSink *loggingSink = [FBSimulatorLoggingEventSink withSimulator:self logger:logger];
   FBCompositeSimulatorEventSink *compositeSink = [FBCompositeSimulatorEventSink withSinks:@[historyGenerator, notificationSink, loggingSink]];
-  FBSimulatorEventRelay *relay = [[FBSimulatorEventRelay alloc] initWithSimDevice:device processQuery:query sink:compositeSink];
+  FBSimulatorEventRelay *relay = [[FBSimulatorEventRelay alloc] initWithSimDevice:self.device processQuery:self.processQuery sink:compositeSink];
 
   _historyGenerator = historyGenerator;
   _eventRelay = relay;

--- a/FBSimulatorControl/Management/FBSimulatorPool.h
+++ b/FBSimulatorControl/Management/FBSimulatorPool.h
@@ -26,7 +26,8 @@ typedef NS_OPTIONS(NSUInteger, FBSimulatorAllocationOptions){
   FBSimulatorAllocationOptionsShutdownOnAllocate = 1 << 2, /** Shutdown of the Simulator becomes a precondition of allocation. */
   FBSimulatorAllocationOptionsEraseOnAllocate = 1 << 4, /** Erasing of the Simulator becomes a precondition of allocation. */
   FBSimulatorAllocationOptionsDeleteOnFree = 1 << 5, /** Deleting of the Simulator becomes a postcondition of freeing. */
-  FBSimulatorAllocationOptionsEraseOnFree = 1 << 6 /** Erasing of the Simulator becomes a postcondition of freeing. */
+  FBSimulatorAllocationOptionsEraseOnFree = 1 << 6, /** Erasing of the Simulator becomes a postcondition of freeing. */
+  FBSimulatorAllocationOptionsPersistHistory = 1 << 7 /** Fetch & Persist History for the allocated Simulator. */
 };
 
 @protocol FBSimulatorLogger;

--- a/FBSimulatorControl/Management/FBSimulatorPool.m
+++ b/FBSimulatorControl/Management/FBSimulatorPool.m
@@ -441,7 +441,9 @@
   BOOL shutdown = (options & FBSimulatorAllocationOptionsShutdownOnAllocate) == FBSimulatorAllocationOptionsShutdownOnAllocate;
   BOOL erase = (options & FBSimulatorAllocationOptionsEraseOnAllocate) == FBSimulatorAllocationOptionsEraseOnAllocate;
   BOOL reuse = (options & FBSimulatorAllocationOptionsReuse) == FBSimulatorAllocationOptionsReuse;
+  BOOL enablePersistence = (options & FBSimulatorAllocationOptionsPersistHistory) == FBSimulatorAllocationOptionsPersistHistory;
 
+  // Shutdown first.
   if (shutdown || erase) {
     [self.logger.debug logFormat:@"Shutting down Simulator %@", simulator.udid];
     if (![self.terminationStrategy killSimulators:@[simulator] withError:&innerError]) {
@@ -490,6 +492,9 @@
         failBool:error];
     }
   }
+
+  // Enable/Disable Persistence
+  simulator.historyGenerator.peristenceEnabled = enablePersistence;
 
   return YES;
 }

--- a/FBSimulatorControlTests/Tests/FBSimulatorControlHistoryTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorControlHistoryTests.m
@@ -29,8 +29,8 @@
   device.UDID = [NSUUID UUID];
   device.name = @"iPhoneMega";
 
-  FBSimulator *simulator = [[FBSimulator alloc] initWithDevice:(id)device configuration:nil pool:nil query:nil logger:nil];
-  self.generator = [FBSimulatorHistoryGenerator withSimulator:simulator];
+  FBSimulator *simulator = [[FBSimulator alloc] initWithDevice:(id)device configuration:nil pool:nil query:nil];
+  self.generator = [FBSimulatorHistoryGenerator forSimulator:simulator];
 }
 
 - (void)tearDown

--- a/FBSimulatorControlTests/Tests/FBSimulatorHistoryGeneratorTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorHistoryGeneratorTests.m
@@ -29,8 +29,8 @@
   device.UDID = [NSUUID UUID];
   device.name = @"iPhoneMega";
 
-  FBSimulator *simulator = [[FBSimulator alloc] initWithDevice:(id)device configuration:nil pool:nil query:nil logger:nil];
-  self.generator = [FBSimulatorHistoryGenerator withSimulator:simulator];
+  FBSimulator *simulator = [[FBSimulator alloc] initWithDevice:(id)device configuration:nil pool:nil query:nil];
+  self.generator = [FBSimulatorHistoryGenerator forSimulator:simulator];
 }
 
 - (void)tearDown

--- a/FBSimulatorControlTests/Utilities/CoreSimulatorDoubles.h
+++ b/FBSimulatorControlTests/Utilities/CoreSimulatorDoubles.h
@@ -29,6 +29,7 @@
 
 @property (nonatomic, readwrite, copy) NSString *name;
 @property (nonatomic, readwrite, copy) NSUUID *UDID;
+@property (nonatomic, readwrite, copy) NSString *dataPath;
 @property (nonatomic, readwrite, assign) unsigned long long state;
 @property (nonatomic, readwrite, strong) FBSimulatorControlTests_SimDeviceType_Double *deviceType;
 @property (nonatomic, readwrite, strong) FBSimulatorControlTests_SimDeviceRuntime_Double *runtime;

--- a/FBSimulatorControlTests/Utilities/CoreSimulatorDoubles.m
+++ b/FBSimulatorControlTests/Utilities/CoreSimulatorDoubles.m
@@ -17,9 +17,22 @@
 
 @implementation FBSimulatorControlTests_SimDevice_Double
 
+@synthesize dataPath = _dataPath;
+
 - (BOOL)isEqual:(FBSimulatorControlTests_SimDevice_Double *)object
 {
   return [self.UDID isEqual:object.UDID];
+}
+
+- (NSString *)dataPath
+{
+  if (!_dataPath) {
+    _dataPath = [[NSTemporaryDirectory()
+      stringByAppendingPathComponent:@"SimDevice_Double"]
+      stringByAppendingPathComponent:[NSString stringWithFormat:@"%@_Data", self.UDID.UUIDString]];
+    [NSFileManager.defaultManager createDirectoryAtPath:_dataPath withIntermediateDirectories:YES attributes:nil error:nil];
+  }
+  return _dataPath;
 }
 
 @end


### PR DESCRIPTION
This can be used to re-inflate the knowledge of the history of a Simulator when a Simulator is created. Very handy for the CLI use case, which can work via multiple invocations of a process linking `FBSimulatorControl`.