### PR TITLE
Tests for Option-Set style parsers

### DIFF
--- a/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
@@ -114,7 +114,7 @@ extension Parser {
     }
   }
 
-  static func ofString(string: String, constant: A) -> Parser<A> {
+  static func ofString(string: String, _ constant: A) -> Parser<A> {
     return Parser.single { token in
       if token != string {
         throw ParseError.DoesNotMatch(token, string)
@@ -134,7 +134,7 @@ extension Parser {
 
   static func succeeded(token: String, by: Parser<A>) -> Parser<A> {
     return Parser<()>
-      .ofString(token, constant: ())
+      .ofString(token, ())
       .sequence(by)
   }
 
@@ -147,15 +147,15 @@ extension Parser {
   }
 
   static func ofMany(parsers: [Parser<A>]) -> Parser<[A]> {
-    return self.ofManyCount(0, parsers: parsers)
+    return self.ofManyCount(0, parsers)
   }
 
   static func ofAny(parsers: [Parser<A>]) -> Parser<A> {
-    return self.ofManyCount(1, parsers: parsers)
+    return self.ofManyCount(1, parsers)
       .fmap { $0.first! }
   }
 
-  static func ofManyCount(count: Int, parsers: [Parser<A>]) -> Parser<[A]> {
+  static func ofManyCount(count: Int, _ parsers: [Parser<A>]) -> Parser<[A]> {
     assert(count >= 0, "Count should be >= 0")
     return Parser<[A]>() { tokens in
       var success = true

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
@@ -88,3 +88,46 @@ class FormatParserTests : XCTestCase {
     ])
   }
 }
+
+class FBSimulatorManagementOptionsParserTests : XCTestCase {
+  func testParsesSimple() {
+    self.assertParsesAll(FBSimulatorManagementOptions.parser(), [
+      (["--delete-all"], FBSimulatorManagementOptions.DeleteAllOnFirstStart),
+      (["--kill-all"], FBSimulatorManagementOptions.KillAllOnFirstStart),
+      (["--kill-spurious"], FBSimulatorManagementOptions.KillSpuriousSimulatorsOnFirstStart),
+      (["--ignore-spurious-kill-fail"], FBSimulatorManagementOptions.IgnoreSpuriousKillFail),
+      (["--kill-spurious-services"], FBSimulatorManagementOptions.KillSpuriousCoreSimulatorServices),
+      (["--process-killing"], FBSimulatorManagementOptions.UseProcessKilling),
+      (["--timeout-resiliance"], FBSimulatorManagementOptions.UseSimDeviceTimeoutResiliance)
+    ])
+  }
+
+  func testParsesCompound() {
+    self.assertParsesAll(FBSimulatorManagementOptions.parser(), [
+      (["--delete-all", "--kill-all"], FBSimulatorManagementOptions.DeleteAllOnFirstStart.union(.KillAllOnFirstStart)),
+      (["--kill-spurious-services", "--process-killing"], FBSimulatorManagementOptions.KillSpuriousCoreSimulatorServices.union(.UseProcessKilling)),
+      (["--ignore-spurious-kill-fail", "--timeout-resiliance"], FBSimulatorManagementOptions.IgnoreSpuriousKillFail.union(.UseSimDeviceTimeoutResiliance)),
+      (["--kill-spurious", "--ignore-spurious-kill-fail"], FBSimulatorManagementOptions.KillSpuriousSimulatorsOnFirstStart.union(.IgnoreSpuriousKillFail))
+    ])
+  }
+}
+
+class FBSimulatorAllocationOptionsParserTests : XCTestCase {
+  func testParsesSimple() {
+    self.assertParsesAll(FBSimulatorAllocationOptions.parser(), [
+      (["--create"], FBSimulatorAllocationOptions.Create),
+      (["--reuse"], FBSimulatorAllocationOptions.Reuse),
+      (["--shutdown-on-allocate"], FBSimulatorAllocationOptions.ShutdownOnAllocate),
+      (["--erase-on-allocate"], FBSimulatorAllocationOptions.EraseOnAllocate),
+      (["--delete-on-free"], FBSimulatorAllocationOptions.DeleteOnFree),
+      (["--erase-on-free"], FBSimulatorAllocationOptions.EraseOnFree)
+    ])
+  }
+
+  func testParsesCompound() {
+    self.assertParsesAll(FBSimulatorAllocationOptions.parser(), [
+      (["--create", "--reuse", "--erase-on-free"], FBSimulatorAllocationOptions.Create.union(.Reuse).union(.EraseOnFree)),
+      (["--shutdown-on-allocate", "--create", "--erase-on-free"], FBSimulatorAllocationOptions.Create.union(.ShutdownOnAllocate).union(.EraseOnFree)),
+    ])
+  }
+}


### PR DESCRIPTION
Some more tests for parsers, this time for option sets. This now places the responsibility for defaulting on empty parse to the caller of the parser.