### PR TITLE
Tests for Format Combinations

### DIFF
--- a/FBSimulatorControl/Management/FBSimulator+Helpers.m
+++ b/FBSimulatorControl/Management/FBSimulator+Helpers.m
@@ -22,7 +22,7 @@
 
 + (FBSimulatorState)simulatorStateFromStateString:(NSString *)stateString
 {
-  stateString = [stateString lowercaseString];
+  stateString = [[stateString lowercaseString] stringByReplacingOccurrencesOfString:@"-" withString:@" "];
   if ([stateString isEqualToString:@"creating"]) {
     return FBSimulatorStateCreating;
   }
@@ -39,7 +39,7 @@
     return FBSimulatorStateCreating;
   }
   if ([stateString isEqualToString:@"shutting down"]) {
-    return FBSimulatorStateCreating;
+    return FBSimulatorStateShuttingDown;
   }
   return FBSimulatorStateUnknown;
 }

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -241,11 +241,7 @@ extension Query : Parsable {
   public static func parser() -> Parser<Query> {
     return Parser
       .ofManyCount(1, parsers: [
-        Parser.ofString("creating", constant: Query.State([FBSimulatorState.Creating])),
-        Parser.ofString("shutdown", constant: Query.State([FBSimulatorState.Shutdown])),
-        Parser.ofString("booting", constant: Query.State([FBSimulatorState.Booting])),
-        Parser.ofString("booted", constant: Query.State([FBSimulatorState.Booted])),
-        Parser.ofString("shutting-down", constant: Query.State([FBSimulatorState.Booted])),
+        FBSimulatorState.parser().fmap { Query.State([$0]) },
         Query.uuidParser(),
         Query.nameParser()
       ])
@@ -274,17 +270,12 @@ extension Query : Parsable {
 extension Format : Parsable {
   public static func parser() -> Parser<Format> {
     return Parser
-      .ofMany([
+      .ofManyCount(1, parsers: [
         Parser.ofString("--udid", constant: Format.UDID),
         Parser.ofString("--name", constant: Format.Name),
-        Parser.ofString("--device-name", constant: Format.Name),
-        Parser.ofString("--os-constant: version", constant: Format.Name)
+        Parser.ofString("--device-name", constant: Format.DeviceName),
+        Parser.ofString("--os", constant: Format.OSVersion)
       ])
-      .fmap { formats in
-        if (formats.isEmpty) {
-          return Format.Compound([Format.Name, Format.UDID])
-        }
-        return Format.Compound(formats)
+      .fmap { Format.flatten($0) }
     }
-  }
 }

--- a/fbsimctl/FBSimulatorControlKitTests/Helpers/TestHelpers.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Helpers/TestHelpers.swift
@@ -13,20 +13,33 @@ import XCTest
 @testable import FBSimulatorControlKit
 
 public extension XCTestCase {
-  func assertParses(tokens: [String]) {
+  func assertParses<A : Equatable>(parser: Parser<A>, _ tokens: [String], _ expected: A) {
     do {
-      let _ = try Query.parser().parse(tokens)
+      let (_, actual) = try parser.parse(tokens)
+      XCTAssertEqual(expected, actual)
     } catch let err {
       XCTFail("Query '\(tokens.joinWithSeparator(" "))' failed to parse \(err)")
     }
   }
 
-  func assertParseFails(tokens: [String]) {
+  func assertParsesAll<A : Equatable>(parser: Parser<A>, _ tokenExpectedPairs: [([String], A)]) {
+    for (tokens, expected) in tokenExpectedPairs {
+      self.assertParses(parser, tokens, expected)
+    }
+  }
+
+  func assertParseFails<A>(parser: Parser<A>, _ tokens: [String]) {
     do {
-      let (_, query) = try Query.parser().parse(tokens)
-      XCTFail("Query '\(tokens.joinWithSeparator(" "))' should have failed to parse but did \(query)")
+      let (_, actual) = try parser.parse(tokens)
+      XCTFail("Query '\(tokens.joinWithSeparator(" "))' should have failed to parse but did \(actual)")
     } catch {
       // Passed
+    }
+  }
+
+  func assertFailsToParseAll<A>(parser: Parser<A>, _ tokensList: [[String]]) {
+    for tokens in tokensList {
+      self.assertParseFails(parser, tokens)
     }
   }
 }

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
@@ -10,69 +10,81 @@
  */
 
 import XCTest
+import FBSimulatorControl
 @testable import FBSimulatorControlKit
 
 class QueryParserTests : XCTestCase {
   func testParsesSimpleQueries() {
-    let queries = [
-      ["iPhone 5"],
-      ["iPad 2"],
-      ["creating"],
-      ["shutdown"],
-      ["booted"],
-      ["booting"],
-      ["shutting-down"],
-      ["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]
-    ]
-    for query in queries {
-      self.assertParses(query)
-    }
+    self.assertParsesAll(Query.parser(), [
+      (["iPhone 5"], .Configured([FBSimulatorConfiguration.iPhone5()])),
+      (["iPad 2"], .Configured([FBSimulatorConfiguration.iPad2()])),
+      (["creating"], .State([.Creating])),
+      (["shutdown"], .State([.Shutdown])),
+      (["booted"], .State([.Booted])),
+      (["booting"], .State([.Booting])),
+      (["shutting-down"], .State([.ShuttingDown])),
+      (["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], .UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]))
+    ])
   }
 
   func testFailsSimpleQueries() {
-    let queries = [
+    self.assertFailsToParseAll(Query.parser(), [
       ["Galaxy S5"],
       ["Nexus Chromebook Pixel G4 Droid S5 S1 S4 4S"],
       ["makingtea"],
       ["B8EEA6C4-47E5-92DE-014E0ECD8139"],
       []
-    ]
-    for query in queries {
-      self.assertParseFails(query)
-    }
+    ])
   }
 
   func testParsesCompoundQueries() {
-    let queries = [
-      ["iPhone 5", "iPad 2"],
-      ["creating", "booting", "shutdown"],
-      ["B8EEA6C4-841B-47E5-92DE-014E0ECD8139", "124DAC9C-4DFF-4F0C-9828-998CCFFCD4C8", "D7DA55E9-26FF-44FD-91A1-5B30DB68A4BB"],
-      ["B8EEA6C4-841B-47E5-92DE-014E0ECD8139", "124DAC9C-4DFF-4F0C-9828-998CCFFCD4C8", "booted"]
-    ]
-    for query in queries {
-      self.assertParses(query)
-    }
+    self.assertParsesAll(Query.parser(), [
+      (["iPhone 5", "iPad 2"], .Configured([FBSimulatorConfiguration.iPhone5(), FBSimulatorConfiguration.iPad2()])),
+      (["creating", "booting", "shutdown"], .State([.Creating, .Booting, .Shutdown])),
+      (["B8EEA6C4-841B-47E5-92DE-014E0ECD8139", "124DAC9C-4DFF-4F0C-9828-998CCFFCD4C8"], .UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139", "124DAC9C-4DFF-4F0C-9828-998CCFFCD4C8"])),
+      (["B8EEA6C4-841B-47E5-92DE-014E0ECD8139", "124DAC9C-4DFF-4F0C-9828-998CCFFCD4C8", "booted"], .And([.UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139", "124DAC9C-4DFF-4F0C-9828-998CCFFCD4C8"]), .State([.Booted])]))
+    ])
   }
 
   func testParsesPartially() {
-    let queries = [
-      ["iPhone 5", "Nexus 5", "iPad 2"],
-      ["creating", "booting", "jelly", "shutdown"],
-      ["B8EEA6C4-841B-47E5-92DE-014E0ECD8139", "banana", "D7DA55E9-26FF-44FD-91A1-5B30DB68A4BB"],
-    ]
-    for query in queries {
-      self.assertParses(query)
-    }
+    self.assertParsesAll(Query.parser(), [
+      (["iPhone 5", "Nexus 5", "iPad 2"], Query.Configured([FBSimulatorConfiguration.iPhone5()])),
+      (["creating", "booting", "jelly", "shutdown"], Query.State([.Creating, .Booting])),
+      (["B8EEA6C4-841B-47E5-92DE-014E0ECD8139", "banana", "D7DA55E9-26FF-44FD-91A1-5B30DB68A4BB"], .UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"])),
+    ])
   }
 
   func testFailsPartialParse() {
-    let queries = [
+    self.assertFailsToParseAll(Query.parser(), [
       ["Nexus 5", "iPhone 5", "iPad 2"],
       ["jelly", "creating", "booting", "shutdown"],
       ["banana", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139", "D7DA55E9-26FF-44FD-91A1-5B30DB68A4BB"],
-    ]
-    for query in queries {
-      self.assertParseFails(query)
-    }
+    ])
+  }
+}
+
+class FormatParserTests : XCTestCase {
+  func testParsesSimpleFormats() {
+    self.assertParsesAll(Format.parser(), [
+      (["--udid"], .UDID),
+      (["--name"], .Name),
+      (["--device-name"], .DeviceName),
+      (["--os"], .OSVersion)
+    ])
+  }
+
+  func testParsesCompoundFormats() {
+    self.assertParsesAll(Format.parser(), [
+      (["--name", "--device-name"], .Compound([.Name, .DeviceName])),
+      (["--udid", "--name", "--device-name", "--os"], .Compound([.UDID, .Name, .DeviceName, .OSVersion]))
+    ])
+  }
+
+  func testFailsToParse() {
+    self.assertFailsToParseAll(Format.parser(), [
+      ["--foo"],
+      ["--bar"],
+      ["--something-else"]
+    ])
   }
 }


### PR DESCRIPTION
Adds test for the parsing of `Format` enumerations, as well as fixes some of the parse issues that they have. Adds equality to `Format` and `Query` so that that parse successes are matched against the expected parse result.