### PR TITLE
Use directory of asl files

### DIFF
--- a/FBSimulatorControl/Logs/FBASLParser.m
+++ b/FBSimulatorControl/Logs/FBASLParser.m
@@ -62,6 +62,7 @@ static BOOL WriteOutputToFilePath(const char *filePath, asl_object_t aslFile, pi
   if (asl == NULL) {
     return nil;
   }
+  asl_set_filter(asl, ASL_FILTER_MASK_UPTO(ASL_LEVEL_DEBUG));
   return [[self alloc] initWithASLObject:asl];
 }
 

--- a/FBSimulatorControl/Logs/FBSimulatorLogs.m
+++ b/FBSimulatorControl/Logs/FBSimulatorLogs.m
@@ -153,32 +153,10 @@
 
 - (NSString *)aslPath
 {
-  NSString *basePath = [[[NSHomeDirectory()
+  return [[[NSHomeDirectory()
     stringByAppendingPathComponent:@"Library/Logs/CoreSimulator"]
     stringByAppendingPathComponent:self.simulator.udid]
     stringByAppendingPathComponent:@"asl"];
-
-  NSFileManager *fileManager = NSFileManager.defaultManager;
-
-  BOOL isDirectory = NO;
-  if (![fileManager fileExistsAtPath:basePath isDirectory:&isDirectory]) {
-    return nil;
-  }
-  if (!isDirectory) {
-    return nil;
-  }
-
-  NSString *file = [[[[NSFileManager.defaultManager
-    contentsOfDirectoryAtPath:basePath error:nil]
-    pathsMatchingExtensions:@[@"asl"]]
-    sortedArrayUsingComparator:[FBSimulatorLogs fileSizeComparatorAtBasePath:basePath]]
-    firstObject];
-
-  if (!file) {
-    return nil;
-  }
-
-  return [basePath stringByAppendingPathComponent:file];
 }
 
 - (NSArray *)crashInfoAfterDate:(NSDate *)date
@@ -232,22 +210,4 @@
     return [pidSet containsObject:@(crashLog.processIdentifier)];
   }];
 }
-
-+ (NSComparator)fileSizeComparatorAtBasePath:(NSString *)basePath
-{
-  NSFileManager *fileManager = NSFileManager.defaultManager;
-
-  return ^ NSComparisonResult (NSString *leftFilename, NSString *rightFilename) {
-    NSDictionary *leftAttributes = [fileManager attributesOfItemAtPath:[basePath stringByAppendingPathComponent:leftFilename] error:nil];
-    NSDictionary *rightAttributes = [fileManager attributesOfItemAtPath:[basePath stringByAppendingPathComponent:rightFilename] error:nil];
-    if (leftAttributes.fileSize == rightAttributes.fileSize) {
-      return NSOrderedSame;
-    }
-    if (leftAttributes.fileSize > rightAttributes.fileSize) {
-      return NSOrderedAscending;
-    }
-    return NSOrderedDescending;
-  };
-}
-
 @end

--- a/FBSimulatorControl/Utility/FBConcurrentCollectionOperations.m
+++ b/FBSimulatorControl/Utility/FBConcurrentCollectionOperations.m
@@ -86,7 +86,7 @@
 
 + (NSArray *)filterMap:(NSArray *)array predicate:(NSPredicate *)predicate map:(id (^)(id))block
 {
-  return[[self
+  return [[self
     map:array
     withBlock:^ id (id object) {
       BOOL pass = [predicate evaluateWithObject:object];

--- a/FBSimulatorControlTests/Tests/FBSimulatorLogsTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorLogsTests.m
@@ -24,7 +24,7 @@
 - (void)assertFindsNeedle:(NSString *)needle fromHaystackBlock:( NSString *(^)(void) )block
 {
   __block NSString *haystack = nil;
-  BOOL foundLog = [NSRunLoop.currentRunLoop spinRunLoopWithTimeout:30 untilTrue:^ BOOL {
+  BOOL foundLog = [NSRunLoop.currentRunLoop spinRunLoopWithTimeout:60 untilTrue:^ BOOL {
     haystack = block();
     return haystack != nil;
   }];


### PR DESCRIPTION
Turns out that there's not any need to use a specific asl file since `asl` is just fine with a whole directory. It looks like different files are used at different times anyway and this could mean that certain messages go to different paths. Also made sure that all logs are forwarded with the debug log level.