### PR TITLE
Opt-In for autoload of FBSimulatorControl Private Frameworks.

### DIFF
--- a/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.h
@@ -23,14 +23,19 @@ extern NSString *const FBSimulatorControlSimulatorLaunchEnvironmentSimulatorUDID
 extern NSString *const FBSimulatorControlDebugLogging;
 
 /**
- Enable/Disable CoreSimulator debug logging.
+ An Environment Variable to enable automatic evaluation of Global Preconditions.
  */
-void FBSetSimulatorLoggingEnabled(BOOL enabled);
+extern NSString *const FBSimulatorControlAutomaticallyLoadFrameworks;
 
 /**
  Environment Globals & other derived constants
  */
 @interface FBSimulatorControlStaticConfiguration : NSObject
+
+/**
+ If set to YES, Global Predocitions will automatically be evaluated on launch.
+ */
++ (BOOL)automaticallyLoadFrameworks;
 
 /**
  The path to of Xcode's /Xcode.app/Contents/Developer directory.

--- a/FBSimulatorControl/Management/FBSimulatorControl+Class.h
+++ b/FBSimulatorControl/Management/FBSimulatorControl+Class.h
@@ -22,6 +22,8 @@
  */
 @interface FBSimulatorControl : NSObject
 
+#pragma mark Initializers
+
 /**
  Creates and returns a new `FBSimulatorControl` instance.
 
@@ -41,6 +43,26 @@
  */
 + (instancetype)withConfiguration:(FBSimulatorControlConfiguration *)configuration error:(NSError **)error;
 
+#pragma mark Framework Loading
+
+/**
+ Loads all of the Frameworks upon which FBSimulatorControl depends.
+ This method *must* be called before any class in FBSimulatorControl can be used.
+ In order to do this automatically, set `FBSIMULATORCONTROL_EVALUATE_GLOBAL_PRECONDITIONS`.
+
+ @param logger the Logger to log events to.
+ @param error any error that occurred during performing the preconditions.
+ @returns YES if FBSimulatorControl is usable, NO otherwise.
+ */
++ (BOOL)loadPrivateFrameworks:(id<FBSimulatorLogger>)logger error:(NSError **)error;
+
+/**
+ Calls +[FBSimulatorControl loadPrivateFrameworks:error], aborting in the event the Frameworks could not be loaded
+ */
++ (void)loadPrivateFrameworksOrAbort;
+
+#pragma mark Session
+
 /**
  Creates and returns a new FBSimulatorSession instance. Does not launch the Simulator or any Applications.
 
@@ -50,6 +72,8 @@
  @returns A new `FBSimulatorSession` instance, or nil if an error occured.
  */
 - (FBSimulatorSession *)createSessionForSimulatorConfiguration:(FBSimulatorConfiguration *)simulatorConfiguration options:(FBSimulatorAllocationOptions)options error:(NSError **)error;
+
+#pragma mark Properties
 
 /**
  The Pool that the FBSimulatorControl instance uses.

--- a/FBSimulatorControl/Management/FBSimulatorControl.m
+++ b/FBSimulatorControl/Management/FBSimulatorControl.m
@@ -9,10 +9,13 @@
 
 #import "FBSimulatorControl+Class.h"
 
+#import <CoreSimulator/NSUserDefaults-SimDefaults.h>
 #import <CoreSimulator/SimDevice.h>
+#import <CoreSimulator/SimRuntime.h>
 
 #import <DVTFoundation/DVTPlatform.h>
 
+#import "FBCollectionDescriptions.h"
 #import "FBProcessLaunchConfiguration.h"
 #import "FBSimulatorConfiguration.h"
 #import "FBSimulatorControlConfiguration.h"
@@ -24,13 +27,20 @@
 #import "FBSimulatorSession+Convenience.h"
 #import "FBSimulatorSession.h"
 
+__attribute__((constructor)) static void FBSimulatorControlEntryPoint(void)
+{
+  if (FBSimulatorControlStaticConfiguration.automaticallyLoadFrameworks) {
+    [FBSimulatorControl loadPrivateFrameworksOrAbort];
+  }
+}
+
 @implementation FBSimulatorControl
 
-#pragma mark - Initializers
+#pragma mark Initializers
 
 + (instancetype)withConfiguration:(FBSimulatorControlConfiguration *)configuration logger:(id<FBSimulatorLogger>)logger error:(NSError **)error
 {
-  if (![FBSimulatorControl doGlobalPreconditionsWithError:error]) {
+  if (![FBSimulatorControl loadPrivateFrameworks:logger error:error]) {
     return nil;
   }
 
@@ -55,7 +65,77 @@
   return self;
 }
 
-#pragma mark - Public Methods
+#pragma mark Framework Loading
+
++ (BOOL)loadPrivateFrameworks:(id<FBSimulatorLogger>)logger error:(NSError **)error
+{
+  static BOOL hasLoaded = NO;
+  if (hasLoaded) {
+    return YES;
+  }
+
+  // This will assert if the directory could not be found.
+  NSString *developerDirectory = FBSimulatorControlStaticConfiguration.developerDirectory;
+
+  // A Mapping of Class Names to the Frameworks that they belong to. This serves to:
+  // 1) Represent the Frameworks that FBSimulatorControl is dependent on via their classes
+  // 2) Provide a path to the relevant Framework.
+  // 3) Provide a class for sanity checking the Framework load.
+  // 4) Provide a class that can be checked before the Framework load to avoid re-loading the same
+  //    Framework if others have done so before.
+  // 5) Provide a sanity check that any preloaded Private Frameworks match the current xcode-select version
+  NSDictionary *classMapping = @{
+    @"SimDevice" : @"Library/PrivateFrameworks/CoreSimulator.framework",
+    @"DVTDevice" : @"../SharedFrameworks/DVTFoundation.framework",
+    @"DTiPhoneSimulatorApplicationSpecifier" : @"../SharedFrameworks/DVTiPhoneSimulatorRemoteClient.framework"
+  };
+  [logger logMessage:@"Using Developer Directory %@", developerDirectory];
+
+  for (NSString *className in classMapping) {
+    NSString *relativePath = classMapping[className];
+    NSString *path = [[developerDirectory stringByAppendingPathComponent:relativePath] stringByStandardizingPath];
+
+    // The Class exists, therefore has been loaded
+    if (NSClassFromString(className)) {
+      [logger logMessage:@"%@ is allready loaded, skipping load of framework %@", className, path];
+      NSError *innerError = nil;
+      if (![self verifyDeveloperDirectoryForPrivateClass:className developerDirectory:developerDirectory logger:logger error:&innerError]) {
+        return [FBSimulatorError failBoolWithError:innerError errorOut:error];
+      }
+      continue;
+    }
+
+    // Otherwise load the Framework.
+    [logger logMessage:@"%@ is not loaded. Loading %@ at path %@", className, path.lastPathComponent, path];
+    NSError *innerError = nil;
+    if (![self loadFrameworkAtPath:path logger:logger error:&innerError]) {
+      return [FBSimulatorError failBoolWithError:innerError errorOut:error];
+    }
+    [logger logMessage:@"Loaded %@ from %@", className, path];
+  }
+
+  // We're done with loading Frameworks.
+  hasLoaded = YES;
+  [logger logMessage:@"Loaded All Private Frameworks %@", [FBCollectionDescriptions oneLineDescriptionFromArray:classMapping.allKeys atKeyPath:@"description"]];
+
+  // Set CoreSimulator Logging since it is now loaded.
+  [self setCoreSimulatorLoggingEnabled:FBSimulatorControlStaticConfiguration.simulatorDebugLoggingEnabled];
+
+  return YES;
+}
+
++ (void)loadPrivateFrameworksOrAbort
+{
+  NSError *error = nil;
+  BOOL success = [FBSimulatorControl loadPrivateFrameworks:FBSimulatorControlStaticConfiguration.defaultLogger error:&error];
+  if (success) {
+    return;
+  }
+  NSLog(@"Failed to load Frameworks with error %@", error);
+  abort();
+}
+
+#pragma mark Sessions
 
 - (FBSimulatorSession *)createSessionForSimulatorConfiguration:(FBSimulatorConfiguration *)simulatorConfiguration options:(FBSimulatorAllocationOptions)options error:(NSError **)error;
 {
@@ -69,21 +149,59 @@
   return [FBSimulatorSession sessionWithSimulator:simulator];
 }
 
-#pragma mark - Private Methods
+#pragma mark Private Methods
 
-+ (BOOL)doGlobalPreconditionsWithError:(NSError **)error
++ (void)setCoreSimulatorLoggingEnabled:(BOOL)enabled
 {
-  static BOOL hasRunOnce = NO;
-  if (!hasRunOnce) {
-    return YES;
-  }
+  NSUserDefaults *simulatorDefaults = [NSUserDefaults simulatorDefaults];
+  [simulatorDefaults setBool:enabled forKey:@"DebugLogging"];
+}
 
-  FBSetSimulatorLoggingEnabled(FBSimulatorControlStaticConfiguration.simulatorDebugLoggingEnabled);
++ (BOOL)loadFrameworkAtPath:(NSString *)path logger:(id<FBSimulatorLogger>)logger error:(NSError **)error
+{
+  NSBundle *bundle = [NSBundle bundleWithPath:path];
+  if (!bundle) {
+    return [[FBSimulatorError
+      describeFormat:@"Failed to load the bundle for path %@", path]
+      failBool:error];
+  }
 
   NSError *innerError = nil;
-  if (![DVTPlatform loadAllPlatformsReturningError:&innerError]) {
-    return [[[FBSimulatorError describe:@"Failed to Load all platforms"] causedBy:innerError] failBool:error];
+  if (![bundle loadAndReturnError:&innerError]) {
+    return [[FBSimulatorError
+      describeFormat:@"Failed to load the the Framework Bundle %@", bundle]
+      failBool:error];
   }
+  [logger logMessage:@"Successfully loaded %@", path.lastPathComponent];
+  return YES;
+}
+
+/**
+ Given that it is possible for FBSimulatorControl.framework to be loaded after any of the
+ Private Frameworks upon which it depends, it's possible that these Frameworks may have
+ been loaded from a different Developer Directory.
+
+ In order to prevent crazy behaviour from arising, FBSimulatorControl will check the
+ directories of these Frameworks match the one that is currently set.
+ */
++ (BOOL)verifyDeveloperDirectoryForPrivateClass:(NSString *)className developerDirectory:(NSString *)developerDirectory logger:(id<FBSimulatorLogger>)logger error:(NSError **)error
+{
+  NSBundle *bundle = [NSBundle bundleForClass:NSClassFromString(className)];
+  if (!bundle) {
+    return [[FBSimulatorError
+      describeFormat:@"Could not obtain Framework bundle for class named %@", className]
+      failBool:error];
+  }
+
+  // Developer Directory is: /Applications/Xcode.app/Contents/Developer
+  // The common base path is: is: /Applications/Xcode.app
+  NSString *basePath = [[developerDirectory stringByDeletingLastPathComponent] stringByDeletingLastPathComponent];
+  if (![bundle.bundlePath hasPrefix:basePath]) {
+    return [[FBSimulatorError
+      describeFormat:@"Expected Framework %@ to be loaded for Developer Directory at path %@, but was loaded from %@", bundle.bundlePath.lastPathComponent, bundle.bundlePath, developerDirectory]
+      failBool:error];
+  }
+  [logger logMessage:@"%@ has correct path of %@", className, basePath];
   return YES;
 }
 

--- a/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
@@ -18,6 +18,7 @@ __attribute__((constructor)) static void EntryPoint()
 {
   setenv(FBSimulatorControlDebugLogging.UTF8String, "YES", 1);
   NSLog(@"Current Configuration => %@", FBSimulatorControlStaticConfiguration.description);
+  [FBSimulatorControl loadPrivateFrameworksOrAbort];
 }
 
 @interface FBSimulatorControlTestCase ()


### PR DESCRIPTION
It's possible that the constructors are re-entrant and this causes issues with `otest-query-osx` used in `xctool`. It's better to place the onus of class loading on the consumer and additionally make it a precondition of `FBSimulatorContol`.

Additionally this removes the `+[DVTPlatform loadAllPlatformsReturningError:]` call. This call was actually *failing* but was being masked by the fact that the precondition method was erroneously never evaluated.