### PR TITLE
Use Travis build matrix to speed up CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: objective-c
 osx_image: xcode7.2
-script: ./build.sh ci
+env:
+- MODE=framework
+- MODE=cli
+- MODE=cli_framework
+script: ./build.sh
 
 branches:
   only:

--- a/build.sh
+++ b/build.sh
@@ -1,15 +1,25 @@
 #!/bin/sh
 
-if [ -z $1 ]; then
+function print_usage() {
   echo "usage: build.sh <subcommand>"
   echo "available subcommands:"
-  echo "  ci"
-  exit
+  echo "all framework cli cli_framework"
+  exit 1
+}
+
+if [[ -n $MODE ]]; then
+  echo "using mode $MODE"
+elif [[ -n $1 ]]; then
+  echo "using mode $1"
+  MODE=$1
+else
+  echo 'No argument or MODE provided'
+  print_usage
+  exit 1
 fi
 
 set -eu
 
-MODE=$1
 
 function framework() {
   NAME='FBSimulatorControl'
@@ -39,9 +49,19 @@ function cli_framework() {
       $1
 }
 
-if [ "$MODE" = "ci" ]; then
+if [[ "$MODE" = "all" ]]; then
   framework test
   cli_framework test
   cli build
+elif [[ "$MODE" = "framework" ]]; then
+  framework test
+elif [[ "$MODE" = "cli" ]]; then
+  cli build
+elif [[ "$MODE" = "cli_framework" ]]; then
+  cli_framework test
+else
+  echo "Invalid mode $MODE"
+  print_usage
+  exit 1
 fi
 


### PR DESCRIPTION
Travis has a ['Build Matrix'](https://docs.travis-ci.com/user/customizing-the-build/#Build-Matrix) that can be used to speed up builds by parallelizing. Some small modifications to the build scripts gives us the ability to paralellize