### PR TITLE
Use 3-level timeouts

### DIFF
--- a/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.h
@@ -48,6 +48,21 @@ extern NSString *const FBSimulatorControlDebugLogging;
 + (NSString *)sdkVersion;
 
 /**
+ A Timeout Value when waiting on events that should happen 'fast'
+ */
++ (NSTimeInterval)fastTimeout;
+
+/**
+ A Timeout Value when waiting on events that will take some time longer than 'fast' events.
+ */
++ (NSTimeInterval)regularTimeout;
+
+/**
+ A Timeout Value when waiting on events that will a longer period of time.
+ */
++ (NSTimeInterval)slowTimeout;
+
+/**
  YES if passing a custom SimDeviceSet to the Simulator App is Supported.
  */
 + (BOOL)supportsCustomDeviceSets;

--- a/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.m
@@ -26,7 +26,7 @@ NSString *const FBSimulatorControlDebugLogging = @"FBSIMULATORCONTROL_DEBUG_LOGG
   dispatch_once(&onceToken, ^{
     directory = [[[FBTaskExecutor.sharedInstance
       taskWithLaunchPath:@"/usr/bin/xcode-select" arguments:@[@"--print-path"]]
-      startSynchronouslyWithTimeout:10]
+      startSynchronouslyWithTimeout:FBSimulatorControlStaticConfiguration.fastTimeout]
       stdOut];
     NSCAssert(directory, @"Xcode Path could not be determined from `xcode-select`");
   });
@@ -58,7 +58,7 @@ NSString *const FBSimulatorControlDebugLogging = @"FBSIMULATORCONTROL_DEBUG_LOGG
   dispatch_once(&onceToken, ^{
     NSString *showSdks= [[[FBTaskExecutor.sharedInstance
       taskWithLaunchPath:@"/usr/bin/xcodebuild" arguments:@[@"-showsdks"]]
-      startSynchronouslyWithTimeout:10]
+      startSynchronouslyWithTimeout:FBSimulatorControlStaticConfiguration.fastTimeout]
       stdOut];
 
     NSString *pattern = @"iphonesimulator(.*)";
@@ -84,6 +84,21 @@ NSString *const FBSimulatorControlDebugLogging = @"FBSIMULATORCONTROL_DEBUG_LOGG
     sdkVersion = [showSdks substringWithRange:[match rangeAtIndex:1]];
   });
   return sdkVersion;
+}
+
++ (NSTimeInterval)fastTimeout
+{
+  return 10;
+}
+
++ (NSTimeInterval)regularTimeout
+{
+  return 30;
+}
+
++ (NSTimeInterval)slowTimeout
+{
+  return 120;
 }
 
 + (BOOL)supportsCustomDeviceSets

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Diagnostics.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Diagnostics.m
@@ -10,6 +10,7 @@
 #import "FBSimulatorInteraction+Diagnostics.h"
 
 #import "FBSimulatorApplication.h"
+#import "FBSimulatorControlStaticConfiguration.h"
 #import "FBSimulatorError.h"
 #import "FBSimulatorEventSink.h"
 #import "FBSimulatorHistory+Queries.h"
@@ -83,7 +84,7 @@ typedef id<FBTask>(^FBDiagnosticTaskFactory)(FBTaskExecutor *executor, pid_t pro
     id<FBTask> task = taskFactory(FBTaskExecutor.sharedInstance, process.processIdentifier);
     NSCAssert(task, @"Task should not be nil");
 
-    [task startSynchronouslyWithTimeout:FBSimulatorDefaultTimeout];
+    [task startSynchronouslyWithTimeout:FBSimulatorControlStaticConfiguration.regularTimeout];
     if (task.error) {
       return [FBSimulatorError failBoolWithError:task.error errorOut:error];
     }

--- a/FBSimulatorControl/Management/FBSimulator+Helpers.m
+++ b/FBSimulatorControl/Management/FBSimulator+Helpers.m
@@ -13,6 +13,7 @@
 
 #import "FBSimDeviceWrapper.h"
 #import "FBSimulator+Private.h"
+#import "FBSimulatorControlStaticConfiguration.h"
 #import "FBSimulatorError.h"
 #import "FBSimulatorInteraction.h"
 #import "FBSimulatorPool.h"
@@ -64,7 +65,7 @@
 
 - (BOOL)waitOnState:(FBSimulatorState)state
 {
-  return [self waitOnState:state timeout:FBSimulatorDefaultTimeout];
+  return [self waitOnState:state timeout:FBSimulatorControlStaticConfiguration.regularTimeout];
 }
 
 - (BOOL)waitOnState:(FBSimulatorState)state timeout:(NSTimeInterval)timeout

--- a/FBSimulatorControl/Management/FBSimulator.h
+++ b/FBSimulatorControl/Management/FBSimulator.h
@@ -21,11 +21,6 @@
 @class SimDevice;
 
 /**
- The Default timeout for waits.
- */
-extern NSTimeInterval const FBSimulatorDefaultTimeout;
-
-/**
  Uses the known values of SimDevice State, to construct an enumeration.
  These mirror the values from -[SimDeviceState state].
  */

--- a/FBSimulatorControl/Management/FBSimulator.m
+++ b/FBSimulatorControl/Management/FBSimulator.m
@@ -35,8 +35,6 @@
 #import "FBSimulatorPool.h"
 #import "FBTaskExecutor.h"
 
-NSTimeInterval const FBSimulatorDefaultTimeout = 20;
-
 @implementation FBSimulator
 
 #pragma mark Lifecycle

--- a/FBSimulatorControl/Management/FBSimulatorPool.m
+++ b/FBSimulatorControl/Management/FBSimulatorPool.m
@@ -32,8 +32,6 @@
 #import "FBTaskExecutor.h"
 #import "NSRunLoop+SimulatorControlAdditions.h"
 
-static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
-
 @implementation FBSimulatorPool
 
 + (void)initialize
@@ -244,7 +242,7 @@ static NSTimeInterval const FBSimulatorPoolDefaultWait = 30.0;
   // Deleting the device from the set can still leave it around for a few seconds.
   // This could race with methods that may reallocate the newly-deleted device
   // So we should wait for the device to no longer be present in the underlying set.
-  BOOL wasRemovedFromDeviceSet = [NSRunLoop.currentRunLoop spinRunLoopWithTimeout:FBSimulatorPoolDefaultWait untilTrue:^ BOOL {
+  BOOL wasRemovedFromDeviceSet = [NSRunLoop.currentRunLoop spinRunLoopWithTimeout:FBSimulatorControlStaticConfiguration.regularTimeout untilTrue:^ BOOL {
     NSOrderedSet *udidSet = [self.allSimulators valueForKey:@"udid"];
     return ![udidSet containsObject:udid];
   }];

--- a/FBSimulatorControl/Tasks/FBTask.h
+++ b/FBSimulatorControl/Tasks/FBTask.h
@@ -12,11 +12,6 @@
 #import <FBSimulatorControl/FBTerminationHandle.h>
 
 /**
- The Default Timeout for Tasks
- */
-extern NSTimeInterval const FBTaskDefaultTimeout;
-
-/**
  Programmatic interface to a Task.
  */
 @protocol FBTask <NSObject, FBTerminationHandle>

--- a/FBSimulatorControl/Tasks/FBTask.m
+++ b/FBSimulatorControl/Tasks/FBTask.m
@@ -13,11 +13,6 @@
 #import "FBTaskExecutor.h"
 #import "NSRunLoop+SimulatorControlAdditions.h"
 
-/**
- The default timeout for synchronous command waits
- */
-NSTimeInterval const FBTaskDefaultTimeout = 30;
-
 @implementation FBTask
 
 #pragma mark Initializers
@@ -83,7 +78,7 @@ NSTimeInterval const FBTaskDefaultTimeout = 30;
     NSString *message = [NSString stringWithFormat:
       @"Shell command '%@' took longer than %f seconds to execute",
       self.task,
-      FBTaskDefaultTimeout
+      timeout
     ];
     self.runningError = [self errorForDescription:message];
   }

--- a/FBSimulatorControl/Tasks/FBTaskExecutor+Convenience.m
+++ b/FBSimulatorControl/Tasks/FBTaskExecutor+Convenience.m
@@ -9,6 +9,7 @@
 
 #import "FBTaskExecutor+Convenience.h"
 
+#import "FBSimulatorControlStaticConfiguration.h"
 #import "FBTask.h"
 #import "FBTaskExecutor+Private.h"
 
@@ -22,7 +23,7 @@
 - (NSString *)executeShellCommand:(NSString *)commandString returningError:(NSError **)error
 {
   id<FBTask> command = [self shellTask:commandString];
-  [command startSynchronouslyWithTimeout:FBTaskDefaultTimeout];
+  [command startSynchronouslyWithTimeout:FBSimulatorControlStaticConfiguration.regularTimeout];
 
   if (command.error) {
     if (error) {
@@ -36,7 +37,7 @@
 - (BOOL)repeatedlyRunCommand:(NSString *)commandString withError:(NSError **)error untilTrue:( BOOL(^)(NSString *stdOut) )block
 {
   @autoreleasepool {
-    NSDate *endDate = [NSDate dateWithTimeIntervalSinceNow:FBTaskDefaultTimeout];
+    NSDate *endDate = [NSDate dateWithTimeIntervalSinceNow:FBSimulatorControlStaticConfiguration.regularTimeout];
     while ([endDate timeIntervalSinceNow] < 0) {
       NSError *innerError = nil;
       NSString *stdOut = [self executeShellCommand:commandString returningError:&innerError];

--- a/FBSimulatorControl/Utility/FBAddVideoPolyfill.m
+++ b/FBSimulatorControl/Utility/FBAddVideoPolyfill.m
@@ -9,6 +9,7 @@
 
 #import "FBAddVideoPolyfill.h"
 
+#import "FBSimulatorControlStaticConfiguration.h"
 #import "FBProcessLaunchConfiguration+Helpers.h"
 #import "FBSimulator+Helpers.h"
 #import "FBSimulator.h"
@@ -16,8 +17,6 @@
 #import "FBSimulatorError.h"
 #import "FBSimulatorInteraction+Applications.h"
 #import "NSRunLoop+SimulatorControlAdditions.h"
-
-static NSTimeInterval const UploadVideoDefaultWait = 15.0;
 
 @interface FBAddVideoPolyfill ()
 
@@ -117,7 +116,7 @@ static NSTimeInterval const UploadVideoDefaultWait = 15.0;
   NSFileManager *fileManager = [NSFileManager defaultManager];
   __block NSError *innerError = nil;
   const BOOL success = [NSRunLoop.currentRunLoop
-    spinRunLoopWithTimeout:UploadVideoDefaultWait
+    spinRunLoopWithTimeout:FBSimulatorControlStaticConfiguration.regularTimeout
     untilTrue:^ BOOL {
       NSArray *paths = [fileManager subpathsOfDirectoryAtPath:directory error:&innerError];
       paths = [paths filteredArrayUsingPredicate:[self.class predicateForVideoFiles]];


### PR DESCRIPTION
Using multiple values all over the place for timeouts means that it can be very tricky to find out if these thresholds are too low when it comes to a resource constrained CI system (Travis). At some point in the future it should be possible to override defaults, which may be important for the CLI use case.