### PR TITLE
Add Log Levels with additional error & debug logging

### DIFF
--- a/FBSimulatorControl/Events/FBSimulatorLoggingEventSink.m
+++ b/FBSimulatorControl/Events/FBSimulatorLoggingEventSink.m
@@ -28,7 +28,7 @@
 
 + (instancetype)withSimulator:(FBSimulator *)simulator logger:(id<FBSimulatorLogger>)logger
 {
-  return [[self alloc] initWithPrefix:[NSString stringWithFormat:@"%@: ", simulator.udid] logger:logger];
+  return [[self alloc] initWithPrefix:[NSString stringWithFormat:@"%@: ", simulator.udid] logger:logger.info.timestamped];
 }
 
 - (instancetype)initWithPrefix:(NSString *)prefix logger:(id<FBSimulatorLogger>)logger
@@ -48,42 +48,42 @@
 
 - (void)didStartWithLaunchInfo:(FBSimulatorLaunchInfo *)launchInfo
 {
-  [self.logger logMessage:@"%@Did Start => %@", self.prefix, launchInfo.shortDescription];
+  [self.logger logFormat:@"%@Did Start => %@", self.prefix, launchInfo.shortDescription];
 }
 
 - (void)didTerminate:(BOOL)expected
 {
-  [self.logger logMessage:@"%@Did Terminate => Expected %d", self.prefix, expected];
+  [self.logger logFormat:@"%@Did Terminate => Expected %d", self.prefix, expected];
 }
 
 - (void)agentDidLaunch:(FBAgentLaunchConfiguration *)launchConfig didStart:(FBProcessInfo *)agentProcess stdOut:(NSFileHandle *)stdOut stdErr:(NSFileHandle *)stdErr
 {
-  [self.logger logMessage:@"%@Agent Did Launch => %@", self.prefix, agentProcess.shortDescription];
+  [self.logger logFormat:@"%@Agent Did Launch => %@", self.prefix, agentProcess.shortDescription];
 }
 
 - (void)agentDidTerminate:(FBProcessInfo *)agentProcess expected:(BOOL)expected
 {
-  [self.logger logMessage:@"%@Agent Did Terminate => Expected %d %@ ", self.prefix, expected, agentProcess.shortDescription];
+  [self.logger logFormat:@"%@Agent Did Terminate => Expected %d %@ ", self.prefix, expected, agentProcess.shortDescription];
 }
 
 - (void)applicationDidLaunch:(FBApplicationLaunchConfiguration *)launchConfig didStart:(FBProcessInfo *)applicationProcess stdOut:(NSFileHandle *)stdOut stdErr:(NSFileHandle *)stdErr
 {
-  [self.logger logMessage:@"%@Application Did Launch => %@", self.prefix, applicationProcess.shortDescription];
+  [self.logger logFormat:@"%@Application Did Launch => %@", self.prefix, applicationProcess.shortDescription];
 }
 
 - (void)applicationDidTerminate:(FBProcessInfo *)applicationProcess expected:(BOOL)expected
 {
-  [self.logger logMessage:@"%@Application Did Terminate => Expected %d %@", self.prefix, expected, applicationProcess.shortDescription];
+  [self.logger logFormat:@"%@Application Did Terminate => Expected %d %@", self.prefix, expected, applicationProcess.shortDescription];
 }
 
 - (void)diagnosticInformationAvailable:(NSString *)name process:(FBProcessInfo *)process value:(id<NSCopying, NSCoding>)value
 {
-  [self.logger logMessage:@"%@Diagnostic Information Available => %@", self.prefix, name];
+  [self.logger logFormat:@"%@Diagnostic Information Available => %@", self.prefix, name];
 }
 
 - (void)didChangeState:(FBSimulatorState)state
 {
-  [self.logger logMessage:@"%@Did Change State => %@", self.prefix, [FBSimulator stateStringFromSimulatorState:state]];
+  [self.logger logFormat:@"%@Did Change State => %@", self.prefix, [FBSimulator stateStringFromSimulatorState:state]];
 }
 
 - (void)terminationHandleAvailable:(id<FBTerminationHandle>)terminationHandle

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction.m
@@ -125,7 +125,8 @@
 
     FBSimulatorTerminationStrategy *terminationStrategy = [FBSimulatorTerminationStrategy
       withConfiguration:simulator.pool.configuration
-      processQuery:simulator.processQuery];
+      processQuery:simulator.processQuery
+      logger:simulator.pool.logger];
 
     NSError *innerError = nil;
     if (![terminationStrategy killSimulators:@[simulator] withError:&innerError]) {

--- a/FBSimulatorControl/Management/FBSimulator.h
+++ b/FBSimulatorControl/Management/FBSimulator.h
@@ -130,4 +130,14 @@ typedef NS_ENUM(NSInteger, FBSimulatorProductFamily) {
  */
 @property (nonatomic, strong, readonly) FBSimulatorLogs *logs;
 
+/**
+ A Full Description of the reciever.
+ */
+- (NSString *)debugDescription;
+
+/**
+ A Partial Description of the reciever.
+ */
+- (NSString *)shortDescription;
+
 @end

--- a/FBSimulatorControl/Management/FBSimulator.m
+++ b/FBSimulatorControl/Management/FBSimulator.m
@@ -166,7 +166,14 @@
   return [self.device isEqual:simulator.device];
 }
 
+#pragma mark Descriptions
+
 - (NSString *)description
+{
+  return [self debugDescription];
+}
+
+- (NSString *)debugDescription
 {
   return [NSString stringWithFormat:
     @"Name %@ | UUID %@ | State %@ | %@",
@@ -175,6 +182,11 @@
     self.device.stateString,
     self.launchInfo.shortDescription
   ];
+}
+
+- (NSString *)shortDescription
+{
+  return [NSString stringWithFormat:@"Simulator %@", self.udid];
 }
 
 @end

--- a/FBSimulatorControl/Management/FBSimulatorControl.m
+++ b/FBSimulatorControl/Management/FBSimulatorControl.m
@@ -83,7 +83,7 @@
     @"DVTDevice" : @"../SharedFrameworks/DVTFoundation.framework",
     @"DTiPhoneSimulatorApplicationSpecifier" : @"../SharedFrameworks/DVTiPhoneSimulatorRemoteClient.framework"
   };
-  [logger logMessage:@"Using Developer Directory %@", developerDirectory];
+  [logger logFormat:@"Using Developer Directory %@", developerDirectory];
 
   for (NSString *className in classMapping) {
     NSString *relativePath = classMapping[className];
@@ -91,7 +91,7 @@
 
     // The Class exists, therefore has been loaded
     if (NSClassFromString(className)) {
-      [logger logMessage:@"%@ is allready loaded, skipping load of framework %@", className, path];
+      [logger logFormat:@"%@ is allready loaded, skipping load of framework %@", className, path];
       NSError *innerError = nil;
       if (![self verifyDeveloperDirectoryForPrivateClass:className developerDirectory:developerDirectory logger:logger error:&innerError]) {
         return [FBSimulatorError failBoolWithError:innerError errorOut:error];
@@ -100,17 +100,17 @@
     }
 
     // Otherwise load the Framework.
-    [logger logMessage:@"%@ is not loaded. Loading %@ at path %@", className, path.lastPathComponent, path];
+    [logger logFormat:@"%@ is not loaded. Loading %@ at path %@", className, path.lastPathComponent, path];
     NSError *innerError = nil;
     if (![self loadFrameworkAtPath:path logger:logger error:&innerError]) {
       return [FBSimulatorError failBoolWithError:innerError errorOut:error];
     }
-    [logger logMessage:@"Loaded %@ from %@", className, path];
+    [logger logFormat:@"Loaded %@ from %@", className, path];
   }
 
   // We're done with loading Frameworks.
   hasLoaded = YES;
-  [logger logMessage:@"Loaded All Private Frameworks %@", [FBCollectionDescriptions oneLineDescriptionFromArray:classMapping.allValues atKeyPath:@"lastPathComponent"]];
+  [logger logFormat:@"Loaded All Private Frameworks %@", [FBCollectionDescriptions oneLineDescriptionFromArray:classMapping.allValues atKeyPath:@"lastPathComponent"]];
 
   // Set CoreSimulator Logging since it is now loaded.
   [self setCoreSimulatorLoggingEnabled:FBSimulatorControlStaticConfiguration.simulatorDebugLoggingEnabled];
@@ -121,7 +121,7 @@
 + (void)loadPrivateFrameworksOrAbort
 {
   NSError *error = nil;
-  BOOL success = [FBSimulatorControl loadPrivateFrameworks:FBSimulatorControlStaticConfiguration.defaultLogger error:&error];
+  BOOL success = [FBSimulatorControl loadPrivateFrameworks:FBSimulatorControlStaticConfiguration.defaultLogger.debug error:&error];
   if (success) {
     return;
   }
@@ -166,7 +166,7 @@
       describeFormat:@"Failed to load the the Framework Bundle %@", bundle]
       failBool:error];
   }
-  [logger logMessage:@"Successfully loaded %@", path.lastPathComponent];
+  [logger logFormat:@"Successfully loaded %@", path.lastPathComponent];
   return YES;
 }
 
@@ -195,7 +195,7 @@
       describeFormat:@"Expected Framework %@ to be loaded for Developer Directory at path %@, but was loaded from %@", bundle.bundlePath.lastPathComponent, bundle.bundlePath, developerDirectory]
       failBool:error];
   }
-  [logger logMessage:@"%@ has correct path of %@", className, basePath];
+  [logger logFormat:@"%@ has correct path of %@", className, basePath];
   return YES;
 }
 

--- a/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.h
+++ b/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.h
@@ -13,6 +13,8 @@
 @class FBSimulator;
 @class FBSimulatorControlConfiguration;
 
+@protocol FBSimulatorLogger;
+
 /**
  A class for terminating Simulators.
  */
@@ -23,10 +25,10 @@
 
  @param configuration the Configuration of FBSimulatorControl.
  @param processQuery the process query object to use. If nil, one will be created
-
+ @param logger the Logger to log all activities on.
  @return a configured FBSimulatorTerminationStrategy instance.
  */
-+ (instancetype)withConfiguration:(FBSimulatorControlConfiguration *)configuration processQuery:(FBProcessQuery *)processQuery;
++ (instancetype)withConfiguration:(FBSimulatorControlConfiguration *)configuration processQuery:(FBProcessQuery *)processQuery logger:(id<FBSimulatorLogger>)logger;
 
 /**
  Kills the provided Simulators.
@@ -36,7 +38,7 @@
 
  @param simulators the Simulators to Kill.
  @param error an error out if any error occured.
- @returns an array of the Simulators that this were killed if successful, nil otherwise.
+ @return an array of the Simulators that this were killed if successful, nil otherwise.
  */
 - (NSArray *)killSimulators:(NSArray *)simulators withError:(NSError **)error;
 
@@ -74,7 +76,7 @@
  This method will not kill Simulators that are launched by FBSimulatorControl in another, or the same process.
 
  @param error an error out if any error occured.
- @returns an YES if successful, nil otherwise.
+ @return an YES if successful, nil otherwise.
  */
 - (BOOL)killSpuriousSimulatorsWithError:(NSError **)error;
 
@@ -83,7 +85,7 @@
  Running multiple versions of the Service on the same machine can lead to instability such as Simulator statuses not updating.
 
  @param error an error out if any error occured.
- @returns an YES if successful, nil otherwise.
+ @return an YES if successful, nil otherwise.
  */
 - (BOOL)killSpuriousCoreSimulatorServicesWithError:(NSError **)error;
 

--- a/FBSimulatorControl/Utility/FBSimulatorError.h
+++ b/FBSimulatorControl/Utility/FBSimulatorError.h
@@ -12,6 +12,8 @@
 @class FBSimulator;
 @class FBProcessQuery;
 
+@protocol FBSimulatorLogger;
+
 /**
  The Error Domain for FBSimulatorControl.
  */
@@ -50,6 +52,9 @@ extern NSString *const FBSimulatorControlErrorDomain;
 
 /**
  Automatically attach Simulator diagnostic info.
+ 
+ @param simulator the Simulator to obtain diagnostic information from.
+ @return the reciever, for chaining.
  */
 - (instancetype)inSimulator:(FBSimulator *)simulator;
 
@@ -64,8 +69,20 @@ extern NSString *const FBSimulatorControlErrorDomain;
 
  @param processIdentifier the Process Identifier to find information for.
  @param query the Query object to obtain process information from.
+ @return the reciever, for chaining.
  */
 - (instancetype)attachProcessInfoForIdentifier:(pid_t)processIdentifier query:(FBProcessQuery *)query;
+
+/**
+ Attaches a Logger to the error.
+ A logger will will recieve error messages for any errors that occur.
+ By default this will be the Global Debug logger.
+ Logging can be suppressed by providing a nil logger argument.
+
+ @param logger the logger to log to
+ @return the reciever, for chaining.
+ */
+- (instancetype)logger:(id<FBSimulatorLogger>)logger;
 
 /**
  Builds the Error with the applied arguments.

--- a/FBSimulatorControl/Utility/FBSimulatorError.m
+++ b/FBSimulatorControl/Utility/FBSimulatorError.m
@@ -23,6 +23,7 @@ NSString *const FBSimulatorControlErrorDomain = @"com.facebook.FBSimulatorContro
 
 @property (nonatomic, copy, readwrite) NSString *describedAs;
 @property (nonatomic, copy, readwrite) NSError *cause;
+@property (nonatomic, strong, readwrite) id<FBSimulatorLogger> logger;
 @property (nonatomic, strong, readwrite) NSMutableDictionary *additionalInfo;
 @property (nonatomic, assign, readwrite) BOOL describeRecursively;
 
@@ -39,6 +40,8 @@ NSString *const FBSimulatorControlErrorDomain = @"com.facebook.FBSimulatorContro
 
   _additionalInfo = [NSMutableDictionary dictionary];
   _describeRecursively = YES;
+  _logger = FBSimulatorControlStaticConfiguration.defaultLogger;
+
   return self;
 }
 
@@ -141,6 +144,12 @@ NSString *const FBSimulatorControlErrorDomain = @"com.facebook.FBSimulatorContro
     value:[query processInfoFor:processIdentifier] ?: @"No Process Info"];
 }
 
+- (instancetype)logger:(id<FBSimulatorLogger>)logger
+{
+  self.logger = logger;
+  return self;
+}
+
 - (NSError *)build
 {
   // If there's just a cause, there's no error to build
@@ -156,8 +165,9 @@ NSString *const FBSimulatorControlErrorDomain = @"com.facebook.FBSimulatorContro
     userInfo[NSUnderlyingErrorKey] = self.underlyingError;
   }
   [userInfo addEntriesFromDictionary:self.additionalInfo];
+
   NSError *error = [NSError errorWithDomain:FBSimulatorControlErrorDomain code:0 userInfo:[userInfo copy]];
-  [FBSimulatorControlStaticConfiguration.defaultLogger logMessage:@"Error => %@", error];
+  [self.logger.error logFormat:@"Error => %@", error];
   return error;
 }
 

--- a/FBSimulatorControl/Utility/FBSimulatorLogger.h
+++ b/FBSimulatorControl/Utility/FBSimulatorLogger.h
@@ -10,18 +10,62 @@
 #import <Foundation/Foundation.h>
 
 /**
- A protocol for defining a class that recieves logger messages.
+ A Protocol for Classes that recieve Logger Messages.
  */
 @protocol FBSimulatorLogger <NSObject>
 
-- (void)logMessage:(NSString *)format, ... NS_FORMAT_FUNCTION(1,2);
+/**
+ Logs a Message with the provided String.
+
+ @param string the string to log.
+ @return the reciever, for chaining.
+ */
+- (instancetype)log:(NSString *)string;
+
+/**
+ Logs a Message with the provided Format String.
+
+ @param format the Format String for the Logger.
+ @return the reciever, for chaining.
+ */
+- (instancetype)logFormat:(NSString *)format, ... NS_FORMAT_FUNCTION(1,2);
+
+/**
+ Returns the Info Logger variant.
+ */
+- (id<FBSimulatorLogger>)info;
+
+/**
+ Returns the Debug Logger variant.
+ */
+- (id<FBSimulatorLogger>)debug;
+
+/**
+ Returns the Error Logger variant.
+ */
+- (id<FBSimulatorLogger>)error;
+
+/**
+ Returns the Timestamped variant.
+ */
+- (id<FBSimulatorLogger>)timestamped;
 
 @end
 
 @interface FBSimulatorLogger : NSObject
 
 /**
- An implementation of `FBSimulatorLogger` that logs to NSLog
+ An implementation of `FBSimulatorLogger` that logs events below an ASL Log Level.
+ 
+ @param maxLevel the Maximum ASL Log Level to Log.
+ @return an FBSimulatorLogger instance.
+ */
++ (id<FBSimulatorLogger>)toNSLogWithMaxLevel:(int)maxLevel;
+
+/**
+ An implementation of `FBSimulatorLogger` that logs all events to NSLog.
+ 
+ @return an FBSimulatorLogger instance.
  */
 + (id<FBSimulatorLogger>)toNSLog;
 

--- a/FBSimulatorControl/Utility/FBSimulatorLogger.m
+++ b/FBSimulatorControl/Utility/FBSimulatorLogger.m
@@ -9,27 +9,218 @@
 
 #import "FBSimulatorLogger.h"
 
-@interface FBSimulatorLogger_NSLog : NSObject<FBSimulatorLogger>
+#import <asl.h>
+
+@interface FBSimulatorLogger_NSLog : NSObject <FBSimulatorLogger>
+
+@property (nonatomic, strong, readonly) NSDateFormatter *dateFormatter;
+
+- (NSString *)logLevelString;
+
+@end
+
+@interface FBSimulatorLogger_NSLog_Debug : FBSimulatorLogger_NSLog
+
+@end
+
+@interface FBSimulatorLogger_NSLog_Info : FBSimulatorLogger_NSLog
+
+@end
+
+@interface FBSimulatorLogger_NSLog_Error : FBSimulatorLogger_NSLog
+
+@end
+
+@implementation FBSimulatorLogger_NSLog_Debug
+
+- (NSString *)logLevelString
+{
+  return @"debug";
+}
+
+@end
+
+@implementation FBSimulatorLogger_NSLog_Error
+
+- (NSString *)logLevelString
+{
+  return @"error";
+}
+
+@end
+
+@implementation FBSimulatorLogger_NSLog_Info
+
+- (NSString *)logLevelString
+{
+  return @"info";
+}
 
 @end
 
 @implementation FBSimulatorLogger_NSLog
 
-- (void)logMessage:(NSString *)format, ...
+- (instancetype)initWithDateFormatter:(NSDateFormatter *)dateFormatter
+{
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  _dateFormatter = dateFormatter;
+
+  return self;
+}
+
+#pragma mark Public
+
+- (instancetype)log:(NSString *)string
+{
+  NSString *prefix = self.prefix;
+  if (prefix) {
+    NSLog(@"%@ %@", prefix, string);
+    return self;
+  }
+
+  NSLog(@"%@", string);
+  return self;
+}
+
+- (instancetype)logFormat:(NSString *)format, ...
 {
   va_list args;
   va_start(args, format);
-  NSLogv(format, args);
+  NSString *string = [[NSString alloc] initWithFormat:format arguments:args];
   va_end(args);
+
+  return [self log:string];
+}
+
+- (id<FBSimulatorLogger>)info
+{
+  return [[FBSimulatorLogger_NSLog_Info alloc] initWithDateFormatter:self.dateFormatter];
+}
+
+- (id<FBSimulatorLogger>)debug
+{
+  return [[FBSimulatorLogger_NSLog_Debug alloc] initWithDateFormatter:self.dateFormatter];
+}
+
+- (id<FBSimulatorLogger>)error
+{
+  return [[FBSimulatorLogger_NSLog_Error alloc] initWithDateFormatter:self.dateFormatter];
+}
+
+- (id<FBSimulatorLogger>)timestamped
+{
+  NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+  dateFormatter.timeStyle = NSDateFormatterMediumStyle;
+  dateFormatter.dateStyle = NSDateFormatterNoStyle;
+  return [[self.class alloc] initWithDateFormatter:dateFormatter];
+}
+
+#pragma mark Private
+
+- (NSString *)prefix
+{
+  NSString *prefix = [self logLevelString];
+  prefix = prefix ? [NSString stringWithFormat:@"[%@]", prefix] : nil;
+  if (!self.dateFormatter) {
+    return prefix;
+  }
+  return [prefix stringByAppendingFormat:@" %@", [self.dateFormatter stringFromDate:NSDate.date]];
+}
+
+- (NSString *)logLevelString
+{
+  return nil;
+}
+
+@end
+
+@interface FBSimulatorLogger_Filter : NSObject <FBSimulatorLogger>
+
+@property (nonatomic, assign, readonly) NSUInteger currentLevel;
+@property (nonatomic, copy, readonly) NSIndexSet *enabledLevels;
+@property (nonatomic, strong, readonly) id<FBSimulatorLogger> underlyingLogger;
+
+@end
+
+@implementation FBSimulatorLogger_Filter
+
+- (instancetype)initWithCurrentLevel:(NSUInteger)currentLevel enabledLevels:(NSIndexSet *)enabledLevels underlyingLogger:(id<FBSimulatorLogger>)underlyingLogger
+{
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  _currentLevel = currentLevel;
+  _enabledLevels = enabledLevels;
+  _underlyingLogger = underlyingLogger;
+
+  return self;
+}
+
+#pragma mark Public
+
+- (instancetype)log:(NSString *)string
+{
+  if (![self.enabledLevels containsIndex:self.currentLevel]) {
+    return self;
+  }
+  return [self.underlyingLogger log:string];
+}
+
+- (instancetype)logFormat:(NSString *)format, ...
+{
+  if (![self.enabledLevels containsIndex:self.currentLevel]) {
+    return self;
+  }
+
+  va_list args;
+  va_start(args, format);
+  NSString *string = [[NSString alloc] initWithFormat:format arguments:args];
+  va_end(args);
+
+  return [self.underlyingLogger log:string];
+}
+
+- (id<FBSimulatorLogger>)info
+{
+  return [[FBSimulatorLogger_Filter alloc] initWithCurrentLevel:ASL_LEVEL_INFO enabledLevels:self.enabledLevels underlyingLogger:self.underlyingLogger.info];
+}
+
+- (id<FBSimulatorLogger>)debug
+{
+  return [[FBSimulatorLogger_Filter alloc] initWithCurrentLevel:ASL_LEVEL_DEBUG enabledLevels:self.enabledLevels underlyingLogger:self.underlyingLogger.debug];
+}
+
+- (id<FBSimulatorLogger>)error
+{
+  return [[FBSimulatorLogger_Filter alloc] initWithCurrentLevel:ASL_LEVEL_ERR enabledLevels:self.enabledLevels underlyingLogger:self.underlyingLogger.error];
+}
+
+- (id<FBSimulatorLogger>)timestamped
+{
+  return [[FBSimulatorLogger_Filter alloc] initWithCurrentLevel:self.currentLevel enabledLevels:self.enabledLevels underlyingLogger:self.underlyingLogger.timestamped];
 }
 
 @end
 
 @implementation FBSimulatorLogger
 
++ (id<FBSimulatorLogger>)toNSLogWithMaxLevel:(int)maxLevel
+{
+  return [[FBSimulatorLogger_Filter alloc]
+    initWithCurrentLevel:0
+    enabledLevels:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, (NSUInteger) maxLevel + 1)]
+    underlyingLogger:[[FBSimulatorLogger_NSLog alloc] initWithDateFormatter:nil]];
+}
+
 + (id<FBSimulatorLogger>)toNSLog
 {
-  return [FBSimulatorLogger_NSLog new];
+  return [self toNSLogWithMaxLevel:100];
 }
 
 @end

--- a/FBSimulatorControl/Video/FBSimulatorVideoRecorder.m
+++ b/FBSimulatorControl/Video/FBSimulatorVideoRecorder.m
@@ -128,27 +128,27 @@
 
 - (void)captureOutput:(AVCaptureFileOutput *)captureOutput didStartRecordingToOutputFileAtURL:(NSURL *)fileURL fromConnections:(NSArray *)connections;
 {
-  [self.logger logMessage:@"Capture started to %@", fileURL];
+  [self.logger logFormat:@"Capture started to %@", fileURL];
 }
 
 - (void)captureOutput:(AVCaptureFileOutput *)captureOutput didPauseRecordingToOutputFileAtURL:(NSURL *)fileURL fromConnections:(NSArray *)connections
 {
-  [self.logger logMessage:@"Capture paused at %@", fileURL];
+  [self.logger logFormat:@"Capture paused at %@", fileURL];
 }
 
 - (void)captureOutput:(AVCaptureFileOutput *)captureOutput didResumeRecordingToOutputFileAtURL:(NSURL *)fileURL fromConnections:(NSArray *)connection
 {
-  [self.logger logMessage:@"Capture resumed at %@", fileURL];
+  [self.logger logFormat:@"Capture resumed at %@", fileURL];
 }
 
 - (void)captureOutput:(AVCaptureFileOutput *)captureOutput willFinishRecordingToOutputFileAtURL:(NSURL *)fileURL fromConnections:(NSArray *)connections error:(NSError *)error
 {
-  [self.logger logMessage:@"Will finish recording to %@", fileURL];
+  [self.logger logFormat:@"Will finish recording to %@", fileURL];
 }
 
 - (void)captureOutput:(AVCaptureFileOutput *)captureOutput didFinishRecordingToOutputFileAtURL:(NSURL *)fileURL fromConnections:(NSArray *)connections error:(NSError *)error;
 {
-  [self.logger logMessage:@"Did finish recording to %@", fileURL];
+  [self.logger logFormat:@"Did finish recording to %@", fileURL];
 }
 
 - (BOOL)captureOutputShouldProvideSampleAccurateRecordingStart:(AVCaptureOutput *)captureOutput


### PR DESCRIPTION
Adding log levels will allow for finer grained logging in the CLI use-case. Additionally, the addition of some logs will make it far easier to track down what the causes of failures are during a run of `FBSimulatorControl`.