### PR TITLE
Pool Precondition to Shutdown processless Simulators

### DIFF
--- a/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.h
@@ -16,16 +16,16 @@
  */
 extern NSString *const FBSimulatorControlConfigurationDefaultNamePrefix;
 
+/**
+ Options that apply to each FBSimulatorControl instance.
+ */
 typedef NS_OPTIONS(NSUInteger, FBSimulatorManagementOptions){
-  FBSimulatorManagementOptionsDeleteAllOnFirstStart = 1 << 0,
-  FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart = 1 << 1,
-  FBSimulatorManagementOptionsIgnoreSpuriousKillFail = 1 << 2,
-  FBSimulatorManagementOptionsAlwaysCreateWhenAllocating = 1 << 3,
-  FBSimulatorManagementOptionsDeleteOnFree = 1 << 4,
-  FBSimulatorManagementOptionsEraseOnFree = 1 << 5,
-  FBSimulatorManagementOptionsUseProcessKilling = 1 << 6,
-  FBSimulatorManagementOptionsKillSpuriousCoreSimulatorServices = 1 << 7,
-  FBSimulatorManagementOptionsUseSimDeviceTimeoutResiliance = 1 << 8,
+  FBSimulatorManagementOptionsDeleteAllOnFirstStart = 1 << 0, /** Deletes all of the devices in a when creating a Simulator Pool */
+  FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart = 1 << 1, /** Kills all Simulators not managed by FBSimulatorControl when creating a Pool */
+  FBSimulatorManagementOptionsIgnoreSpuriousKillFail = 1 << 2, /** Don't fail Pool creation when failing to kill spurious Simulators */
+  FBSimulatorManagementOptionsKillSpuriousCoreSimulatorServices = 1 << 3, /** Kills CoreSimulatorService daemons from the non-current Xcode version when creating a Pool */
+  FBSimulatorManagementOptionsUseProcessKilling = 1 << 4, /** Kills Simulators using kill(2) instead of -[NSRunningApplication terminate] */
+  FBSimulatorManagementOptionsUseSimDeviceTimeoutResiliance = 1 << 5, /** Uses an alternative strategy for communicating with the Simulator that may be more robust with Xcode 7.1 */
 };
 
 /**
@@ -53,7 +53,7 @@ typedef NS_OPTIONS(NSUInteger, FBSimulatorManagementOptions){
 @property (nonatomic, copy, readonly) NSString *deviceSetPath;
 
 /**
- The options for Simulator Management.
+ The Options for Simulator Management.
  */
 @property (nonatomic, assign, readonly) FBSimulatorManagementOptions options;
 

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Convenience.h
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Convenience.h
@@ -10,22 +10,6 @@
 #import <FBSimulatorControl/FBSimulatorInteraction.h>
 
 /**
- Some conveniences for making the interactions associated with a Simulator Configuration.
- */
-@interface FBSimulatorInteraction (Convenience)
-
-/**
- Makes an interaction by:
- 1) Setting the Locale (if the configuration contains one)
- 2) Sets up the keyboard
-
- @param configuration the configuration to apply.
- */
-- (instancetype)configureWith:(FBSimulatorConfiguration *)configuration;
-
-@end
-
-/**
  Helps make a more fluent API for interacting with Simulators.
  */
 @interface FBSimulator (FBSimulatorInteraction)

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Convenience.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Convenience.m
@@ -12,18 +12,6 @@
 #import "FBSimulatorConfiguration.h"
 #import "FBSimulatorInteraction+Setup.h"
 
-@implementation FBSimulatorInteraction (Convenience)
-
-- (instancetype)configureWith:(FBSimulatorConfiguration *)configuration
-{
-  if (configuration.locale) {
-    [self setLocale:configuration.locale];
-  }
-  return [self setupKeyboard];
-}
-
-@end
-
 @implementation FBSimulator (FBSimulatorInteraction)
 
 - (FBSimulatorInteraction *)interact

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction.m
@@ -101,11 +101,10 @@
 
     FBSimulatorTerminationStrategy *terminationStrategy = [FBSimulatorTerminationStrategy
       withConfiguration:simulator.pool.configuration
-      allSimulators:@[simulator]
       processQuery:simulator.processQuery];
 
     NSError *innerError = nil;
-    if (![terminationStrategy killAllWithError:&innerError]) {
+    if (![terminationStrategy killSimulators:@[simulator] withError:&innerError]) {
       return [[[[FBSimulatorError describe:@"Could not shutdown simulator"] inSimulator:simulator] causedBy:innerError] failBool:error];
     }
     [simulator.eventSink didTerminate:YES];

--- a/FBSimulatorControl/Management/FBSimulator+Helpers.h
+++ b/FBSimulatorControl/Management/FBSimulator+Helpers.h
@@ -64,4 +64,12 @@
  */
 - (NSString *)pathForStorage:(NSString *)key ofExtension:(NSString *)extension;
 
+/**
+ Erases the Simulator, with a descriptive message in the event of a failure.
+
+ @param error a descriptive error for any error that occurred.
+ @return YES if successful, NO otherwise.
+ */
+- (BOOL)eraseWithError:(NSError **)error;
+
 @end

--- a/FBSimulatorControl/Management/FBSimulator+Helpers.m
+++ b/FBSimulatorControl/Management/FBSimulator+Helpers.m
@@ -9,6 +9,8 @@
 
 #import "FBSimulator+Helpers.h"
 
+#import <CoreSimulator/SimDevice.h>
+
 #import "FBSimulatorError.h"
 #import "FBSimulatorPool.h"
 #import "NSRunLoop+SimulatorControlAdditions.h"
@@ -100,6 +102,15 @@
   BOOL success = [NSFileManager.defaultManager createFileAtPath:path contents:NSData.data attributes:nil];
   NSAssert(success, @"Cannot create a path for storage at %@", path);
   return path;
+}
+
+- (BOOL)eraseWithError:(NSError **)error
+{
+  NSError *innerError = nil;
+  if (![self.device eraseContentsAndSettingsWithError:&innerError]) {
+    return [[[[FBSimulatorError describeFormat:@"Failed to Erase Contents and Settings %@", self] causedBy:innerError] inSimulator:self] failBool:error];
+  }
+  return YES;
 }
 
 @end

--- a/FBSimulatorControl/Management/FBSimulatorControl+Class.h
+++ b/FBSimulatorControl/Management/FBSimulatorControl+Class.h
@@ -9,10 +9,11 @@
 
 #import <Foundation/Foundation.h>
 
+#import <FBSimulatorControl/FBSimulatorPool.h>
+
 @class FBSimulatorApplication;
 @class FBSimulatorConfiguration;
 @class FBSimulatorControlConfiguration;
-@class FBSimulatorPool;
 @class FBSimulatorSession;
 
 /**
@@ -33,10 +34,11 @@
  Creates and returns a new FBSimulatorSession instance. Does not launch the Simulator or any Applications.
 
  @param simulatorConfiguration the Configuration of the Simulator to Launch.
+ @param options the options to for the allocation/freeing of the Simulator.
  @param error an outparam for describing any error that occured during the creation of the Session.
  @returns A new `FBSimulatorSession` instance, or nil if an error occured.
  */
-- (FBSimulatorSession *)createSessionForSimulatorConfiguration:(FBSimulatorConfiguration *)simulatorConfiguration error:(NSError **)error;
+- (FBSimulatorSession *)createSessionForSimulatorConfiguration:(FBSimulatorConfiguration *)simulatorConfiguration options:(FBSimulatorAllocationOptions)options error:(NSError **)error;
 
 /**
  The Pool that the FBSimulatorControl instance uses.

--- a/FBSimulatorControl/Management/FBSimulatorControl.m
+++ b/FBSimulatorControl/Management/FBSimulatorControl.m
@@ -55,13 +55,12 @@
 
 #pragma mark - Public Methods
 
-- (FBSimulatorSession *)createSessionForSimulatorConfiguration:(FBSimulatorConfiguration *)simulatorConfiguration error:(NSError **)error;
+- (FBSimulatorSession *)createSessionForSimulatorConfiguration:(FBSimulatorConfiguration *)simulatorConfiguration options:(FBSimulatorAllocationOptions)options error:(NSError **)error;
 {
   NSParameterAssert(simulatorConfiguration);
 
   NSError *innerError = nil;
-  FBSimulator *simulator = [self.simulatorPool allocateSimulatorWithConfiguration:simulatorConfiguration error:&innerError];
-
+  FBSimulator *simulator = [self.simulatorPool allocateSimulatorWithConfiguration:simulatorConfiguration options:options error:&innerError];
   if (!simulator) {
     return [[[FBSimulatorError describeFormat:@"Failed to allocate simulator for configuration %@", simulatorConfiguration] causedBy:innerError] fail:error];
   }

--- a/FBSimulatorControl/Management/FBSimulatorPool+Private.h
+++ b/FBSimulatorControl/Management/FBSimulatorPool+Private.h
@@ -17,6 +17,7 @@
 @property (nonatomic, strong, readonly) FBProcessQuery *processQuery;
 
 @property (nonatomic, strong, readonly) NSMutableOrderedSet *allocatedUDIDs;
+@property (nonatomic, strong, readonly) NSMutableDictionary *allocationOptions;
 @property (nonatomic, strong, readonly) NSMutableDictionary *inflatedSimulators;
 
 @property (nonatomic, copy, readwrite) NSError *firstRunError;

--- a/FBSimulatorControl/Management/FBSimulatorPool.h
+++ b/FBSimulatorControl/Management/FBSimulatorPool.h
@@ -17,6 +17,18 @@
 @class SimDevice;
 @class SimDeviceSet;
 
+/**
+ Options for how a pool should handle allocation & freeing.
+ */
+typedef NS_OPTIONS(NSUInteger, FBSimulatorAllocationOptions){
+  FBSimulatorAllocationOptionsCreate = 1 << 0, /** Permit the creation of Simulators when allocating. */
+  FBSimulatorAllocationOptionsReuse = 1 << 1, /** Permit the reuse of Simulators when allocating. */
+  FBSimulatorAllocationOptionsShutdownOnAllocate = 1 << 2, /** Shutdown of the Simulator becomes a precondition of allocation. */
+  FBSimulatorAllocationOptionsEraseOnAllocate = 1 << 4, /** Erasing of the Simulator becomes a precondition of allocation. */
+  FBSimulatorAllocationOptionsDeleteOnFree = 1 << 5, /** Deleting of the Simulator becomes a postcondition of freeing. */
+  FBSimulatorAllocationOptionsEraseOnFree = 1 << 6 /** Erasing of the Simulator becomes a postcondition of freeing. */
+};
+
 @protocol FBSimulatorLogger;
 
 /**
@@ -53,14 +65,15 @@
 
 /**
  Returns a Device for the given parameters. Will create devices where necessary.
- If you plan on running multiple tests in the lifecycle of a process, you should use `freeDevice:error:`
+ If you plan on running multiple tests in the lifecycle of a process, you sshould use `freeDevice:error:`
  otherwise devices will continue to be allocated.
 
  @param configuration the Configuration of the Device to Allocate. Must not be nil.
+ @param options the options for the allocation/freeing of the Simulator.
  @param error an error out for any error that occured.
- @returns a device if one could be found or created, nil if an error occured.
+ @return a FBSimulator if one could be allocated with the provided options, nil otherwise
  */
-- (FBSimulator *)allocateSimulatorWithConfiguration:(FBSimulatorConfiguration *)configuration error:(NSError **)error;
+- (FBSimulator *)allocateSimulatorWithConfiguration:(FBSimulatorConfiguration *)configuration options:(FBSimulatorAllocationOptions)options error:(NSError **)error;
 
 /**
  Marks a device that was previously returned from `allocateDeviceWithName:sdkVersion:error:` as free.

--- a/FBSimulatorControlTests/Tests/FBSimulatorControlConfigurationTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorControlConfigurationTests.m
@@ -24,7 +24,7 @@
   return [FBSimulatorControlConfiguration
     configurationWithSimulatorApplication:application
     deviceSetPath:nil
-    options:FBSimulatorManagementOptionsEraseOnFree];
+    options:FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart];
 }
 
 - (void)testEqualityOfCopy

--- a/FBSimulatorControlTests/Tests/FBSimulatorLaunchTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorLaunchTests.m
@@ -57,21 +57,14 @@
 {
   // Simulator Pool management is single threaded since it relies on unsynchronised mutable state
   // Create the sessions in sequence, then boot them in paralell.
-  __block NSError *error = nil;
-  FBSimulatorSession *session1 = [self.control createSessionForSimulatorConfiguration:FBSimulatorConfiguration.iPhone5 error:&error];
+  FBSimulatorSession *session1 = [self createSessionWithConfiguration:FBSimulatorConfiguration.iPhone5];
   XCTAssertEqual(session1.state, FBSimulatorSessionStateNotStarted);
-  XCTAssertNotNil(session1);
-  XCTAssertNil(error);
 
-  FBSimulatorSession *session2 = [self.control createSessionForSimulatorConfiguration:FBSimulatorConfiguration.iPhone5 error:&error];
+  FBSimulatorSession *session2 = [self createSessionWithConfiguration:FBSimulatorConfiguration.iPhone5];
   XCTAssertEqual(session2.state, FBSimulatorSessionStateNotStarted);
-  XCTAssertNotNil(session2);
-  XCTAssertNil(error);
 
-  FBSimulatorSession *session3 = [self.control createSessionForSimulatorConfiguration:FBSimulatorConfiguration.iPad2 error:&error];
+  FBSimulatorSession *session3 = [self createSessionWithConfiguration:FBSimulatorConfiguration.iPad2];
   XCTAssertEqual(session3.state, FBSimulatorSessionStateNotStarted);
-  XCTAssertNotNil(session3);
-  XCTAssertNil(error);
 
   XCTAssertEqual(self.control.simulatorPool.allocatedSimulators.count, 3u);
   XCTAssertEqual(([[NSSet setWithArray:@[session1.simulator.udid, session2.simulator.udid, session3.simulator.udid]] count]), 3u);

--- a/FBSimulatorControlTests/Tests/FBSimulatorPoolAllocationTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorPoolAllocationTests.m
@@ -44,8 +44,8 @@
 
 - (void)testReallocatesAndErasesFreedDevice
 {
-  FBSimulatorManagementOptions options = FBSimulatorManagementOptionsEraseOnFree | FBSimulatorManagementOptionsDeleteAllOnFirstStart;
-  self.managementOptions = options;
+  FBSimulatorAllocationOptions options = self.allocationOptions;
+  self.allocationOptions = options | FBSimulatorAllocationOptionsEraseOnFree;
 
   FBSimulator *simulator = [self createSession].simulator;
   NSString *simulatorUUID = simulator.udid;
@@ -60,6 +60,9 @@
 
 - (void)testDoesNotReallocateDeletedDevice
 {
+  FBSimulatorAllocationOptions options = self.allocationOptions;
+  self.allocationOptions = options | FBSimulatorAllocationOptionsDeleteOnFree;
+
   FBSimulator *simulator = [self createSession].simulator;
   NSString *simulatorUUID = simulator.udid;
   [self assertFreesSimulator:simulator];
@@ -71,6 +74,9 @@
 
 - (void)testRemovesDeletedDeviceFromSet
 {
+  FBSimulatorAllocationOptions options = self.allocationOptions;
+  self.allocationOptions = options | FBSimulatorAllocationOptionsDeleteOnFree;
+
   FBSimulator *simulator = [self createSession].simulator;
   NSString *simulatorUUID = simulator.udid;
   [self assertFreesSimulator:simulator];

--- a/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.h
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.h
@@ -10,6 +10,7 @@
 #import <XCTest/XCTest.h>
 
 #import <FBSimulatorControl/FBSimulatorControlConfiguration.h>
+#import <FBSimulatorControl/FBSimulatorPool.h>
 
 @class FBSimulator;
 @class FBSimulatorConfiguration;
@@ -29,6 +30,11 @@
 - (FBSimulator *)allocateSimulator;
 
 /**
+ Creates a Session with the provided configuration.
+ */
+- (FBSimulatorSession *)createSessionWithConfiguration:(FBSimulatorConfiguration *)configuration;
+
+/**
  Creates a Session with the default configuration.
  */
 - (FBSimulatorSession *)createSession;
@@ -39,9 +45,14 @@
 - (FBSimulatorSession *)createBootedSession;
 
 /**
- The Per-Test-Case Management Options.
+ The Per-TestCase Management Options for created FBSimulatorControl instances.
  */
 @property (nonatomic, assign, readwrite) FBSimulatorManagementOptions managementOptions;
+
+/**
+ The Per Test Case Allocation Options for created allocated Simulators/Sessions.
+ */
+@property (nonatomic, assign, readwrite) FBSimulatorAllocationOptions allocationOptions;
 
 /**
  A default Simulator Configuration.

--- a/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
@@ -21,6 +21,10 @@
 
 #import "FBSimulatorControlAssertions.h"
 
+@interface FBSimulatorControlTestCase ()
+
+@end
+
 @implementation FBSimulatorControlTestCase
 
 @synthesize control = _control;
@@ -57,19 +61,24 @@
 - (FBSimulator *)allocateSimulator
 {
   NSError *error = nil;
-  FBSimulator *simulator = [self.control.simulatorPool allocateSimulatorWithConfiguration:self.simulatorConfiguration error:&error];
+  FBSimulator *simulator = [self.control.simulatorPool allocateSimulatorWithConfiguration:self.simulatorConfiguration options:self.allocationOptions error:&error];
   XCTAssertNil(error);
   XCTAssertNotNil(simulator);
   return simulator;
 }
 
-- (FBSimulatorSession *)createSession
+- (FBSimulatorSession *)createSessionWithConfiguration:(FBSimulatorConfiguration *)configuration
 {
   NSError *error = nil;
-  FBSimulatorSession *session = [self.control createSessionForSimulatorConfiguration:self.simulatorConfiguration error:&error];
+  FBSimulatorSession *session = [self.control createSessionForSimulatorConfiguration:configuration options:self.allocationOptions error:&error];
   XCTAssertNil(error);
   XCTAssertNotNil(session);
   return session;
+}
+
+- (FBSimulatorSession *)createSession
+{
+  return [self createSessionWithConfiguration:self.simulatorConfiguration];
 }
 
 - (FBSimulatorSession *)createBootedSession
@@ -83,7 +92,8 @@
 
 - (void)setUp
 {
-  self.managementOptions = FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart | FBSimulatorManagementOptionsIgnoreSpuriousKillFail | FBSimulatorManagementOptionsDeleteOnFree;
+  self.managementOptions = FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart | FBSimulatorManagementOptionsIgnoreSpuriousKillFail;
+  self.allocationOptions = FBSimulatorAllocationOptionsReuse | FBSimulatorAllocationOptionsCreate | FBSimulatorAllocationOptionsEraseOnAllocate;
   self.simulatorConfiguration = FBSimulatorConfiguration.iPhone5;
   self.deviceSetPath = nil;
 }


### PR DESCRIPTION
When running the CLI over a bunch of commands repeatedly there are currently two big shortcomings:
1) Allocating Simulators will erase and delete much more than is expected. This is because management options for allocation were global. This has now been replaced with per-allocation options in the form of `FBSimulatorAllocationOptions`. This breaks up `FBSimulatorManagementOptions` which was becoming very bloated.
2) Allocating can be slightly racey if there are Simulators without processes, but that are not 'Shutdown'. Placing an additional precondition that all Simulators are in a known-good state helps out here.