### PR TITLE
Query History by State Change

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		AA10BD551C17581A00565499 /* FBWritableLogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA10BD431C17581A00565499 /* FBWritableLogTests.m */; };
 		AA10BD581C17583400565499 /* FBSimulatorControlHistoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA10BD571C17583400565499 /* FBSimulatorControlHistoryTests.m */; };
 		AA111CCE1BBE7C5A0054AFDD /* CoreSimulatorDoubles.m in Sources */ = {isa = PBXBuildFile; fileRef = AA111CCD1BBE7C5A0054AFDD /* CoreSimulatorDoubles.m */; };
+		AA1D653E1C21A9690069F90D /* FBCollectionDescriptions.h in Headers */ = {isa = PBXBuildFile; fileRef = AA1D653C1C21A9690069F90D /* FBCollectionDescriptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA1D653F1C21A9690069F90D /* FBCollectionDescriptions.m in Sources */ = {isa = PBXBuildFile; fileRef = AA1D653D1C21A9690069F90D /* FBCollectionDescriptions.m */; };
 		AA3230CB1BDA387700C5BA01 /* FBSimulatorControlAssertions.m in Sources */ = {isa = PBXBuildFile; fileRef = AA3230CA1BDA387700C5BA01 /* FBSimulatorControlAssertions.m */; };
 		AA5639551C060005009BAFAA /* FBSimulatorControl.h in Headers */ = {isa = PBXBuildFile; fileRef = AA5639541C05FFF5009BAFAA /* FBSimulatorControl.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA5696381B9FB7B500A2918F /* DVTFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA5696371B9FB7B500A2918F /* DVTFoundation.framework */; };
@@ -237,6 +239,8 @@
 		AA10BD571C17583400565499 /* FBSimulatorControlHistoryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorControlHistoryTests.m; sourceTree = "<group>"; };
 		AA111CCC1BBE7C5A0054AFDD /* CoreSimulatorDoubles.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreSimulatorDoubles.h; sourceTree = "<group>"; };
 		AA111CCD1BBE7C5A0054AFDD /* CoreSimulatorDoubles.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CoreSimulatorDoubles.m; sourceTree = "<group>"; };
+		AA1D653C1C21A9690069F90D /* FBCollectionDescriptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBCollectionDescriptions.h; sourceTree = "<group>"; };
+		AA1D653D1C21A9690069F90D /* FBCollectionDescriptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBCollectionDescriptions.m; sourceTree = "<group>"; };
 		AA3230C91BDA387700C5BA01 /* FBSimulatorControlAssertions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorControlAssertions.h; sourceTree = "<group>"; };
 		AA3230CA1BDA387700C5BA01 /* FBSimulatorControlAssertions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorControlAssertions.m; sourceTree = "<group>"; };
 		AA4876491BAC7399007F7D23 /* FBSimulatorControl-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "FBSimulatorControl-Info.plist"; sourceTree = "<group>"; };
@@ -1862,6 +1866,8 @@
 			children = (
 				AA0771EF1C1ADFA300E7FD52 /* FBBinaryParser.h */,
 				AA0771F01C1ADFA300E7FD52 /* FBBinaryParser.m */,
+				AA1D653C1C21A9690069F90D /* FBCollectionDescriptions.h */,
+				AA1D653D1C21A9690069F90D /* FBCollectionDescriptions.m */,
 				AA95173A1C15F54600A89CAD /* FBConcurrentCollectionOperations.h */,
 				AA95173B1C15F54600A89CAD /* FBConcurrentCollectionOperations.m */,
 				AA95173C1C15F54600A89CAD /* FBSimDeviceWrapper.h */,
@@ -1989,6 +1995,7 @@
 				AA95174E1C15F54600A89CAD /* FBSimulatorConfiguration+CoreSimulator.h in Headers */,
 				AA95176E1C15F54600A89CAD /* FBSimulatorInteraction+Setup.h in Headers */,
 				AA9517531C15F54600A89CAD /* FBSimulatorControlConfiguration.h in Headers */,
+				AA1D653E1C21A9690069F90D /* FBCollectionDescriptions.h in Headers */,
 				AA95177F1C15F54600A89CAD /* FBSimulator.h in Headers */,
 				AA9517551C15F54600A89CAD /* FBSimulatorControlStaticConfiguration.h in Headers */,
 				AA9517B61C15F54600A89CAD /* FBSimDeviceWrapper.h in Headers */,
@@ -2155,6 +2162,7 @@
 				AA9517961C15F54600A89CAD /* FBSimulatorLaunchInfo.m in Sources */,
 				AA9517711C15F54600A89CAD /* FBSimulatorInteraction+Upload.m in Sources */,
 				AA9517A81C15F54600A89CAD /* FBTaskExecutor+Convenience.m in Sources */,
+				AA1D653F1C21A9690069F90D /* FBCollectionDescriptions.m in Sources */,
 				AA95174B1C15F54600A89CAD /* FBProcessLaunchConfiguration.m in Sources */,
 				AA9517A31C15F54600A89CAD /* FBSimulatorSession.m in Sources */,
 				AA9517BF1C15F54600A89CAD /* FBSimulatorVideoRecorder.m in Sources */,

--- a/FBSimulatorControl/FBSimulatorControl.h
+++ b/FBSimulatorControl/FBSimulatorControl.h
@@ -8,6 +8,7 @@
  */
 
 #import <FBSimulatorControl/FBBinaryParser.h>
+#import <FBSimulatorControl/FBCollectionDescriptions.h>
 #import <FBSimulatorControl/FBCompositeSimulatorEventSink.h>
 #import <FBSimulatorControl/FBConcurrentCollectionOperations.h>
 #import <FBSimulatorControl/FBCoreSimulatorNotifier.h>

--- a/FBSimulatorControl/Logs/FBSimulatorLogs.m
+++ b/FBSimulatorControl/Logs/FBSimulatorLogs.m
@@ -152,7 +152,7 @@
 
 - (NSArray *)subprocessCrashes
 {
-  return [self subprocessCrashesAfterDate:self.session.history.sessionStartDate];
+  return [self subprocessCrashesAfterDate:self.session.history.startDate];
 }
 
 - (NSDictionary *)launchedApplicationLogs

--- a/FBSimulatorControl/Model/FBSimulatorHistory+Queries.h
+++ b/FBSimulatorControl/Model/FBSimulatorHistory+Queries.h
@@ -19,6 +19,20 @@
 @interface FBSimulatorHistory (Queries)
 
 /**
+ Returns Agent State for all running agents, does not reach into previous states.
+
+ @return an NSArray<FBProcessInfo> of the currently running, User Launched Agents.
+ */
+- (NSArray *)launchedAgents;
+
+/**
+ Returns Application State for all running applications, does not reach into previous states.
+
+ @return an NSArray<FBProcessInfo> of the currently running, User Launched Applications.
+ */
+- (NSArray *)launchedApplications;
+
+/**
  Returns all of the Agents and Applications that have been launched, in the order that they were launched.
  Reaches into previous states in order to find Agents and Applications that have been terminated.
 
@@ -30,7 +44,7 @@
  Returns all of the Applications that have been launched, in the order that they were launched.
  Reaches into previous states in order to find Applications that have been terminated.
 
- @return An NSArray<FBProcessInfo> of All Launched Applications, most recent first.
+ @return An NSArray<FBProcessInfo> of All Launched Application Processes, most recent first.
  */
 - (NSArray *)allLaunchedApplications;
 
@@ -38,7 +52,7 @@
  Returns all of the Agents that have been launched, in the order that they were launched.
  Reaches into previous states in order to find Agents that have been terminated.
 
- @return An NSArray<FBProcessInfo> of All Launched Agents, most recent first.
+ @return An NSArray<FBProcessInfo> of All Launched Agent Processes, most recent first.
  */
 - (NSArray *)allLaunchedAgents;
 
@@ -54,7 +68,7 @@
  Returns the Launch Configration for the Application that was launched most recently.
  Reaches into previous states in order to find Applications that have been terminated.
 
- @return An FBProcessInfo for the most recently launched Application, nil if no Application has been launched.
+ @return A FBApplicationLaunchConfiguration for the most recently launched Application, nil if no Application has been launched.
  */
 - (FBApplicationLaunchConfiguration *)lastLaunchedApplication;
 
@@ -64,7 +78,15 @@
 
  @return An FBProcessInfo for the most recently launched Agent, nil if no Agent has been launched.
  */
-- (FBProcessInfo *)lastLaunchedAgent;
+- (FBProcessInfo *)lastLaunchedAgentProcess;
+
+/**
+ Returns the Launch Configration for the Agent that was launched most recently.
+ Reaches into previous states in order to find Applications that have been terminated.
+
+ @return An A FBAgentLaunchConfiguration for the most recently launched Agent, nil if no Agent has been launched.
+ */
+- (FBAgentLaunchConfiguration *)lastLaunchedAgent;
 
 /**
  Returns the Process State for the given launch configuration, does not reach into previous states.
@@ -91,20 +113,6 @@
 - (FBProcessInfo *)runningProcessForApplication:(FBSimulatorApplication *)application;
 
 /**
- Returns Agent State for all running agents, does not reach into previous states.
-
- @return an NSArray<FBUserLaunchedProcess> of the currently running, User Launched Agents.
- */
-- (NSArray *)runningAgents;
-
-/**
- Returns Application State for all running applications, does not reach into previous states.
-
- @return an NSArray<FBUserLaunchedProcess> of the currently running, User Launched Applications.
- */
-- (NSArray *)runningApplications;
-
-/**
  Finds the first diagnostic for the provided name, matching the application.
  Reaches into previous states in order to find Diagnostics for Applications that have been terminated.
 
@@ -115,13 +123,21 @@
 - (id<NSCopying, NSCoding>)diagnosticNamed:(NSString *)name forApplication:(FBSimulatorApplication *)application;
 
 /**
- Describes the `simulatorState` changes.
+ Returns the History representing the last change to Simulator State.
+
+ @param state the state change to search for.
+ @return the history of the prior change to the given state, or nil if this change never occurred.
+ */
+- (instancetype)lastChangeOfState:(FBSimulatorState)state;
+
+/**
+ An NSArray<FBSimulatorHistory> of the changes to the `simulatorState` property.
  */
 - (NSArray *)changesToSimulatorState;
 
 /**
- The date of the first session state.
+ The timestamp of the first state.
  */
-- (NSDate *)sessionStartDate;
+- (NSDate *)startDate;
 
 @end

--- a/FBSimulatorControl/Model/FBSimulatorHistory.h
+++ b/FBSimulatorControl/Model/FBSimulatorHistory.h
@@ -30,7 +30,7 @@
 /**
  The Simulator's State.
  */
-@property (nonatomic, assign, readonly) FBSimulatorState state;
+@property (nonatomic, assign, readonly) FBSimulatorState simulatorState;
 
 /**
  Process information for the processes that have been launched by FBSimulatorControl.

--- a/FBSimulatorControl/Model/FBSimulatorHistory.h
+++ b/FBSimulatorControl/Model/FBSimulatorHistory.h
@@ -67,11 +67,6 @@
 @property (nonatomic, copy, readonly) FBSimulatorHistory *previousState;
 
 /**
- A String description of the difference between the provided states.
- */
-+ (NSString *)describeDifferenceBetween:(FBSimulatorHistory *)first and:(FBSimulatorHistory *)second;
-
-/**
  Describes all the changes of the reciever, to the first change.
  */
 - (NSString *)recursiveChangeDescription;

--- a/FBSimulatorControl/Utility/FBCollectionDescriptions.h
+++ b/FBSimulatorControl/Utility/FBCollectionDescriptions.h
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+/**
+ Better String representations of Collections.
+ */
+@interface FBCollectionDescriptions : NSObject
+
+/**
+ Creates a One-Line Array description from the array, with a given keyPath.
+
+ @param array the Array to construct a description for.
+ @param keyPath the Key Path, to obtain a String description from.
+ */
++ (NSString *)oneLineDescriptionFromArray:(NSArray *)array atKeyPath:(NSString *)keyPath;
+
+/**
+ Creates a One-Line Array description from the Dictionary.
+
+ @param dictionary the Dictionary to construct a description for.
+ */
++ (NSString *)oneLineDescriptionFromDictionary:(NSDictionary *)dictionary;
+
+@end

--- a/FBSimulatorControl/Utility/FBCollectionDescriptions.m
+++ b/FBSimulatorControl/Utility/FBCollectionDescriptions.m
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBCollectionDescriptions.h"
+
+@implementation FBCollectionDescriptions
+
++ (NSString *)oneLineDescriptionFromArray:(NSArray *)array atKeyPath:(NSString *)keyPath
+{
+  return [NSString stringWithFormat:@"[%@]", [[array valueForKeyPath:keyPath] componentsJoinedByString:@", "]];
+}
+
++ (NSString *)oneLineDescriptionFromDictionary:(NSDictionary *)dictionary
+{
+  NSMutableString *string = [NSMutableString stringWithString:@"{"];
+  for (NSString *key in dictionary.allKeys) {
+    [string stringByAppendingFormat:@"%@ => %@, ", key, dictionary[key]];
+  }
+  [string appendString:@"}"];
+  return string;
+}
+
+@end

--- a/FBSimulatorControlTests/Tests/FBSimulatorHistoryGeneratorTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorHistoryGeneratorTests.m
@@ -97,15 +97,16 @@
   [self.generator didChangeState:FBSimulatorStateShuttingDown];
   [self.generator didChangeState:FBSimulatorStateShutdown];
 
-  FBSimulatorHistory *history = self.generator.history;
-
-  [self assertHistory:history changes:@[
+  FBSimulatorHistory *latest = self.generator.history;
+  [self assertHistory:latest changes:@[
     @(FBSimulatorStateCreating),
     @(FBSimulatorStateBooting),
     @(FBSimulatorStateBooted),
     @(FBSimulatorStateShuttingDown),
     @(FBSimulatorStateShutdown)
   ]];
+
+  XCTAssertEqual(latest.previousState.previousState, [latest lastChangeOfState:FBSimulatorStateBooted]);
 }
 
 @end

--- a/FBSimulatorControlTests/Tests/FBSimulatorLaunchTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorLaunchTests.m
@@ -41,8 +41,8 @@
   [self.assert noNotificationsToConsume];
 
   XCTAssertEqual(session.simulator.state, FBSimulatorStateBooted);
-  XCTAssertEqual(session.history.runningAgents.count, 0u);
-  XCTAssertEqual(session.history.runningApplications.count, 0u);
+  XCTAssertEqual(session.history.launchedAgents.count, 0u);
+  XCTAssertEqual(session.history.launchedApplications.count, 0u);
   XCTAssertNotNil(session.simulator.launchInfo);
 
   [self assertShutdownSimulatorAndTerminateSession:session];
@@ -77,8 +77,8 @@
   for (FBSimulatorSession *session in sessions) {
     XCTAssertEqual(session.simulator.state, FBSimulatorStateBooted);
     XCTAssertEqual(session.state, FBSimulatorSessionStateStarted);
-    XCTAssertEqual(session.history.runningApplications.count, 0u);
-    XCTAssertEqual(session.history.runningAgents.count, 0u);
+    XCTAssertEqual(session.history.launchedAgents.count, 0u);
+    XCTAssertEqual(session.history.launchedApplications.count, 0u);
     XCTAssertNotNil(session.simulator.launchInfo);
   }
 


### PR DESCRIPTION
Sometimes you may want to query Simulator history in order to find out the last time a particular event occurred. In the case of logs you may want to know last time a Simulator was booted in order to narrow down information and discard pre-last-boot information. By adding queries by last-change-to-state it's possible to find this information.

In addition, the recursive description has been improved so that the ordering is correct and less-noisy descriptions are used.