### PR TITLE
Debug Logging via FBSIMULATORCONTROL_DEBUG_LOGGING

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -155,6 +155,8 @@
 		AA9517C31C15F60B00A89CAD /* FBCompositeSimulatorEventSink.m in Sources */ = {isa = PBXBuildFile; fileRef = AA9517C11C15F60B00A89CAD /* FBCompositeSimulatorEventSink.m */; };
 		AAAA67C61BC4FED200075197 /* FBSimulatorControlFixtures.m in Sources */ = {isa = PBXBuildFile; fileRef = AAAA67C51BC4FED200075197 /* FBSimulatorControlFixtures.m */; };
 		AAAA67C91BC501BB00075197 /* TableSearch.app in Resources */ = {isa = PBXBuildFile; fileRef = AAAA67C71BC5018500075197 /* TableSearch.app */; };
+		AAB207C01C2099A9007C7908 /* FBSimulatorLoggingEventSink.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB207BE1C2099A9007C7908 /* FBSimulatorLoggingEventSink.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AAB207C11C2099A9007C7908 /* FBSimulatorLoggingEventSink.m in Sources */ = {isa = PBXBuildFile; fileRef = AAB207BF1C2099A9007C7908 /* FBSimulatorLoggingEventSink.m */; };
 		AAB4AC1E1BB586930046F6A1 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAB4AC1D1BB586930046F6A1 /* AVFoundation.framework */; };
 		AAB4AC271BBBC6880046F6A1 /* FBSimulatorControlTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = AAB4AC261BBBC6880046F6A1 /* FBSimulatorControlTestCase.m */; };
 		AAC083751B9FB88B00451648 /* CoreSimulator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E29B6970A5500000000 /* CoreSimulator.framework */; };
@@ -930,6 +932,8 @@
 		AAAA67C41BC4FED200075197 /* FBSimulatorControlFixtures.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorControlFixtures.h; sourceTree = "<group>"; };
 		AAAA67C51BC4FED200075197 /* FBSimulatorControlFixtures.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorControlFixtures.m; sourceTree = "<group>"; };
 		AAAA67C71BC5018500075197 /* TableSearch.app */ = {isa = PBXFileReference; lastKnownFileType = wrapper.application; path = TableSearch.app; sourceTree = "<group>"; };
+		AAB207BE1C2099A9007C7908 /* FBSimulatorLoggingEventSink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorLoggingEventSink.h; sourceTree = "<group>"; };
+		AAB207BF1C2099A9007C7908 /* FBSimulatorLoggingEventSink.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorLoggingEventSink.m; sourceTree = "<group>"; };
 		AAB4AC1D1BB586930046F6A1 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		AAB4AC251BBBC6880046F6A1 /* FBSimulatorControlTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorControlTestCase.h; sourceTree = "<group>"; };
 		AAB4AC261BBBC6880046F6A1 /* FBSimulatorControlTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorControlTestCase.m; sourceTree = "<group>"; };
@@ -1696,6 +1700,8 @@
 				AA9516D71C15F54600A89CAD /* FBSimulatorEventSink.h */,
 				AA9516DA1C15F54600A89CAD /* FBSimulatorHistoryGenerator.h */,
 				AA9516DB1C15F54600A89CAD /* FBSimulatorHistoryGenerator.m */,
+				AAB207BE1C2099A9007C7908 /* FBSimulatorLoggingEventSink.h */,
+				AAB207BF1C2099A9007C7908 /* FBSimulatorLoggingEventSink.m */,
 				AA9516DC1C15F54600A89CAD /* FBSimulatorNotificationEventSink.h */,
 				AA9516DD1C15F54600A89CAD /* FBSimulatorNotificationEventSink.m */,
 				AA9516D31C15F54600A89CAD /* FBSimulatorResourceManager.h */,
@@ -2007,6 +2013,7 @@
 				AA9517871C15F54600A89CAD /* FBSimulatorPredicates.h in Headers */,
 				AA9517811C15F54600A89CAD /* FBSimulatorControl+Class.h in Headers */,
 				AA9517BA1C15F54600A89CAD /* FBSimulatorLogger.h in Headers */,
+				AAB207C01C2099A9007C7908 /* FBSimulatorLoggingEventSink.h in Headers */,
 				AA9517A21C15F54600A89CAD /* FBSimulatorSession.h in Headers */,
 				AA9517BC1C15F54600A89CAD /* NSRunLoop+SimulatorControlAdditions.h in Headers */,
 				AA95177E1C15F54600A89CAD /* FBSimulator+Private.h in Headers */,
@@ -2143,6 +2150,7 @@
 				AA9517A61C15F54600A89CAD /* FBTask.m in Sources */,
 				AA9517481C15F54600A89CAD /* FBProcessLaunchConfiguration+Helpers.m in Sources */,
 				AA9517B11C15F54600A89CAD /* FBSimulatorWindowTiler.m in Sources */,
+				AAB207C11C2099A9007C7908 /* FBSimulatorLoggingEventSink.m in Sources */,
 				AA9517801C15F54600A89CAD /* FBSimulator.m in Sources */,
 				AA9517961C15F54600A89CAD /* FBSimulatorLaunchInfo.m in Sources */,
 				AA9517711C15F54600A89CAD /* FBSimulatorInteraction+Upload.m in Sources */,

--- a/FBSimulatorControl.xcodeproj/xcshareddata/xcschemes/FBSimulatorControl.xcscheme
+++ b/FBSimulatorControl.xcodeproj/xcshareddata/xcschemes/FBSimulatorControl.xcscheme
@@ -70,6 +70,13 @@
             ReferencedContainer = "container:FBSimulatorControl.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "FBSIMULATORCONTROL_DEBUG_LOGGING"
+            value = "YES"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration.h
@@ -44,14 +44,14 @@
 @property (nonatomic, copy, readonly) NSString *stdErrPath;
 
 /**
- A Short Description of the reciever.
+ A Full Description of the reciever.
  */
-- (NSString *)shortDescription;
+- (NSString *)debugDescription;
 
 /**
- A Longer Description of the reciever.
+ A Partial Description of the reciever.
  */
-- (NSString *)longDescription;
+- (NSString *)shortDescription;
 
 @end
 

--- a/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration.m
@@ -92,7 +92,7 @@
   return nil;
 }
 
-- (NSString *)longDescription
+- (NSString *)debugDescription
 {
   NSAssert(NO, @"%@ is abstract", NSStringFromSelector(_cmd));
   return nil;
@@ -106,7 +106,7 @@
 
 - (NSString *)description
 {
-  return [self longDescription];
+  return [self debugDescription];
 }
 
 @end
@@ -148,7 +148,7 @@
   return self.application.binary.path;
 }
 
-- (NSString *)longDescription
+- (NSString *)debugDescription
 {
   return [NSString stringWithFormat:
     @"App Launch | Application %@ | Arguments %@ | Environment %@ | StdOut %@ | StdErr %@",
@@ -246,7 +246,7 @@
   return self.agentBinary.path;
 }
 
-- (NSString *)longDescription
+- (NSString *)debugDescription
 {
   return [NSString stringWithFormat:
     @"Agent Launch | Binary %@ | Arguments %@ | Environment %@ | StdOut %@ | StdErr %@",

--- a/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.h
@@ -9,7 +9,21 @@
 
 #import <Foundation/Foundation.h>
 
+/**
+ An Environment Variable that is inserted into launched Simulator.app processes
+ in order to easily identify the Simulator UUID that they were launched to run against.
+ */
 extern NSString *const FBSimulatorControlSimulatorLaunchEnvironmentSimulatorUDID;
+
+/**
+ An Environment Variable to enable Simulator Debug Logging
+ */
+extern NSString *const FBSimulatorControlDebugLogging;
+
+/**
+ Enable/Disable CoreSimulator debug logging.
+ */
+void FBSetSimulatorLoggingEnabled(BOOL enabled);
 
 /**
  Environment Globals & other derived constants
@@ -40,5 +54,10 @@ extern NSString *const FBSimulatorControlSimulatorLaunchEnvironmentSimulatorUDID
  YES if passing a custom SimDeviceSet to the Simulator App is Supported.
  */
 + (BOOL)supportsCustomDeviceSets;
+
+/**
+ Global override for Simulator Debug Logging
+ */
++ (BOOL)simulatorDebugLoggingEnabled;
 
 @end

--- a/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.m
@@ -9,11 +9,20 @@
 
 #import "FBSimulatorControlStaticConfiguration.h"
 
+#import <CoreSimulator/NSUserDefaults-SimDefaults.h>
+
 #import "FBSimulator.h"
 #import "FBSimulatorApplication.h"
 #import "FBTaskExecutor.h"
 
 NSString *const FBSimulatorControlSimulatorLaunchEnvironmentSimulatorUDID = @"FBSIMULATORCONTROL_SIM_UDID";
+NSString *const FBSimulatorControlDebugLogging = @"FBSIMULATORCONTROL_DEBUG_LOGGING";
+
+void FBSetSimulatorLoggingEnabled(BOOL enabled)
+{
+  NSUserDefaults *simulatorDefaults = [NSUserDefaults simulatorDefaults];
+  [simulatorDefaults setBool:enabled forKey:@"DebugLogging"];
+}
 
 @implementation FBSimulatorControlStaticConfiguration
 
@@ -121,6 +130,11 @@ NSString *const FBSimulatorControlSimulatorLaunchEnvironmentSimulatorUDID = @"FB
   // This means that the '-DeviceSetPath' won't do anything for Simulators booted with prior to Xcode 7.
   // It should be possible to fix this by injecting a shim that swizzles this method in these Xcode versions.
   return [self.sdkVersionNumber isGreaterThanOrEqualTo:[NSDecimalNumber decimalNumberWithString:@"9.0"]];
+}
+
++ (BOOL)simulatorDebugLoggingEnabled
+{
+  return [NSProcessInfo.processInfo.environment[FBSimulatorControlDebugLogging] boolValue];
 }
 
 @end

--- a/FBSimulatorControl/Events/FBSimulatorLoggingEventSink.h
+++ b/FBSimulatorControl/Events/FBSimulatorLoggingEventSink.h
@@ -23,13 +23,9 @@
  Creates a new Logging Event Sink for the provided Simulator.
  
  @param simulator the Simulator to log events for. Will not be retained. Must not be nil.
+ @param logger the Logger to write messages to. May be nil.
  @return a new FBSimulatorLoggingEventSink instance.
  */
-+ (instancetype)withSimulator:(FBSimulator *)simulator;
-
-/**
- The Logger to write messages to.
- */
-@property (nonatomic, strong, readwrite) id<FBSimulatorLogger> logger;
++ (instancetype)withSimulator:(FBSimulator *)simulator logger:(id<FBSimulatorLogger>)logger;
 
 @end

--- a/FBSimulatorControl/Events/FBSimulatorLoggingEventSink.h
+++ b/FBSimulatorControl/Events/FBSimulatorLoggingEventSink.h
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <FBSimulatorControl/FBSimulatorEventSink.h>
+#import <FBSimulatorControl/FBSimulatorLogger.h>
+
+@class FBSimulator;
+
+/**
+ An Event Relay that writes messages to a logger.
+ */
+@interface FBSimulatorLoggingEventSink : NSObject <FBSimulatorEventSink>
+
+/**
+ Creates a new Logging Event Sink for the provided Simulator.
+ 
+ @param simulator the Simulator to log events for. Will not be retained. Must not be nil.
+ @return a new FBSimulatorLoggingEventSink instance.
+ */
++ (instancetype)withSimulator:(FBSimulator *)simulator;
+
+/**
+ The Logger to write messages to.
+ */
+@property (nonatomic, strong, readwrite) id<FBSimulatorLogger> logger;
+
+@end

--- a/FBSimulatorControl/Events/FBSimulatorLoggingEventSink.m
+++ b/FBSimulatorControl/Events/FBSimulatorLoggingEventSink.m
@@ -15,6 +15,7 @@
 
 @interface FBSimulatorLoggingEventSink ()
 
+@property (nonatomic, strong, readonly) id<FBSimulatorLogger> logger;
 @property (nonatomic, copy, readonly) NSString *prefix;
 
 @end
@@ -23,9 +24,8 @@
 
 #pragma mark Initializers
 
-+ (instancetype)withSimulator:(FBSimulator *)simulator
++ (instancetype)withSimulator:(FBSimulator *)simulator logger:(id<FBSimulatorLogger>)logger
 {
-  id<FBSimulatorLogger> logger = FBSimulatorControlStaticConfiguration.simulatorDebugLoggingEnabled ? FBSimulatorLogger.toNSLog : nil;
   return [[self alloc] initWithPrefix:[NSString stringWithFormat:@"%@: ", simulator.udid] logger:logger];
 }
 

--- a/FBSimulatorControl/Events/FBSimulatorLoggingEventSink.m
+++ b/FBSimulatorControl/Events/FBSimulatorLoggingEventSink.m
@@ -9,9 +9,11 @@
 
 #import "FBSimulatorLoggingEventSink.h"
 
-#import "FBSimulator.h"
+#import "FBProcessInfo.h"
 #import "FBSimulator+Helpers.h"
+#import "FBSimulator.h"
 #import "FBSimulatorControlStaticConfiguration.h"
+#import "FBSimulatorLaunchInfo.h"
 
 @interface FBSimulatorLoggingEventSink ()
 
@@ -46,7 +48,7 @@
 
 - (void)didStartWithLaunchInfo:(FBSimulatorLaunchInfo *)launchInfo
 {
-  [self.logger logMessage:@"%@Did Start => %@", self.prefix, launchInfo];
+  [self.logger logMessage:@"%@Did Start => %@", self.prefix, launchInfo.shortDescription];
 }
 
 - (void)didTerminate:(BOOL)expected
@@ -56,22 +58,22 @@
 
 - (void)agentDidLaunch:(FBAgentLaunchConfiguration *)launchConfig didStart:(FBProcessInfo *)agentProcess stdOut:(NSFileHandle *)stdOut stdErr:(NSFileHandle *)stdErr
 {
-  [self.logger logMessage:@"%@Agent Did Launch => %@", self.prefix, agentProcess];
+  [self.logger logMessage:@"%@Agent Did Launch => %@", self.prefix, agentProcess.shortDescription];
 }
 
 - (void)agentDidTerminate:(FBProcessInfo *)agentProcess expected:(BOOL)expected
 {
-  [self.logger logMessage:@"%@Agent Did Terminate => Expected %d %@ ", self.prefix, expected, agentProcess];
+  [self.logger logMessage:@"%@Agent Did Terminate => Expected %d %@ ", self.prefix, expected, agentProcess.shortDescription];
 }
 
 - (void)applicationDidLaunch:(FBApplicationLaunchConfiguration *)launchConfig didStart:(FBProcessInfo *)applicationProcess stdOut:(NSFileHandle *)stdOut stdErr:(NSFileHandle *)stdErr
 {
-  [self.logger logMessage:@"%@Application Did Launch => %@", self.prefix, applicationProcess];
+  [self.logger logMessage:@"%@Application Did Launch => %@", self.prefix, applicationProcess.shortDescription];
 }
 
 - (void)applicationDidTerminate:(FBProcessInfo *)applicationProcess expected:(BOOL)expected
 {
-  [self.logger logMessage:@"%@Application Did Terminate => Expected %d %@", self.prefix, expected, applicationProcess];
+  [self.logger logMessage:@"%@Application Did Terminate => Expected %d %@", self.prefix, expected, applicationProcess.shortDescription];
 }
 
 - (void)diagnosticInformationAvailable:(NSString *)name process:(FBProcessInfo *)process value:(id<NSCopying, NSCoding>)value

--- a/FBSimulatorControl/Events/FBSimulatorLoggingEventSink.m
+++ b/FBSimulatorControl/Events/FBSimulatorLoggingEventSink.m
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBSimulatorLoggingEventSink.h"
+
+#import "FBSimulator.h"
+#import "FBSimulator+Helpers.h"
+#import "FBSimulatorControlStaticConfiguration.h"
+
+@interface FBSimulatorLoggingEventSink ()
+
+@property (nonatomic, copy, readonly) NSString *prefix;
+
+@end
+
+@implementation FBSimulatorLoggingEventSink
+
+#pragma mark Initializers
+
++ (instancetype)withSimulator:(FBSimulator *)simulator
+{
+  id<FBSimulatorLogger> logger = FBSimulatorControlStaticConfiguration.simulatorDebugLoggingEnabled ? FBSimulatorLogger.toNSLog : nil;
+  return [[self alloc] initWithPrefix:[NSString stringWithFormat:@"%@: ", simulator.udid] logger:logger];
+}
+
+- (instancetype)initWithPrefix:(NSString *)prefix logger:(id<FBSimulatorLogger>)logger
+{
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  _prefix = prefix;
+  _logger = logger;
+
+  return self;
+}
+
+#pragma mark FBSimulatorEventSink Implementation
+
+- (void)didStartWithLaunchInfo:(FBSimulatorLaunchInfo *)launchInfo
+{
+  [self.logger logMessage:@"%@Did Start => %@", self.prefix, launchInfo];
+}
+
+- (void)didTerminate:(BOOL)expected
+{
+  [self.logger logMessage:@"%@Did Terminate => Expected %d", self.prefix, expected];
+}
+
+- (void)agentDidLaunch:(FBAgentLaunchConfiguration *)launchConfig didStart:(FBProcessInfo *)agentProcess stdOut:(NSFileHandle *)stdOut stdErr:(NSFileHandle *)stdErr
+{
+  [self.logger logMessage:@"%@Agent Did Launch => %@", self.prefix, agentProcess];
+}
+
+- (void)agentDidTerminate:(FBProcessInfo *)agentProcess expected:(BOOL)expected
+{
+  [self.logger logMessage:@"%@Agent Did Terminate => Expected %d %@ ", self.prefix, expected, agentProcess];
+}
+
+- (void)applicationDidLaunch:(FBApplicationLaunchConfiguration *)launchConfig didStart:(FBProcessInfo *)applicationProcess stdOut:(NSFileHandle *)stdOut stdErr:(NSFileHandle *)stdErr
+{
+  [self.logger logMessage:@"%@Application Did Launch => %@", self.prefix, applicationProcess];
+}
+
+- (void)applicationDidTerminate:(FBProcessInfo *)applicationProcess expected:(BOOL)expected
+{
+  [self.logger logMessage:@"%@Application Did Terminate => Expected %d %@", self.prefix, expected, applicationProcess];
+}
+
+- (void)diagnosticInformationAvailable:(NSString *)name process:(FBProcessInfo *)process value:(id<NSCopying, NSCoding>)value
+{
+  [self.logger logMessage:@"%@Diagnostic Information Available => %@", self.prefix, name];
+}
+
+- (void)didChangeState:(FBSimulatorState)state
+{
+  [self.logger logMessage:@"%@Did Change State => %@", self.prefix, [FBSimulator stateStringFromSimulatorState:state]];
+}
+
+- (void)terminationHandleAvailable:(id<FBTerminationHandle>)terminationHandle
+{
+
+}
+
+@end

--- a/FBSimulatorControl/FBSimulatorControl.h
+++ b/FBSimulatorControl/FBSimulatorControl.h
@@ -53,6 +53,7 @@
 #import <FBSimulatorControl/FBSimulatorInteraction.h>
 #import <FBSimulatorControl/FBSimulatorLaunchInfo.h>
 #import <FBSimulatorControl/FBSimulatorLogger.h>
+#import <FBSimulatorControl/FBSimulatorLoggingEventSink.h>
 #import <FBSimulatorControl/FBSimulatorLogs+Private.h>
 #import <FBSimulatorControl/FBSimulatorLogs.h>
 #import <FBSimulatorControl/FBSimulatorNotificationEventSink.h>

--- a/FBSimulatorControl/Logs/FBSimulatorLogs.h
+++ b/FBSimulatorControl/Logs/FBSimulatorLogs.h
@@ -32,6 +32,11 @@
 - (FBWritableLog *)systemLog;
 
 /**
+ The Log for CoreSimulator.
+ */
+- (FBWritableLog *)coreSimulator;
+
+/**
  The Bootstrap of the Simulator's launchd_sim.
  */
 - (FBWritableLog *)simulatorBootstrap;

--- a/FBSimulatorControl/Logs/FBSimulatorLogs.m
+++ b/FBSimulatorControl/Logs/FBSimulatorLogs.m
@@ -43,6 +43,14 @@
     build];
 }
 
+- (FBWritableLog *)coreSimulator
+{
+  return [[[[FBWritableLogBuilder builder]
+    updatePath:self.coreSimulatorLogPath]
+    updateHumanReadableName:@"Core Simulator Log"]
+    build];
+}
+
 - (FBWritableLog *)simulatorBootstrap
 {
   NSString *expectedPath = [[self.simulator.device.setPath
@@ -72,6 +80,11 @@
 - (NSString *)systemLogPath
 {
   return [self.simulator.device.logPath stringByAppendingPathComponent:@"system.log"];
+}
+
+- (NSString *)coreSimulatorLogPath
+{
+  return [NSHomeDirectory() stringByAppendingPathComponent:@"Library/Logs/CoreSimulator/CoreSimulator.log"];
 }
 
 - (NSString *)diagnosticReportsPath

--- a/FBSimulatorControl/Management/FBSimulator+Private.h
+++ b/FBSimulatorControl/Management/FBSimulator+Private.h
@@ -13,6 +13,7 @@
 @class FBProcessQuery;
 @class FBSimulatorEventRelay;
 @class FBSimulatorHistoryGenerator;
+@protocol FBSimulatorLogger;
 
 @interface FBSimulator ()
 
@@ -23,7 +24,7 @@
 @property (nonatomic, copy, readwrite) FBSimulatorConfiguration *configuration;
 @property (nonatomic, weak, readwrite) FBSimulatorSession *session;
 
-+ (instancetype)fromSimDevice:(SimDevice *)device configuration:(FBSimulatorConfiguration *)configuration pool:(FBSimulatorPool *)pool query:(FBProcessQuery *)query;
-- (instancetype)initWithDevice:(SimDevice *)device configuration:(FBSimulatorConfiguration *)configuration pool:(FBSimulatorPool *)pool query:(FBProcessQuery *)query;
++ (instancetype)fromSimDevice:(SimDevice *)device configuration:(FBSimulatorConfiguration *)configuration pool:(FBSimulatorPool *)pool query:(FBProcessQuery *)query logger:(id<FBSimulatorLogger>)logger;
+- (instancetype)initWithDevice:(SimDevice *)device configuration:(FBSimulatorConfiguration *)configuration pool:(FBSimulatorPool *)pool query:(FBProcessQuery *)query logger:(id<FBSimulatorLogger>)logger;
 
 @end

--- a/FBSimulatorControl/Management/FBSimulator.m
+++ b/FBSimulatorControl/Management/FBSimulator.m
@@ -162,7 +162,7 @@ NSTimeInterval const FBSimulatorDefaultTimeout = 20;
     self.name,
     self.udid,
     self.device.stateString,
-    self.launchInfo
+    self.launchInfo.shortDescription
   ];
 }
 

--- a/FBSimulatorControl/Management/FBSimulator.m
+++ b/FBSimulatorControl/Management/FBSimulator.m
@@ -29,6 +29,7 @@
 #import "FBSimulatorEventSink.h"
 #import "FBSimulatorHistoryGenerator.h"
 #import "FBSimulatorLaunchInfo.h"
+#import "FBSimulatorLoggingEventSink.h"
 #import "FBSimulatorLogs.h"
 #import "FBSimulatorNotificationEventSink.h"
 #import "FBSimulatorPool.h"
@@ -68,7 +69,8 @@ NSTimeInterval const FBSimulatorDefaultTimeout = 20;
 
   FBSimulatorHistoryGenerator *historyGenerator = [FBSimulatorHistoryGenerator withSimulator:self];
   FBSimulatorNotificationEventSink *notificationSink = [FBSimulatorNotificationEventSink withSimulator:self];
-  FBCompositeSimulatorEventSink *compositeSink = [FBCompositeSimulatorEventSink withSinks:@[historyGenerator, notificationSink]];
+  FBSimulatorLoggingEventSink *loggingSink = [FBSimulatorLoggingEventSink withSimulator:self];
+  FBCompositeSimulatorEventSink *compositeSink = [FBCompositeSimulatorEventSink withSinks:@[historyGenerator, notificationSink, loggingSink]];
   FBSimulatorEventRelay *relay = [[FBSimulatorEventRelay alloc] initWithSimDevice:device processQuery:query sink:compositeSink];
 
   _historyGenerator = historyGenerator;

--- a/FBSimulatorControl/Management/FBSimulator.m
+++ b/FBSimulatorControl/Management/FBSimulator.m
@@ -41,13 +41,14 @@ NSTimeInterval const FBSimulatorDefaultTimeout = 20;
 
 #pragma mark Lifecycle
 
-+ (instancetype)fromSimDevice:(SimDevice *)device configuration:(FBSimulatorConfiguration *)configuration pool:(FBSimulatorPool *)pool query:(FBProcessQuery *)query
++ (instancetype)fromSimDevice:(SimDevice *)device configuration:(FBSimulatorConfiguration *)configuration pool:(FBSimulatorPool *)pool query:(FBProcessQuery *)query logger:(id<FBSimulatorLogger>)logger
 {
   return [[FBSimulator alloc]
     initWithDevice:device
     configuration:configuration ?: [self inferSimulatorConfigurationFromDevice:device]
     pool:pool
-    query:query];
+    query:query
+    logger:logger];
 }
 
 + (FBSimulatorConfiguration *)inferSimulatorConfigurationFromDevice:(SimDevice *)device
@@ -55,7 +56,7 @@ NSTimeInterval const FBSimulatorDefaultTimeout = 20;
   return [[FBSimulatorConfiguration.defaultConfiguration withDeviceType:device.deviceType] withRuntime:device.runtime];
 }
 
-- (instancetype)initWithDevice:(SimDevice *)device configuration:(FBSimulatorConfiguration *)configuration pool:(FBSimulatorPool *)pool query:(FBProcessQuery *)query
+- (instancetype)initWithDevice:(SimDevice *)device configuration:(FBSimulatorConfiguration *)configuration pool:(FBSimulatorPool *)pool query:(FBProcessQuery *)query logger:(id<FBSimulatorLogger>)logger
 {
   self = [super init];
   if (!self) {
@@ -69,7 +70,7 @@ NSTimeInterval const FBSimulatorDefaultTimeout = 20;
 
   FBSimulatorHistoryGenerator *historyGenerator = [FBSimulatorHistoryGenerator withSimulator:self];
   FBSimulatorNotificationEventSink *notificationSink = [FBSimulatorNotificationEventSink withSimulator:self];
-  FBSimulatorLoggingEventSink *loggingSink = [FBSimulatorLoggingEventSink withSimulator:self];
+  FBSimulatorLoggingEventSink *loggingSink = [FBSimulatorLoggingEventSink withSimulator:self logger:logger];
   FBCompositeSimulatorEventSink *compositeSink = [FBCompositeSimulatorEventSink withSinks:@[historyGenerator, notificationSink, loggingSink]];
   FBSimulatorEventRelay *relay = [[FBSimulatorEventRelay alloc] initWithSimDevice:device processQuery:query sink:compositeSink];
 

--- a/FBSimulatorControl/Management/FBSimulatorControl+Class.h
+++ b/FBSimulatorControl/Management/FBSimulatorControl+Class.h
@@ -15,6 +15,7 @@
 @class FBSimulatorConfiguration;
 @class FBSimulatorControlConfiguration;
 @class FBSimulatorSession;
+@protocol FBSimulatorLogger;
 
 /**
  The Root Class for the FBSimulatorControl Framework.
@@ -22,7 +23,17 @@
 @interface FBSimulatorControl : NSObject
 
 /**
- Returns a new `FBSimulatorControl` instance.
+ Creates and returns a new `FBSimulatorControl` instance.
+
+ @param configuration the Configuration to setup the instance with.
+ @param logger the logger to use to verbosely describe what is going on. May be nil.
+ @param error any error that occurred during instantiation.
+ @returns a new FBSimulatorControl instance.
+ */
++ (instancetype)withConfiguration:(FBSimulatorControlConfiguration *)configuration logger:(id<FBSimulatorLogger>)logger error:(NSError **)error;
+
+/**
+ Creates and returns a new `FBSimulatorControl` instance.
 
  @param configuration the Configuration to setup the instance with.
  @param error any error that occurred during instantiation.

--- a/FBSimulatorControl/Management/FBSimulatorControl.m
+++ b/FBSimulatorControl/Management/FBSimulatorControl.m
@@ -23,6 +23,7 @@
 #import "FBProcessLaunchConfiguration.h"
 #import "FBSimulatorConfiguration.h"
 #import "FBSimulatorControlConfiguration.h"
+#import "FBSimulatorControlStaticConfiguration.h"
 #import "FBSimulatorError.h"
 #import "FBSimulatorHistory.h"
 #import "FBSimulatorPool.h"
@@ -75,6 +76,8 @@
   if (!hasRunOnce) {
     return YES;
   }
+
+  FBSetSimulatorLoggingEnabled(FBSimulatorControlStaticConfiguration.simulatorDebugLoggingEnabled);
 
   NSError *innerError = nil;
   if (![DVTPlatform loadAllPlatformsReturningError:&innerError]) {

--- a/FBSimulatorControl/Management/FBSimulatorControl.m
+++ b/FBSimulatorControl/Management/FBSimulatorControl.m
@@ -26,6 +26,7 @@
 #import "FBSimulatorControlStaticConfiguration.h"
 #import "FBSimulatorError.h"
 #import "FBSimulatorHistory.h"
+#import "FBSimulatorLogger.h"
 #import "FBSimulatorPool.h"
 #import "FBSimulatorSession+Convenience.h"
 #import "FBSimulatorSession.h"
@@ -34,15 +35,22 @@
 
 #pragma mark - Initializers
 
-+ (instancetype)withConfiguration:(FBSimulatorControlConfiguration *)configuration error:(NSError **)error
++ (instancetype)withConfiguration:(FBSimulatorControlConfiguration *)configuration logger:(id<FBSimulatorLogger>)logger error:(NSError **)error
 {
   if (![FBSimulatorControl doGlobalPreconditionsWithError:error]) {
     return nil;
   }
-  return [[FBSimulatorControl alloc] initWithConfiguration:configuration error:error];
+
+  logger = logger ?: FBSimulatorControlStaticConfiguration.simulatorDebugLoggingEnabled ? FBSimulatorLogger.toNSLog : nil;
+  return [[FBSimulatorControl alloc] initWithConfiguration:configuration logger:logger error:error];
 }
 
-- (instancetype)initWithConfiguration:(FBSimulatorControlConfiguration *)configuration error:(NSError **)error
++ (instancetype)withConfiguration:(FBSimulatorControlConfiguration *)configuration error:(NSError **)error
+{
+  return [self withConfiguration:configuration logger:nil error:error];
+}
+
+- (instancetype)initWithConfiguration:(FBSimulatorControlConfiguration *)configuration logger:(id<FBSimulatorLogger>)logger error:(NSError **)error
 {
   self = [super init];
   if (!self) {
@@ -50,7 +58,7 @@
   }
 
   _configuration = configuration;
-  _simulatorPool = [FBSimulatorPool poolWithConfiguration:configuration error:error];
+  _simulatorPool = [FBSimulatorPool poolWithConfiguration:configuration logger:logger error:error];
   return self;
 }
 

--- a/FBSimulatorControl/Management/FBSimulatorPool+Private.h
+++ b/FBSimulatorControl/Management/FBSimulatorPool+Private.h
@@ -15,6 +15,7 @@
 
 @property (nonatomic, strong, readonly) SimDeviceSet *deviceSet;
 @property (nonatomic, strong, readonly) FBProcessQuery *processQuery;
+@property (nonatomic, strong, readonly) id<FBSimulatorLogger> logger;
 
 @property (nonatomic, strong, readonly) NSMutableOrderedSet *allocatedUDIDs;
 @property (nonatomic, strong, readonly) NSMutableDictionary *allocationOptions;
@@ -22,7 +23,7 @@
 
 @property (nonatomic, copy, readwrite) NSError *firstRunError;
 
-- (instancetype)initWithConfiguration:(FBSimulatorControlConfiguration *)configuration deviceSet:(SimDeviceSet *)deviceSet;
+- (instancetype)initWithConfiguration:(FBSimulatorControlConfiguration *)configuration deviceSet:(SimDeviceSet *)deviceSet logger:(id<FBSimulatorLogger>)logger;
 
 /**
  Kills all of the Simulators the reciever's Device Set.

--- a/FBSimulatorControl/Management/FBSimulatorPool.h
+++ b/FBSimulatorControl/Management/FBSimulatorPool.h
@@ -125,14 +125,4 @@ typedef NS_OPTIONS(NSUInteger, FBSimulatorAllocationOptions){
  */
 - (NSString *)debugDescription;
 
-/**
- Log SimDeviceSet interactions.
- */
-- (void)startLoggingSimDeviceSetInteractions:(id<FBSimulatorLogger>)logger;
-
 @end
-
-/**
- Enable/disable CoreSimulator debug logging and any other verbose logging we can get our hands on.
- */
-void FBSetSimulatorLoggingEnabled(BOOL enabled);

--- a/FBSimulatorControl/Management/FBSimulatorPool.h
+++ b/FBSimulatorControl/Management/FBSimulatorPool.h
@@ -39,11 +39,12 @@ typedef NS_OPTIONS(NSUInteger, FBSimulatorAllocationOptions){
 /**
  Creates and returns an FBSimulatorPool.
 
- @param configuration the configuration to use.
+ @param configuration the configuration to use. Must not be nil.
+ @param logger the logger to use to verbosely describe what is going on. May be nil.
  @param error any error that occurred during the creation of the pool.
  @returns a new FBSimulatorPool.
  */
-+ (instancetype)poolWithConfiguration:(FBSimulatorControlConfiguration *)configuration error:(NSError **)error;
++ (instancetype)poolWithConfiguration:(FBSimulatorControlConfiguration *)configuration logger:(id<FBSimulatorLogger>)logger error:(NSError **)error;
 
 /**
  Returns the configuration for the reciever.

--- a/FBSimulatorControl/Management/FBSimulatorPool.m
+++ b/FBSimulatorControl/Management/FBSimulatorPool.m
@@ -10,7 +10,6 @@
 #import "FBSimulatorPool.h"
 #import "FBSimulatorPool+Private.h"
 
-#import <CoreSimulator/NSUserDefaults-SimDefaults.h>
 #import <CoreSimulator/SimDevice.h>
 #import <CoreSimulator/SimDeviceSet.h>
 #import <CoreSimulator/SimDeviceType.h>
@@ -419,32 +418,10 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
 - (NSString *)debugDescription
 {
   NSMutableString *description = [NSMutableString string];
-  [description appendFormat:@"SimDevices: %@", [self.deviceSet.availableDevices description]];
-  [description appendFormat:@"\nAll Simulators: %@", [self.allSimulators description]];
+  [description appendFormat:@"All Simulators: %@", [self.allSimulators description]];
   [description appendFormat:@"\nAllocated Simulators: %@ \n\n", [self.allocatedSimulators description]];
-  [description appendFormat:@"\nSimulator Processes: %@ \n\n", [self activeSimulatorProcessesWithError:nil]];
+  [description appendFormat:@"\nSimulator Processes: %@ \n\n", [self.processQuery.simulatorProcesses description]];
   return description;
 }
 
-- (void)startLoggingSimDeviceSetInteractions:(id<FBSimulatorLogger>)logger;
-{
-  [FBCoreSimulatorNotifier notifierForPool:self block:^(NSDictionary *info) {
-    [logger logMessage:@"Device Set Changed: %@", info];
-  }];
-}
-
-- (NSString *)activeSimulatorProcessesWithError:(NSError *)error
-{
-  return [[[FBTaskExecutor.sharedInstance
-    taskWithLaunchPath:@"/usr/bin/pgrep" arguments:@[@"-lf", @"Simulator"]]
-    startSynchronouslyWithTimeout:8]
-    stdOut];
-}
-
 @end
-
-void FBSetSimulatorLoggingEnabled(BOOL enabled)
-{
-  NSUserDefaults *simulatorDefaults = [NSUserDefaults simulatorDefaults];
-  [simulatorDefaults setBool:enabled forKey:@"DebugLogging"];
-}

--- a/FBSimulatorControl/Management/FBSimulatorPool.m
+++ b/FBSimulatorControl/Management/FBSimulatorPool.m
@@ -38,7 +38,7 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
 
 #pragma mark - Initializers
 
-+ (instancetype)poolWithConfiguration:(FBSimulatorControlConfiguration *)configuration error:(NSError **)error
++ (instancetype)poolWithConfiguration:(FBSimulatorControlConfiguration *)configuration logger:(id<FBSimulatorLogger>)logger error:(NSError **)error
 {
   NSError *innerError = nil;
   SimDeviceSet *deviceSet = [self createDeviceSetWithConfiguration:configuration error:&innerError];
@@ -46,14 +46,14 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
     return [[[FBSimulatorError describe:@"Failed to create device set"] causedBy:innerError] fail:error];
   }
 
-  FBSimulatorPool *pool = [[FBSimulatorPool alloc] initWithConfiguration:configuration deviceSet:deviceSet];
+  FBSimulatorPool *pool = [[FBSimulatorPool alloc] initWithConfiguration:configuration deviceSet:deviceSet logger:logger];
   if (![pool performPoolPreconditionsWithError:&innerError]) {
     return [[[FBSimulatorError describe:@"Failed meet pool preconditions"] causedBy:innerError] fail:error];
   }
   return pool;
 }
 
-- (instancetype)initWithConfiguration:(FBSimulatorControlConfiguration *)configuration deviceSet:(SimDeviceSet *)deviceSet
+- (instancetype)initWithConfiguration:(FBSimulatorControlConfiguration *)configuration deviceSet:(SimDeviceSet *)deviceSet logger:(id<FBSimulatorLogger>)logger
 {
   self = [super init];
   if (!self) {
@@ -66,6 +66,7 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
   _inflatedSimulators = [NSMutableDictionary dictionary];
   _processQuery = [FBProcessQuery new];
   _deviceSet = deviceSet;
+  _logger = logger;
 
   return self;
 }
@@ -129,7 +130,7 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
     if (self.inflatedSimulators[udid]) {
       continue;
     }
-    FBSimulator *simulator = [FBSimulator fromSimDevice:device configuration:nil pool:self query:self.processQuery];
+    FBSimulator *simulator = [FBSimulator fromSimDevice:device configuration:nil pool:self query:self.processQuery logger:self.logger];
     self.inflatedSimulators[udid] = simulator;
   }
 

--- a/FBSimulatorControl/Model/FBSimulatorLaunchInfo.h
+++ b/FBSimulatorControl/Model/FBSimulatorLaunchInfo.h
@@ -69,4 +69,14 @@
  */
 - (NSArray *)launchedProcesses;
 
+/**
+ A Full Description of the Launch Info.
+ */
+- (NSString *)debugDescription;
+
+/**
+ A Partial Description of the Launch Info.
+ */
+- (NSString *)shortDescription;
+
 @end

--- a/FBSimulatorControl/Model/FBSimulatorLaunchInfo.m
+++ b/FBSimulatorControl/Model/FBSimulatorLaunchInfo.m
@@ -102,15 +102,6 @@
 
 #pragma mark NSObject
 
-- (NSString *)description
-{
-  return [NSString stringWithFormat:
-    @"simulator_pid %d | launchd_sim_pid %d",
-    self.simulatorProcess.processIdentifier,
-    self.launchdProcess.processIdentifier
-  ];
-}
-
 - (NSUInteger)hash
 {
   return self.simulatorApplication.hash ^ self.simulatorProcess.hash | self.launchdProcess.hash;
@@ -125,6 +116,31 @@
   return [self.simulatorApplication isEqual:info.simulatorApplication] &&
          [self.simulatorProcess isEqual:info.simulatorProcess] &&
          [self.launchdProcess isEqual:info.launchdProcess];
+}
+
+#pragma mark Descriptions
+
+- (NSString *)debugDescription
+{
+  return [NSString stringWithFormat:
+    @"Simulator Process (%@) | launchd_sim Process (%@)",
+    self.simulatorProcess.debugDescription,
+    self.launchdProcess.debugDescription
+  ];
+}
+
+- (NSString *)shortDescription
+{
+  return [NSString stringWithFormat:
+    @"simulator_pid %d | launchd_sim_pid %d",
+    self.simulatorProcess.processIdentifier,
+    self.launchdProcess.processIdentifier
+  ];
+}
+
+- (NSString *)description
+{
+  return self.debugDescription;
 }
 
 #pragma mark NSCopying

--- a/FBSimulatorControl/Notifiers/FBCoreSimulatorNotifier.h
+++ b/FBSimulatorControl/Notifiers/FBCoreSimulatorNotifier.h
@@ -13,20 +13,30 @@
 
 @class FBSimulator;
 @class FBSimulatorPool;
+@class SimDevice;
 
 /**
  A class for wrapping Core Simulator Notifiers in a `FBTerminationHandle`
  */
-@interface FBCoreSimulatorNotifier : NSObject<FBTerminationHandle>
+@interface FBCoreSimulatorNotifier : NSObject <FBTerminationHandle>
 
 /**
- Creates and returns an FBSimDeviceNotifier for the lifecycle events that SimDevice broadcasts for the provided Simulator.
+ Creates and returns an FBSimDeviceNotifier for the lifecycle events that the Simulator's SimDevice broadcasts.
 
  @param simulator the FBSimulator to relay events from.
  @param block the block to call when events are sent from the SimDevice.
  @return an instance of FBSimDeviceNotifier for later termination.
  */
 + (instancetype)notifierForSimulator:(FBSimulator *)simulator block:(void (^)(NSDictionary *info))block;
+
+/**
+ Creates and returns an FBSimDeviceNotifier for the lifecycle events that SimDevice broadcasts.
+
+ @param simDevice the FBSimulator to relay events from.
+ @param block the block to call when events are sent from the SimDevice.
+ @return an instance of FBSimDeviceNotifier for later termination.
+ */
++ (instancetype)notifierForSimDevice:(SimDevice *)simDevice block:(void (^)(NSDictionary *info))block;
 
 /**
  Creates and returns an FBSimDeviceNotifier for the lifecycle events that SimDeviceSet broadcasts for the provided Pool.

--- a/FBSimulatorControl/Notifiers/FBCoreSimulatorNotifier.m
+++ b/FBSimulatorControl/Notifiers/FBCoreSimulatorNotifier.m
@@ -28,13 +28,18 @@
 
 + (instancetype)notifierForSimulator:(FBSimulator *)simulator block:(void (^)(NSDictionary *info))block
 {
-  id<SimDeviceNotifier> notifier = simulator.device.notificationManager;
-  return [[self alloc] initWithNotifier:notifier block:block];
+  return [self notifierForSimDevice:simulator.device block:block];
 }
 
 + (instancetype)notifierForPool:(FBSimulatorPool *)pool block:(void (^)(NSDictionary *info))block
 {
   id<SimDeviceNotifier> notifier = pool.deviceSet.notificationManager;
+  return [[self alloc] initWithNotifier:notifier block:block];
+}
+
++ (instancetype)notifierForSimDevice:(SimDevice *)simDevice block:(void (^)(NSDictionary *info))block
+{
+  id<SimDeviceNotifier> notifier = simDevice.notificationManager;
   return [[self alloc] initWithNotifier:notifier block:block];
 }
 

--- a/FBSimulatorControl/Processes/FBProcessInfo.h
+++ b/FBSimulatorControl/Processes/FBProcessInfo.h
@@ -46,4 +46,14 @@
  */
 @property (nonatomic, copy, readonly) NSDictionary *environment;
 
+/**
+ A Full Description of the Process.
+ */
+- (NSString *)debugDescription;
+
+/**
+ A Partial Description of the Process.
+ */
+- (NSString *)shortDescription;
+
 @end

--- a/FBSimulatorControl/Processes/FBProcessInfo.m
+++ b/FBSimulatorControl/Processes/FBProcessInfo.m
@@ -50,7 +50,9 @@
         [self.environment isEqual:object.environment];
 }
 
-- (NSString *)description
+#pragma mark Descriptions
+
+- (NSString *)debugDescription
 {
   return [NSString stringWithFormat:
     @"Process %@ | PID %d | Arguments %@ | Environment %@",
@@ -59,6 +61,20 @@
     self.arguments,
     self.environment
   ];
+}
+
+- (NSString *)shortDescription
+{
+  return [NSString stringWithFormat:
+    @"Process %@ | PID %d",
+    self.launchPath.lastPathComponent,
+    self.processIdentifier
+  ];
+}
+
+- (NSString *)description
+{
+  return [self debugDescription];
 }
 
 #pragma mark NSCopying

--- a/FBSimulatorControlTests/Tests/FBSimulatorControlHistoryTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorControlHistoryTests.m
@@ -29,7 +29,7 @@
   device.UDID = [NSUUID UUID];
   device.name = @"iPhoneMega";
 
-  FBSimulator *simulator = [[FBSimulator alloc] initWithDevice:(id)device configuration:nil pool:nil query:nil];
+  FBSimulator *simulator = [[FBSimulator alloc] initWithDevice:(id)device configuration:nil pool:nil query:nil logger:nil];
   self.generator = [FBSimulatorHistoryGenerator withSimulator:simulator];
 }
 

--- a/FBSimulatorControlTests/Tests/FBSimulatorHistoryGeneratorTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorHistoryGeneratorTests.m
@@ -29,7 +29,7 @@
   device.UDID = [NSUUID UUID];
   device.name = @"iPhoneMega";
 
-  FBSimulator *simulator = [[FBSimulator alloc] initWithDevice:(id)device configuration:nil pool:nil query:nil];
+  FBSimulator *simulator = [[FBSimulator alloc] initWithDevice:(id)device configuration:nil pool:nil query:nil logger:nil];
   self.generator = [FBSimulatorHistoryGenerator withSimulator:simulator];
 }
 

--- a/FBSimulatorControlTests/Tests/FBSimulatorPoolTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorPoolTests.m
@@ -70,7 +70,7 @@
     configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
     deviceSetPath:nil
     options:0];
-  self.pool = [[FBSimulatorPool alloc] initWithConfiguration:poolConfig deviceSet:(id)deviceSet];
+  self.pool = [[FBSimulatorPool alloc] initWithConfiguration:poolConfig deviceSet:(id)deviceSet logger:nil];
 
   return deviceSet.availableDevices;
 }

--- a/FBSimulatorControlTests/Utilities/CoreSimulatorDoubles.h
+++ b/FBSimulatorControlTests/Utilities/CoreSimulatorDoubles.h
@@ -31,6 +31,7 @@
 @property (nonatomic, readwrite, assign) unsigned long long state;
 @property (nonatomic, readwrite, strong) FBSimulatorControlTests_SimDeviceType_Double *deviceType;
 @property (nonatomic, readwrite, strong) FBSimulatorControlTests_SimDeviceRuntime_Double *runtime;
+@property (nonatomic, readwrite, strong) SimDeviceNotificationManager *notificationManager;
 
 @end
 


### PR DESCRIPTION
- Adds an environment variable that is used to enable debug logging for Events that get propagated to a Simulator's Event Sink. 
- Strips away some of the cruft in `FBSimulatorPool` and replace with all the `FBSimulatorControl` niceties on the `debugDescription`.
- Automatic Enabling of the `CoreSimulator` debug log at `~/Library/Logs/CoreSimulator/CoreSimulator.log` via the environment variable
- Threading a `FBSimulatorLogger` from `FBSimulatorControl` down to the construction of `FBSimulatorLoggingEventSink`. This will also be useful in future to log interactions, termination strategy & redirection for `fbsimctl`.
- Short and Debug descriptions for `FBProcessInfo`, `FBSimulatorLaunchInfo` & `FBProcessLaunchConfiguration`. By implementing `debugDescription` these classes can trivially be made to conform to Swift's `CustomDebugStringConvertible`.