### PR TITLE
Use +[NSObject initialize] when using CoreSimulator-dependent classes

### DIFF
--- a/FBSimulatorControl/Configuration/FBSimulatorConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorConfiguration.m
@@ -12,6 +12,7 @@
 
 #import <objc/runtime.h>
 
+#import "FBSimulatorControl+Class.h"
 #import "FBSimulatorConfiguration+CoreSimulator.h"
 #import "FBSimulatorControlStaticConfiguration.h"
 
@@ -495,6 +496,11 @@
 @end
 
 @implementation FBSimulatorConfiguration
+
++ (void)initialize
+{
+  [FBSimulatorControl loadPrivateFrameworksOrAbort];
+}
 
 #pragma mark Initializers
 

--- a/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.m
@@ -9,6 +9,7 @@
 
 #import "FBSimulatorControlConfiguration.h"
 
+#import "FBSimulatorControl+Class.h"
 #import "FBSimulatorApplication.h"
 
 NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
@@ -22,6 +23,11 @@ NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
 @end
 
 @implementation FBSimulatorControlConfiguration
+
++ (void)initialize
+{
+  [FBSimulatorControl loadPrivateFrameworksOrAbort];
+}
 
 #pragma mark Initializers
 

--- a/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.h
@@ -23,19 +23,9 @@ extern NSString *const FBSimulatorControlSimulatorLaunchEnvironmentSimulatorUDID
 extern NSString *const FBSimulatorControlDebugLogging;
 
 /**
- An Environment Variable to enable automatic evaluation of Global Preconditions.
- */
-extern NSString *const FBSimulatorControlAutomaticallyLoadFrameworks;
-
-/**
  Environment Globals & other derived constants
  */
 @interface FBSimulatorControlStaticConfiguration : NSObject
-
-/**
- If set to YES, Global Predocitions will automatically be evaluated on launch.
- */
-+ (BOOL)automaticallyLoadFrameworks;
 
 /**
  The path to of Xcode's /Xcode.app/Contents/Developer directory.

--- a/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.m
@@ -16,14 +16,8 @@
 
 NSString *const FBSimulatorControlSimulatorLaunchEnvironmentSimulatorUDID = @"FBSIMULATORCONTROL_SIM_UDID";
 NSString *const FBSimulatorControlDebugLogging = @"FBSIMULATORCONTROL_DEBUG_LOGGING";
-NSString *const FBSimulatorControlAutomaticallyLoadFrameworks = @"FBSIMULATORCONTROL_AUTOMATICALLY_LOAD_FRAMEWORKS";
 
 @implementation FBSimulatorControlStaticConfiguration
-
-+ (BOOL)automaticallyLoadFrameworks
-{
-  return [NSProcessInfo.processInfo.environment[FBSimulatorControlAutomaticallyLoadFrameworks] boolValue];
-}
 
 + (NSString *)developerDirectory
 {

--- a/FBSimulatorControl/Management/FBSimulatorControl.m
+++ b/FBSimulatorControl/Management/FBSimulatorControl.m
@@ -27,23 +27,17 @@
 #import "FBSimulatorSession+Convenience.h"
 #import "FBSimulatorSession.h"
 
-__attribute__((constructor)) static void FBSimulatorControlEntryPoint(void)
-{
-  if (FBSimulatorControlStaticConfiguration.automaticallyLoadFrameworks) {
-    [FBSimulatorControl loadPrivateFrameworksOrAbort];
-  }
-}
-
 @implementation FBSimulatorControl
 
 #pragma mark Initializers
 
++ (void)initialize
+{
+  [FBSimulatorControl loadPrivateFrameworksOrAbort];
+}
+
 + (instancetype)withConfiguration:(FBSimulatorControlConfiguration *)configuration logger:(id<FBSimulatorLogger>)logger error:(NSError **)error
 {
-  if (![FBSimulatorControl loadPrivateFrameworks:logger error:error]) {
-    return nil;
-  }
-
   logger = logger ?: FBSimulatorControlStaticConfiguration.defaultLogger;
   return [[FBSimulatorControl alloc] initWithConfiguration:configuration logger:logger error:error];
 }

--- a/FBSimulatorControl/Management/FBSimulatorPool.m
+++ b/FBSimulatorControl/Management/FBSimulatorPool.m
@@ -36,6 +36,11 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
 
 @implementation FBSimulatorPool
 
++ (void)initialize
+{
+  [FBSimulatorControl loadPrivateFrameworksOrAbort];
+}
+
 #pragma mark - Initializers
 
 + (instancetype)poolWithConfiguration:(FBSimulatorControlConfiguration *)configuration logger:(id<FBSimulatorLogger>)logger error:(NSError **)error

--- a/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
@@ -18,7 +18,6 @@ __attribute__((constructor)) static void EntryPoint()
 {
   setenv(FBSimulatorControlDebugLogging.UTF8String, "YES", 1);
   NSLog(@"Current Configuration => %@", FBSimulatorControlStaticConfiguration.description);
-  [FBSimulatorControl loadPrivateFrameworksOrAbort];
 }
 
 @interface FBSimulatorControlTestCase ()

--- a/README.md
+++ b/README.md
@@ -34,12 +34,7 @@ Once you build the `FBSimulatorControl.framework`, it can be linked like any oth
 ## Usage
 In order to support different Xcode versions and system environments, `FBSimulatorControl` weakly links against Xcode's Private Frameworks and load these Frameworks when they are needed. `FBSimulatorControl` will link against the version of Xcode that you have set with [`xcode-select`](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/xcode-select.1.html). The Xcode version can be overridden by setting the `DEVELOPER_DIR` environment variable in the process that links with `FBSimulatorControl`.
 
-Since the Frameworks upon which `FBSimulatorControl` depends are loaded laziliy, they must be loaded before using the Framework. This also prevents loading of multiple versions of the Xcode Private Frameworks. There are a number of ways to achieve this:
-- Pass `FBSIMULATORCONTROL_AUTOMATICALLY_LOAD_FRAMEWORKS` to the environment. This will load the Frameworks when `FBSimulatorControl` is linked.
-- Call `+[FBSimulatorControl loadPrivateFrameworksOrAbort]` before using any of the `FBSimulatorControl` classes.
-- Call `+[FBSimulatorControl withConfiguration:error:]` first. This method will ensure that the necessary Frameworks are loaded.
-
-There's no need to worry about these methods conflicting, `FBSimulatorControl` will ensure that the Frameworks are only loaded once.
+Since the Frameworks upon which `FBSimulatorControl` depends are loaded laziliy, they must be loaded before using the Framework. Any of the `FBSimulatorControl` classes that have this runtime dependency will load these Private Frameworks when they are used for the first time.
 
 [The tests](FBSimulatorControlTests/Tests) should provide you with some basic guidance for using the API. `FBSimulatorControl` has an umbrella that can be imported to give access to the entire API.
 


### PR DESCRIPTION
This is probably the best balance between convenience and not having unexpected behaviour when `FBSimulatorControl` is first linked by clients.