### PR TITLE
Parsing of Actions

### DIFF
--- a/fbsimctl/FBSimulatorControlKit/Sources/Arguments.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Arguments.swift
@@ -9,7 +9,7 @@
 
 import Foundation
 
-public extension Subcommand {
+public extension Action {
   public static let HELP_STR = "help"
   public static let INTERACT = "interact"
   public static let LIST = "list"

--- a/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
@@ -54,7 +54,7 @@ public indirect enum Action {
  The entry point for all commands.
  */
 public enum Command {
-  case Single(Configuration, Action)
+  case Perform(Configuration, [Action])
   case Interact(Configuration, Int?)
   case Help(Action?)
 }
@@ -117,8 +117,8 @@ public extension Format {
 extension Command : Equatable {}
 public func == (left: Command, right: Command) -> Bool {
   switch (left, right) {
-  case (.Single(let leftConfiguration, let leftAction), .Single(let rightConfiguration, let rightAction)):
-    return leftConfiguration == rightConfiguration && leftAction == rightAction
+  case (.Perform(let leftConfiguration, let leftActions), .Perform(let rightConfiguration, let rightActions)):
+    return leftConfiguration == rightConfiguration && leftActions == rightActions
   case (.Interact(let leftConfiguration, let leftPort), .Interact(let rightConfiguration, let rightPort)):
     return leftConfiguration == rightConfiguration &&  leftPort == rightPort
   case (.Help(let leftAction), .Help(let rightAction)):

--- a/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
@@ -11,14 +11,6 @@ import Foundation
 import FBSimulatorControl
 
 /**
- Defines a single transaction with FBSimulatorControl
-*/
-public struct Command {
-  let configuration: Configuration
-  let subcommand: Action
-}
-
-/**
   Describes the Configuration for the running of a Command
 */
 public final class Configuration : FBSimulatorControlConfiguration {
@@ -59,6 +51,13 @@ public indirect enum Action {
   case Help(Action?)
 }
 
+/**
+ The entry point for all commands.
+ */
+public enum Command {
+  case Single(Configuration, Action)
+  case Help(Action?)
+}
 
 public extension Query {
   static func flatten(queries: [Query]) -> Query {
@@ -112,6 +111,18 @@ public extension Format {
     }
 
     return .Compound(formats)
+  }
+}
+
+extension Command : Equatable {}
+public func == (left: Command, right: Command) -> Bool {
+  switch (left, right) {
+  case (.Single(let leftConfiguration, let leftAction), .Single(let rightConfiguration, let rightAction)):
+    return leftConfiguration == rightConfiguration && leftAction == rightAction
+  case (.Help(let leftAction), .Help(let rightAction)):
+    return leftAction == rightAction
+  default:
+    return false
   }
 }
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
@@ -43,7 +43,6 @@ public indirect enum Query {
  An Action that can be performed provided a FBSimulatorControl instance.
 */
 public indirect enum Action {
-  case Interact(Int?)
   case List(Query, Format)
   case Boot(Query)
   case Shutdown(Query)
@@ -56,6 +55,7 @@ public indirect enum Action {
  */
 public enum Command {
   case Single(Configuration, Action)
+  case Interact(Configuration, Int?)
   case Help(Action?)
 }
 
@@ -119,6 +119,8 @@ public func == (left: Command, right: Command) -> Bool {
   switch (left, right) {
   case (.Single(let leftConfiguration, let leftAction), .Single(let rightConfiguration, let rightAction)):
     return leftConfiguration == rightConfiguration && leftAction == rightAction
+  case (.Interact(let leftConfiguration, let leftPort), .Interact(let rightConfiguration, let rightPort)):
+    return leftConfiguration == rightConfiguration &&  leftPort == rightPort
   case (.Help(let leftAction), .Help(let rightAction)):
     return leftAction == rightAction
   default:
@@ -129,8 +131,6 @@ public func == (left: Command, right: Command) -> Bool {
 extension Action : Equatable { }
 public func == (leftAction: Action, rightAction: Action) -> Bool {
   switch (leftAction, rightAction) {
-  case (.Interact(let leftPort), .Interact(let rightPort)):
-    return leftPort == rightPort
   case (.List(let leftQuery, let leftFormat), .List(let rightQuery, let rightFormat)):
     return leftQuery == rightQuery && leftFormat == rightFormat
   case (.Boot(let leftQuery), .Boot(let rightQuery)):

--- a/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
@@ -22,13 +22,6 @@ public struct Command {
   Describes the Configuration for the running of a Command
 */
 public final class Configuration : FBSimulatorControlConfiguration {
-  public static func defaultConfiguration() -> Configuration {
-    return Configuration(
-      simulatorApplication: try! FBSimulatorApplication(error: ()),
-      deviceSetPath: nil,
-      options: FBSimulatorManagementOptions()
-    )
-  }
 }
 
 /**

--- a/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
@@ -15,7 +15,7 @@ import FBSimulatorControl
 */
 public struct Command {
   let configuration: Configuration
-  let subcommand: Subcommand
+  let subcommand: Action
 }
 
 /**
@@ -55,15 +55,15 @@ public indirect enum Query {
 }
 
 /**
- The Base of all fbsimctl commands
+ An Action that can be performed provided a FBSimulatorControl instance.
 */
-public indirect enum Subcommand {
+public indirect enum Action {
   case Interact(Int?)
   case List(Query, Format)
   case Boot(Query)
   case Shutdown(Query)
   case Diagnose(Query)
-  case Help(Subcommand?)
+  case Help(Action?)
 }
 
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
@@ -118,10 +118,10 @@ public extension Format {
 extension Query : Equatable { }
 public func == (leftQuery: Query, rightQuery: Query) -> Bool {
   switch (leftQuery, rightQuery) {
-  case (let .UDID(left), let .UDID(right)): return left == right
-  case (let .State(left), let .State(right)): return left == right
-  case (let .Configured(left), let .Configured(right)): return left == right
-  case (let .And(left), let .And(right)): return left == right
+  case (.UDID(let left), .UDID(let right)): return left == right
+  case (.State(let left), .State(let right)): return left == right
+  case (.Configured(let left), .Configured(let right)): return left == right
+  case (.And(let left), .And(let right)): return left == right
   default: return false
   }
 }
@@ -133,7 +133,7 @@ public func == (lhs: Format, rhs: Format) -> Bool {
   case (.OSVersion, .OSVersion): return true
   case (.DeviceName, .DeviceName): return true
   case (.Name, .Name): return true
-  case (let .Compound(leftComp), let .Compound(rightComp)): return leftComp == rightComp
+  case (.Compound(let leftComp), .Compound(let rightComp)): return leftComp == rightComp
   default: return false
   }
 }

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -231,7 +231,7 @@ extension Action : Parsable {
 
   static func bootParser() -> Parser<Action> {
     return Parser
-      .succeeded("boot", Query.parser())
+      .succeeded("boot", Query.parser().fallback(Query.defaultValue()))
       .fmap { Action.Boot($0) }
   }
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -70,10 +70,23 @@ extension FBSimulatorState : Parsable {
 extension Command : Parsable {
   public static func parser() -> Parser<Command> {
     return Parser
+      .alternative([
+        self.helpParser(),
+        self.actionParser()
+      ])
+  }
+
+  static func actionParser() -> Parser<Command> {
+    return Parser
       .ofTwo(Configuration.parser(), Action.parser())
-      .fmap { (configuration, subcommand) in
-        Command(configuration: configuration, subcommand: subcommand)
-    }
+      .fmap { (configuration, action) in
+        return Command.Single(configuration, action)
+      }
+  }
+
+  static func helpParser() -> Parser<Command> {
+    return Parser
+      .ofString("help", .Help(nil))
   }
 }
 
@@ -197,17 +210,12 @@ extension Configuration : Parsable {
 extension Action : Parsable {
   public static func parser() -> Parser<Action> {
     return Parser.ofAny([
-      self.helpParser(),
       self.interactParser(),
       self.listParser(),
       self.bootParser(),
       self.shutdownParser(),
       self.diagnoseParser(),
     ])
-  }
-
-  static func helpParser() -> Parser<Action> {
-    return Parser.ofString("help", .Help(nil))
   }
 
   static func interactParser() -> Parser<Action> {

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -79,9 +79,12 @@ extension Command : Parsable {
 
   static func actionParser() -> Parser<Command> {
     return Parser
-      .ofTwo(Configuration.parser(), Action.parser())
-      .fmap { (configuration, action) in
-        return Command.Single(configuration, action)
+      .ofTwo(
+        Configuration.parser(),
+        Parser.manyCount(1, Action.parser())
+      )
+      .fmap { (configuration, actions) in
+        return Command.Perform(configuration, actions)
       }
   }
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -190,7 +190,7 @@ extension Configuration : Parsable {
 
   public static func deviceSetParser() -> Parser<String> {
     return Parser
-      .succeeded("--device-set", by: Parser<String>.ofDirectory())
+      .succeeded("--device-set", Parser<String>.ofDirectory())
   }
 }
 
@@ -212,35 +212,38 @@ extension Action : Parsable {
 
   static func interactParser() -> Parser<Action> {
     return Parser
-      .succeeded("interact", by: Parser.succeeded("--port", by: Parser<Int>.ofInt()).optional())
+      .succeeded("interact", Parser.succeeded("--port", Parser<Int>.ofInt()).optional())
       .fmap { Action.Interact($0) }
   }
 
   static func listParser() -> Parser<Action> {
     let followingParser = Parser
-      .ofTwo(Query.parser(), Format.parser())
+      .ofTwo(
+        Query.parser().fallback(Query.defaultValue()),
+        Format.parser().fallback(Format.defaultValue())
+      )
       .fmap { (query, format) in
         Action.List(query, format)
     }
 
-    return Parser.succeeded("list", by: followingParser)
+    return Parser.succeeded("list", followingParser)
   }
 
   static func bootParser() -> Parser<Action> {
     return Parser
-      .succeeded("boot", by: Query.parser())
+      .succeeded("boot", Query.parser())
       .fmap { Action.Boot($0) }
   }
 
   static func shutdownParser() -> Parser<Action> {
     return Parser
-      .succeeded("shutdown", by: Query.parser())
+      .succeeded("shutdown", Query.parser().fallback(Query.defaultValue()))
       .fmap { Action.Shutdown($0) }
   }
 
   static func diagnoseParser() -> Parser<Action> {
     return Parser
-      .succeeded("diagnose", by: Query.parser())
+      .succeeded("diagnose", Query.parser().fallback(Query.defaultValue()))
       .fmap { Action.Diagnose($0) }
   }
 }

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -93,7 +93,7 @@ extension Command : Parsable {
 extension FBSimulatorAllocationOptions : Parsable {
   public static func parser() -> Parser<FBSimulatorAllocationOptions> {
     return Parser
-      .ofMany([
+      .alternativeMany([
         self.createParser(),
         self.reuseParser(),
         self.shutdownOnAllocateParser(),
@@ -139,7 +139,7 @@ extension FBSimulatorAllocationOptions : Parsable {
 extension FBSimulatorManagementOptions : Parsable {
   public static func parser() -> Parser<FBSimulatorManagementOptions> {
     return Parser
-      .ofManyCount(1, [
+      .alternativeMany(1, [
         self.deleteAllOnFirstParser(),
         self.killAllOnFirstParser(),
         self.killSpuriousSimulatorsOnFirstStartParser(),
@@ -209,7 +209,7 @@ extension Configuration : Parsable {
 
 extension Action : Parsable {
   public static func parser() -> Parser<Action> {
-    return Parser.ofAny([
+    return Parser.alternative([
       self.interactParser(),
       self.listParser(),
       self.bootParser(),
@@ -259,7 +259,7 @@ extension Action : Parsable {
 extension Query : Parsable {
   public static func parser() -> Parser<Query> {
     return Parser
-      .ofManyCount(1, [
+      .alternativeMany(1, [
         FBSimulatorState.parser().fmap { Query.State([$0]) },
         Query.uuidParser(),
         Query.nameParser()
@@ -289,7 +289,7 @@ extension Query : Parsable {
 extension Format : Parsable {
   public static func parser() -> Parser<Format> {
     return Parser
-      .ofManyCount(1, [
+      .alternativeMany(1, [
         Parser.ofString("--udid", Format.UDID),
         Parser.ofString("--name", Format.Name),
         Parser.ofString("--device-name", Format.DeviceName),

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -72,6 +72,7 @@ extension Command : Parsable {
     return Parser
       .alternative([
         self.helpParser(),
+        self.interactParser(),
         self.actionParser()
       ])
   }
@@ -81,6 +82,17 @@ extension Command : Parsable {
       .ofTwo(Configuration.parser(), Action.parser())
       .fmap { (configuration, action) in
         return Command.Single(configuration, action)
+      }
+  }
+
+  static func interactParser() -> Parser<Command> {
+    return Parser
+      .ofTwo(
+        Configuration.parser(),
+        Parser.succeeded("interact", Parser.succeeded("--port", Parser<Int>.ofInt()).optional())
+      )
+      .fmap { (configuration, port) in
+        return Command.Interact(configuration, port)
       }
   }
 
@@ -210,18 +222,11 @@ extension Configuration : Parsable {
 extension Action : Parsable {
   public static func parser() -> Parser<Action> {
     return Parser.alternative([
-      self.interactParser(),
       self.listParser(),
       self.bootParser(),
       self.shutdownParser(),
       self.diagnoseParser(),
     ])
-  }
-
-  static func interactParser() -> Parser<Action> {
-    return Parser
-      .succeeded("interact", Parser.succeeded("--port", Parser<Int>.ofInt()).optional())
-      .fmap { Action.Interact($0) }
   }
 
   static func listParser() -> Parser<Action> {

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -70,7 +70,7 @@ extension FBSimulatorState : Parsable {
 extension Command : Parsable {
   public static func parser() -> Parser<Command> {
     return Parser
-      .ofTwo(Configuration.parser(), b: Subcommand.parser())
+      .ofTwo(Configuration.parser(), Subcommand.parser())
       .fmap { (configuration, subcommand) in
         Command(configuration: configuration, subcommand: subcommand)
     }
@@ -175,7 +175,10 @@ extension FBSimulatorManagementOptions : Parsable {
 
 extension Configuration : Parsable {
   public static func parser() -> Parser<Configuration> {
-    return Parser.ofTwo(deviceSetParser(), b: FBSimulatorManagementOptions.parser())
+    return Parser.ofTwo(
+        self.deviceSetParser().optional(),
+        FBSimulatorManagementOptions.parser().fallback(FBSimulatorManagementOptions())
+      )
       .fmap { setPath, options in
         return Configuration(
           simulatorApplication: try! FBSimulatorApplication(error: ()),
@@ -185,10 +188,9 @@ extension Configuration : Parsable {
       }
   }
 
-  static func deviceSetParser() -> Parser<String?> {
+  public static func deviceSetParser() -> Parser<String> {
     return Parser
-      .succeeded("--device-set", by: Parser<String>.ofDirectory() )
-      .optional()
+      .succeeded("--device-set", by: Parser<String>.ofDirectory())
   }
 }
 
@@ -216,7 +218,7 @@ extension Subcommand : Parsable {
 
   static func listParser() -> Parser<Subcommand> {
     let followingParser = Parser
-      .ofTwo(Query.parser(), b: Format.parser())
+      .ofTwo(Query.parser(), Format.parser())
       .fmap { (query, format) in
         Subcommand.List(query, format)
     }

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -70,7 +70,7 @@ extension FBSimulatorState : Parsable {
 extension Command : Parsable {
   public static func parser() -> Parser<Command> {
     return Parser
-      .ofTwo(Configuration.parser(), Subcommand.parser())
+      .ofTwo(Configuration.parser(), Action.parser())
       .fmap { (configuration, subcommand) in
         Command(configuration: configuration, subcommand: subcommand)
     }
@@ -194,8 +194,8 @@ extension Configuration : Parsable {
   }
 }
 
-extension Subcommand : Parsable {
-  public static func parser() -> Parser<Subcommand> {
+extension Action : Parsable {
+  public static func parser() -> Parser<Action> {
     return Parser.ofAny([
       self.helpParser(),
       self.interactParser(),
@@ -206,42 +206,42 @@ extension Subcommand : Parsable {
     ])
   }
 
-  static func helpParser() -> Parser<Subcommand> {
+  static func helpParser() -> Parser<Action> {
     return Parser.ofString("help", .Help(nil))
   }
 
-  static func interactParser() -> Parser<Subcommand> {
+  static func interactParser() -> Parser<Action> {
     return Parser
       .succeeded("interact", by: Parser.succeeded("--port", by: Parser<Int>.ofInt()).optional())
-      .fmap { Subcommand.Interact($0) }
+      .fmap { Action.Interact($0) }
   }
 
-  static func listParser() -> Parser<Subcommand> {
+  static func listParser() -> Parser<Action> {
     let followingParser = Parser
       .ofTwo(Query.parser(), Format.parser())
       .fmap { (query, format) in
-        Subcommand.List(query, format)
+        Action.List(query, format)
     }
 
     return Parser.succeeded("list", by: followingParser)
   }
 
-  static func bootParser() -> Parser<Subcommand> {
+  static func bootParser() -> Parser<Action> {
     return Parser
       .succeeded("boot", by: Query.parser())
-      .fmap { Subcommand.Boot($0) }
+      .fmap { Action.Boot($0) }
   }
 
-  static func shutdownParser() -> Parser<Subcommand> {
+  static func shutdownParser() -> Parser<Action> {
     return Parser
       .succeeded("shutdown", by: Query.parser())
-      .fmap { Subcommand.Shutdown($0) }
+      .fmap { Action.Shutdown($0) }
   }
 
-  static func diagnoseParser() -> Parser<Subcommand> {
+  static func diagnoseParser() -> Parser<Action> {
     return Parser
       .succeeded("diagnose", by: Query.parser())
-      .fmap { Subcommand.Diagnose($0) }
+      .fmap { Action.Diagnose($0) }
   }
 }
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/Defaults.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Defaults.swift
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import Foundation
+import FBSimulatorControl
+
+public protocol Default {
+  static func defaultValue() -> Self
+}
+
+extension Configuration : Default {
+  public static func defaultValue() -> Configuration {
+    return Configuration(
+      simulatorApplication: try! FBSimulatorApplication(error: ()),
+      deviceSetPath: nil,
+      options: FBSimulatorManagementOptions()
+    )
+  }
+}
+
+extension Format : Default {
+  public static func defaultValue() -> Format {
+    return .Compound([ .UDID, .Name])
+  }
+}
+
+extension Query : Default {
+  public static func defaultValue() -> Query {
+    return .And([])
+  }
+}

--- a/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
@@ -114,7 +114,7 @@ extension Parser {
     }
   }
 
-  static func ofString(string: String, constant: A) -> Parser<A> {
+  static func ofString(string: String, _ constant: A) -> Parser<A> {
     return Parser.single { token in
       if token != string {
         throw ParseError.DoesNotMatch(token, string)
@@ -134,7 +134,7 @@ extension Parser {
 
   static func succeeded(token: String, by: Parser<A>) -> Parser<A> {
     return Parser<()>
-      .ofString(token, constant: ())
+      .ofString(token, ())
       .sequence(by)
   }
 
@@ -147,15 +147,15 @@ extension Parser {
   }
 
   static func ofMany(parsers: [Parser<A>]) -> Parser<[A]> {
-    return self.ofManyCount(0, parsers: parsers)
+    return self.ofManyCount(0, parsers)
   }
 
   static func ofAny(parsers: [Parser<A>]) -> Parser<A> {
-    return self.ofManyCount(1, parsers: parsers)
+    return self.ofManyCount(1, parsers)
       .fmap { $0.first! }
   }
 
-  static func ofManyCount(count: Int, parsers: [Parser<A>]) -> Parser<[A]> {
+  static func ofManyCount(count: Int, _ parsers: [Parser<A>]) -> Parser<[A]> {
     assert(count >= 0, "Count should be >= 0")
     return Parser<[A]>() { tokens in
       var success = true

--- a/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
@@ -138,7 +138,7 @@ extension Parser {
       .sequence(by)
   }
 
-  static func ofTwo<B>(a: Parser<A>, b: Parser<B>) -> Parser<(A, B)> {
+  static func ofTwo<B>(a: Parser<A>, _ b: Parser<B>) -> Parser<(A, B)> {
     return a.bind { valueA in
       return b.fmap { valueB in
         return (valueA, valueB)

--- a/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
@@ -16,7 +16,7 @@ public extension Command {
       let (_, command) = try Command.parser().parse(arguments)
       return command
     } catch {
-      return Command(configuration: Configuration.defaultValue(), subcommand: .Help(nil))
+      return Command.Help(nil)
     }
   }
 }
@@ -143,6 +143,17 @@ extension Parser {
       return b.fmap { valueB in
         return (valueA, valueB)
       }
+    }
+  }
+
+  static func alternative(parsers: [Parser<A>]) -> Parser<A> {
+    return Parser<A>() { tokens in
+      for parser in parsers {
+        do {
+          return try parser.parse(tokens)
+        } catch {}
+      }
+      throw ParseError.EndOfInput
     }
   }
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
@@ -16,7 +16,7 @@ public extension Command {
       let (_, command) = try Command.parser().parse(arguments)
       return command
     } catch {
-      return Command(configuration: Configuration.defaultConfiguration(), subcommand: .Help(nil))
+      return Command(configuration: Configuration.defaultValue(), subcommand: .Help(nil))
     }
   }
 }
@@ -132,7 +132,7 @@ extension Parser {
     }
   }
 
-  static func succeeded(token: String, by: Parser<A>) -> Parser<A> {
+  static func succeeded(token: String, _ by: Parser<A>) -> Parser<A> {
     return Parser<()>
       .ofString(token, ())
       .sequence(by)

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -35,10 +35,23 @@ private struct BaseRunner : Runner {
     case .Interact(let configuration, let port):
       let control = try! FBSimulatorControl.withConfiguration(configuration)
       return InteractionRunner(control: control, portNumber: port).run()
-    case .Single(let configuration, let action):
+    case .Perform(let configuration, let actions):
       let control = try! FBSimulatorControl.withConfiguration(configuration)
-      return ActionRunner(action: action, control: control).run()
+      return ActionsRunner(actions: actions, control: control).run()
     }
+  }
+}
+
+private struct ActionsRunner : Runner {
+  let actions: [Action]
+  let control: FBSimulatorControl
+
+  func run() -> Output {
+    var output = Output.Success("")
+    for action in actions {
+      output = ActionRunner(action: action, control: control).run()
+    }
+    return output
   }
 }
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -41,14 +41,14 @@ private struct BaseRunner : Runner {
     case .Interact(let portNumber):
       return InteractionRunner(control: control, portNumber: portNumber).run()
     default:
-      let runner = SubcommandRunner(subcommand: self.command.subcommand, control: control)
+      let runner = ActionRunner(subcommand: self.command.subcommand, control: control)
       return runner.run()
     }
   }
 }
 
-private struct SubcommandRunner : Runner {
-  let subcommand: Subcommand
+private struct ActionRunner : Runner {
+  let subcommand: Action
   let control: FBSimulatorControl
 
   // TODO: Sessions don't make much sense in this context, combine multiple simulators into one session
@@ -119,8 +119,8 @@ private class InteractionRunner : Runner, RelayTransformer {
   func transform(input: String) -> Output {
     let arguments = input.componentsSeparatedByCharactersInSet(NSCharacterSet.whitespaceCharacterSet())
     do {
-      let (_, subcommand) = try Subcommand.parser().parse(arguments)
-      let runner = SubcommandRunner(subcommand: subcommand, control: self.control)
+      let (_, subcommand) = try Action.parser().parse(arguments)
+      let runner = ActionRunner(subcommand: subcommand, control: self.control)
       return runner.run()
     } catch {
       return .Failure("NOPE")

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -32,15 +32,12 @@ private struct BaseRunner : Runner {
     switch (self.command) {
     case .Help:
       return .Success(Command.getHelp())
+    case .Interact(let configuration, let port):
+      let control = try! FBSimulatorControl.withConfiguration(configuration)
+      return InteractionRunner(control: control, portNumber: port).run()
     case .Single(let configuration, let action):
       let control = try! FBSimulatorControl.withConfiguration(configuration)
-      switch (action) {
-      case .Interact(let portNumber):
-        return InteractionRunner(control: control, portNumber: portNumber).run()
-      default:
-        let runner = ActionRunner(action: action, control: control)
-        return runner.run()
-      }
+      return ActionRunner(action: action, control: control).run()
     }
   }
 }

--- a/fbsimctl/FBSimulatorControlKitTests/Helpers/TestHelpers.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Helpers/TestHelpers.swift
@@ -1,5 +1,3 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
-
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
  * All rights reserved.

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
@@ -225,7 +225,13 @@ class ActionParserTests : XCTestCase {
 class CommandParserTests : XCTestCase {
   func testParsesSingleAction() {
     self.assertParsesAll(Command.parser(), [
-      (["boot", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Command.Single(Configuration.defaultValue(), Action.Boot(.UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"])))),
+      (["boot", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Command.Perform(Configuration.defaultValue(), [Action.Boot(.UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]))])),
+    ])
+  }
+
+  func testParsesMultipleActions() {
+    self.assertParsesAll(Command.parser(), [
+      (["list", "booted", "boot", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Command.Perform(Configuration.defaultValue(), [Action.List(Query.State([.Booted]), Format.defaultValue()), Action.Boot(.UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]))])),
     ])
   }
 

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
@@ -131,3 +131,56 @@ class FBSimulatorAllocationOptionsParserTests : XCTestCase {
     ])
   }
 }
+
+class ConfigurationParserTests : XCTestCase {
+  func testParsesEmpty() {
+    self.assertParses(Configuration.parser(), [], Configuration(
+      simulatorApplication: try! FBSimulatorApplication(error: ()),
+      deviceSetPath: nil,
+      options: FBSimulatorManagementOptions()
+    ))
+  }
+
+  func testParsesWithSetPath() {
+    self.assertParses(
+      Configuration.parser(),
+      ["--device-set", "/usr/bin"],
+      Configuration(
+        simulatorApplication: try! FBSimulatorApplication(error: ()),
+        deviceSetPath: "/usr/bin",
+        options: FBSimulatorManagementOptions()
+      )
+    )
+  }
+
+  func testParseFailureWithInvalidSetPath() {
+    self.assertParseFails(
+      Configuration.deviceSetParser(),
+      ["--device-set", "/usr/asd2asd2___2332213/asdbin"]
+    )
+  }
+
+  func testParsesWithOptions() {
+    self.assertParses(
+      Configuration.parser(),
+      ["--kill-all", "--process-killing"],
+      Configuration(
+        simulatorApplication: try! FBSimulatorApplication(error: ()),
+        deviceSetPath: nil,
+        options: FBSimulatorManagementOptions.KillAllOnFirstStart.union(.UseProcessKilling)
+      )
+    )
+  }
+
+  func testParsesWithSetPathAndOptions() {
+    self.assertParses(
+      Configuration.parser(),
+      ["--device-set", "/usr/bin", "--delete-all", "--kill-spurious"],
+      Configuration(
+        simulatorApplication: try! FBSimulatorApplication(error: ()),
+        deviceSetPath: "/usr/bin",
+        options: FBSimulatorManagementOptions.DeleteAllOnFirstStart.union(.KillSpuriousSimulatorsOnFirstStart)
+      )
+    )
+  }
+}

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
@@ -184,13 +184,6 @@ class ConfigurationParserTests : XCTestCase {
 }
 
 class ActionParserTests : XCTestCase {
-  func testParsesInteract() {
-    self.assertParsesAll(Action.parser(), [
-      (["interact"], Action.Interact(nil)),
-      (["interact", "--port", "42"], Action.Interact(42))
-    ])
-  }
-
   func testParsesList() {
     self.assertParsesAll(Action.parser(), [
       (["list"], Action.List(Query.defaultValue(), Format.defaultValue())),
@@ -232,8 +225,14 @@ class ActionParserTests : XCTestCase {
 class CommandParserTests : XCTestCase {
   func testParsesSingleAction() {
     self.assertParsesAll(Command.parser(), [
-      (["interact"], Command.Single(Configuration.defaultValue(), Action.Interact(nil))),
       (["boot", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Command.Single(Configuration.defaultValue(), Action.Boot(.UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"])))),
+    ])
+  }
+
+  func testParsesInteract() {
+    self.assertParsesAll(Command.parser(), [
+      (["interact"], Command.Interact(Configuration.defaultValue(), nil)),
+      (["interact", "--port", "42"], Command.Interact(Configuration.defaultValue(), 42))
     ])
   }
 

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
@@ -1,5 +1,3 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
-
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
  * All rights reserved.
@@ -182,5 +180,51 @@ class ConfigurationParserTests : XCTestCase {
         options: FBSimulatorManagementOptions.DeleteAllOnFirstStart.union(.KillSpuriousSimulatorsOnFirstStart)
       )
     )
+  }
+}
+
+class ActionParserTests : XCTestCase {
+  func testParsesInteract() {
+    self.assertParsesAll(Action.parser(), [
+      (["interact"], Action.Interact(nil)),
+      (["interact", "--port", "42"], Action.Interact(42))
+    ])
+  }
+
+  func testParsesList() {
+    self.assertParsesAll(Action.parser(), [
+      (["list"], Action.List(Query.defaultValue(), Format.defaultValue())),
+      (["list", "booted"], Action.List(Query.State([.Booted]), Format.defaultValue())),
+      (["list", "--name"], Action.List(Query.defaultValue(), Format.Name)),
+      (["list", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139", "--os"], Action.List(Query.UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]), Format.OSVersion)),
+      (["list", "booted", "iPhone 5", "--device-name", "--os"], Action.List(Query.And([.State([.Booted]), .Configured([FBSimulatorConfiguration.iPhone5()])]), Format.Compound([.DeviceName, .OSVersion])))
+    ])
+  }
+
+  func testParsesBoot() {
+    self.assertParsesAll(Action.parser(), [
+      (["boot"], Action.Boot(Query.defaultValue())),
+      (["boot", "iPad 2"], Action.Boot(.Configured([FBSimulatorConfiguration.iPad2()]))),
+      (["boot", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Action.Boot(.UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]))),
+      (["boot", "iPhone 5", "shutdown", "iPhone 6"], Action.Boot(.And([.Configured([FBSimulatorConfiguration.iPhone5(), FBSimulatorConfiguration.iPhone6()]), .State([.Shutdown])]))),
+    ])
+  }
+
+  func testParsesShutdown() {
+    self.assertParsesAll(Action.parser(), [
+      (["shutdown"], Action.Shutdown(Query.defaultValue())),
+      (["shutdown", "iPad 2"], Action.Shutdown(.Configured([FBSimulatorConfiguration.iPad2()]))),
+      (["shutdown", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Action.Shutdown(.UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]))),
+      (["shutdown", "iPhone 5", "shutdown", "iPhone 6"], Action.Shutdown(.And([.Configured([FBSimulatorConfiguration.iPhone5(), FBSimulatorConfiguration.iPhone6()]), .State([.Shutdown])]))),
+    ])
+  }
+
+  func testParsesDiagnose() {
+    self.assertParsesAll(Action.parser(), [
+      (["diagnose"], Action.Diagnose(Query.defaultValue())),
+      (["diagnose", "iPad 2"], Action.Diagnose(.Configured([FBSimulatorConfiguration.iPad2()]))),
+      (["diagnose", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Action.Diagnose(.UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]))),
+      (["diagnose", "iPhone 5", "shutdown", "iPhone 6"], Action.Diagnose(.And([.Configured([FBSimulatorConfiguration.iPhone5(), FBSimulatorConfiguration.iPhone6()]), .State([.Shutdown])]))),
+    ])
   }
 }

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
@@ -228,3 +228,18 @@ class ActionParserTests : XCTestCase {
     ])
   }
 }
+
+class CommandParserTests : XCTestCase {
+  func testParsesSingleAction() {
+    self.assertParsesAll(Command.parser(), [
+      (["interact"], Command.Single(Configuration.defaultValue(), Action.Interact(nil))),
+      (["boot", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Command.Single(Configuration.defaultValue(), Action.Boot(.UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"])))),
+    ])
+  }
+
+  func testParsesHelp() {
+    self.assertParsesAll(Command.parser(), [
+      (["help"], Command.Help(nil))
+    ])
+  }
+}

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
@@ -88,3 +88,46 @@ class FormatParserTests : XCTestCase {
     ])
   }
 }
+
+class FBSimulatorManagementOptionsParserTests : XCTestCase {
+  func testParsesSimple() {
+    self.assertParsesAll(FBSimulatorManagementOptions.parser(), [
+      (["--delete-all"], FBSimulatorManagementOptions.DeleteAllOnFirstStart),
+      (["--kill-all"], FBSimulatorManagementOptions.KillAllOnFirstStart),
+      (["--kill-spurious"], FBSimulatorManagementOptions.KillSpuriousSimulatorsOnFirstStart),
+      (["--ignore-spurious-kill-fail"], FBSimulatorManagementOptions.IgnoreSpuriousKillFail),
+      (["--kill-spurious-services"], FBSimulatorManagementOptions.KillSpuriousCoreSimulatorServices),
+      (["--process-killing"], FBSimulatorManagementOptions.UseProcessKilling),
+      (["--timeout-resiliance"], FBSimulatorManagementOptions.UseSimDeviceTimeoutResiliance)
+    ])
+  }
+
+  func testParsesCompound() {
+    self.assertParsesAll(FBSimulatorManagementOptions.parser(), [
+      (["--delete-all", "--kill-all"], FBSimulatorManagementOptions.DeleteAllOnFirstStart.union(.KillAllOnFirstStart)),
+      (["--kill-spurious-services", "--process-killing"], FBSimulatorManagementOptions.KillSpuriousCoreSimulatorServices.union(.UseProcessKilling)),
+      (["--ignore-spurious-kill-fail", "--timeout-resiliance"], FBSimulatorManagementOptions.IgnoreSpuriousKillFail.union(.UseSimDeviceTimeoutResiliance)),
+      (["--kill-spurious", "--ignore-spurious-kill-fail"], FBSimulatorManagementOptions.KillSpuriousSimulatorsOnFirstStart.union(.IgnoreSpuriousKillFail))
+    ])
+  }
+}
+
+class FBSimulatorAllocationOptionsParserTests : XCTestCase {
+  func testParsesSimple() {
+    self.assertParsesAll(FBSimulatorAllocationOptions.parser(), [
+      (["--create"], FBSimulatorAllocationOptions.Create),
+      (["--reuse"], FBSimulatorAllocationOptions.Reuse),
+      (["--shutdown-on-allocate"], FBSimulatorAllocationOptions.ShutdownOnAllocate),
+      (["--erase-on-allocate"], FBSimulatorAllocationOptions.EraseOnAllocate),
+      (["--delete-on-free"], FBSimulatorAllocationOptions.DeleteOnFree),
+      (["--erase-on-free"], FBSimulatorAllocationOptions.EraseOnFree)
+    ])
+  }
+
+  func testParsesCompound() {
+    self.assertParsesAll(FBSimulatorAllocationOptions.parser(), [
+      (["--create", "--reuse", "--erase-on-free"], FBSimulatorAllocationOptions.Create.union(.Reuse).union(.EraseOnFree)),
+      (["--shutdown-on-allocate", "--create", "--erase-on-free"], FBSimulatorAllocationOptions.Create.union(.ShutdownOnAllocate).union(.EraseOnFree)),
+    ])
+  }
+}

--- a/fbsimctl/fbsimctl.xcodeproj/project.pbxproj
+++ b/fbsimctl/fbsimctl.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		AA1B7F781C2867EE0038C6A5 /* StdIORelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B7F691C2867EE0038C6A5 /* StdIORelay.swift */; };
 		AA2AFD731C29412C000123BA /* CommandParsersTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA2AFD721C29412C000123BA /* CommandParsersTest.swift */; };
 		AA2AFD751C294158000123BA /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA2AFD741C294158000123BA /* TestHelpers.swift */; };
+		AA3ADDB81C2B0B2D004E4FA9 /* Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3ADDB71C2B0B2D004E4FA9 /* Defaults.swift */; };
+		AA3ADDB91C2B19A4004E4FA9 /* Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3ADDB71C2B0B2D004E4FA9 /* Defaults.swift */; };
 		AA6085BE1C287AC3009B500E /* FBSimulatorControl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA93B7C91BE8361800CF6A56 /* FBSimulatorControl.framework */; };
 		AA6085CF1C287DBD009B500E /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE35A7C1C2863EB0073CC70 /* main.swift */; };
 		AA6085D01C287E02009B500E /* Arguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B7F5B1C2867EE0038C6A5 /* Arguments.swift */; };
@@ -84,6 +86,7 @@
 		AA1B7F691C2867EE0038C6A5 /* StdIORelay.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StdIORelay.swift; sourceTree = "<group>"; };
 		AA2AFD721C29412C000123BA /* CommandParsersTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandParsersTest.swift; sourceTree = "<group>"; };
 		AA2AFD741C294158000123BA /* TestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
+		AA3ADDB71C2B0B2D004E4FA9 /* Defaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Defaults.swift; sourceTree = "<group>"; };
 		AA6085BF1C287B36009B500E /* fbsimctl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fbsimctl.h; sourceTree = "<group>"; };
 		AA93B7B01BE8351000CF6A56 /* fbsimctl */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = fbsimctl; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA93B7C91BE8361800CF6A56 /* FBSimulatorControl.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = FBSimulatorControl.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -132,6 +135,7 @@
 				AA1B7F5E1C2867EE0038C6A5 /* CommandParsers.swift */,
 				AA1B7F5F1C2867EE0038C6A5 /* Constants.h */,
 				AA1B7F601C2867EE0038C6A5 /* Constants.m */,
+				AA3ADDB71C2B0B2D004E4FA9 /* Defaults.swift */,
 				AA1B7F611C2867EE0038C6A5 /* Help.swift */,
 				AA1B7F621C2867EE0038C6A5 /* LineBuffer.swift */,
 				AA1B7F641C2867EE0038C6A5 /* Parser.swift */,
@@ -353,6 +357,7 @@
 				AA6085D91C287E02009B500E /* Runners.swift in Sources */,
 				AA6085DA1C287E02009B500E /* SignalHandler.swift in Sources */,
 				AA6085DB1C287E02009B500E /* SocketRelay.swift in Sources */,
+				AA3ADDB91C2B19A4004E4FA9 /* Defaults.swift in Sources */,
 				AA6085DC1C287E02009B500E /* StdIORelay.swift in Sources */,
 				AA6085CF1C287DBD009B500E /* main.swift in Sources */,
 			);
@@ -363,6 +368,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA1B7F711C2867EE0038C6A5 /* LineBuffer.swift in Sources */,
+				AA3ADDB81C2B0B2D004E4FA9 /* Defaults.swift in Sources */,
 				AA1B7F781C2867EE0038C6A5 /* StdIORelay.swift in Sources */,
 				AA1B7F6F1C2867EE0038C6A5 /* Constants.m in Sources */,
 				AA1B7F771C2867EE0038C6A5 /* SocketRelay.swift in Sources */,


### PR DESCRIPTION
- [x] `Action` is a better coloured bikeshed than `Subcommand`
- [x] Improved defaulting in parsing
- [x] Tests for all Actions
- [x] Move `Help` to the upper level, remove dependency on `Configuration`
- [x] Move `interact` to the upper level, with a dependency on `Configuration`
- [x] Parsing of multiple actions