### PR TITLE
Add Debug Logging after creation

### DIFF
--- a/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.h
@@ -12,11 +12,6 @@
 @class FBSimulatorApplication;
 
 /**
- The default prefix for Pool-Managed Simulators
- */
-extern NSString *const FBSimulatorControlConfigurationDefaultNamePrefix;
-
-/**
  Options that apply to each FBSimulatorControl instance.
  */
 typedef NS_OPTIONS(NSUInteger, FBSimulatorManagementOptions){
@@ -37,16 +32,11 @@ typedef NS_OPTIONS(NSUInteger, FBSimulatorManagementOptions){
 /**
  Creates and returns a new Configuration with the provided parameters.
 
- @param simulatorApplication the FBSimulatorApplication for the Simulator.app.
  @param options the options for Simulator Management.
+ @param deviceSetPath the Path to the Device Set. If nil, the default Device Set will be used.
  @returns a new Configuration Object with the arguments applied.
  */
-+ (instancetype)configurationWithSimulatorApplication:(FBSimulatorApplication *)simulatorApplication deviceSetPath:(NSString *)deviceSetPath options:(FBSimulatorManagementOptions)options;
-
-/**
- The FBSimulatorApplication for the Simulator.app.
- */
-@property (nonatomic, copy, readonly) FBSimulatorApplication *simulatorApplication;
++ (instancetype)configurationWithDeviceSetPath:(NSString *)deviceSetPath options:(FBSimulatorManagementOptions)options;
 
 /**
  The Location of the SimDeviceSet. If no path is provided, the default device set will be used.

--- a/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.m
@@ -12,11 +12,8 @@
 #import "FBSimulatorApplication.h"
 #import "FBSimulatorControl+Class.h"
 
-NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
-
 @interface FBSimulatorControlConfiguration ()
 
-@property (nonatomic, copy, readwrite) FBSimulatorApplication *simulatorApplication;
 @property (nonatomic, copy, readwrite) NSString *deviceSetPath;
 @property (nonatomic, assign, readwrite) FBSimulatorManagementOptions options;
 
@@ -31,24 +28,18 @@ NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
 
 #pragma mark Initializers
 
-+ (instancetype)configurationWithSimulatorApplication:(FBSimulatorApplication *)simulatorApplication deviceSetPath:(NSString *)deviceSetPath options:(FBSimulatorManagementOptions)options
++ (instancetype)configurationWithDeviceSetPath:(NSString *)deviceSetPath options:(FBSimulatorManagementOptions)options
 {
-  if (!simulatorApplication) {
-    return nil;
-  }
-  return [[self alloc] initWithSimulatorApplication:simulatorApplication deviceSetPath:deviceSetPath options:options];
+  return [[self alloc] initWithDeviceSetPath:deviceSetPath options:options];
 }
 
-- (instancetype)initWithSimulatorApplication:(FBSimulatorApplication *)simulatorApplication deviceSetPath:(NSString *)deviceSetPath options:(FBSimulatorManagementOptions)options
+- (instancetype)initWithDeviceSetPath:(NSString *)deviceSetPath options:(FBSimulatorManagementOptions)options
 {
-  NSParameterAssert(simulatorApplication);
-
   self = [super init];
   if (!self) {
     return nil;
   }
 
-  _simulatorApplication = simulatorApplication;
   _deviceSetPath = deviceSetPath;
   _options = options;
 
@@ -60,8 +51,7 @@ NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
 - (instancetype)copyWithZone:(NSZone *)zone
 {
   return [self.class
-    configurationWithSimulatorApplication:self.simulatorApplication
-    deviceSetPath:self.deviceSetPath
+    configurationWithDeviceSetPath:self.deviceSetPath
     options:self.options];
 }
 
@@ -74,7 +64,6 @@ NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
     return nil;
   }
 
-  _simulatorApplication = [coder decodeObjectForKey:NSStringFromSelector(@selector(simulatorApplication))];
   _deviceSetPath = [coder decodeObjectForKey:NSStringFromSelector(@selector(deviceSetPath))];
   _options = [[coder decodeObjectForKey:NSStringFromSelector(@selector(options))] unsignedIntegerValue];
 
@@ -83,7 +72,6 @@ NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
 
 - (void)encodeWithCoder:(NSCoder *)coder
 {
-  [coder encodeObject:self.simulatorApplication forKey:NSStringFromSelector(@selector(simulatorApplication))];
   [coder encodeObject:self.deviceSetPath forKey:NSStringFromSelector(@selector(deviceSetPath))];
   [coder encodeObject:@(self.options) forKey:NSStringFromSelector(@selector(options))];
 }
@@ -92,7 +80,7 @@ NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
 
 - (NSUInteger)hash
 {
-  return self.simulatorApplication.hash | self.deviceSetPath.hash | self.options;
+  return self.deviceSetPath.hash | self.options;
 }
 
 - (BOOL)isEqual:(FBSimulatorControlConfiguration *)object
@@ -100,17 +88,15 @@ NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
   if (![object isKindOfClass:self.class]) {
     return NO;
   }
-  return [self.simulatorApplication isEqual:object.simulatorApplication] &&
-         ((self.deviceSetPath == nil && object.deviceSetPath == nil) || [self.deviceSetPath isEqual:object.deviceSetPath]) &&
+  return ((self.deviceSetPath == nil && object.deviceSetPath == nil) || [self.deviceSetPath isEqual:object.deviceSetPath]) &&
          self.options == object.options;
 }
 
 - (NSString *)description
 {
   return [NSString stringWithFormat:
-    @"Pool Config | Set Path %@ | Sim App %@ | Options %ld",
+    @"Pool Config | Set Path %@ | Options %ld",
     self.deviceSetPath,
-    self.simulatorApplication,
     self.options
   ];
 }

--- a/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.m
@@ -122,7 +122,12 @@ NSString *const FBSimulatorControlDebugLogging = @"FBSIMULATORCONTROL_DEBUG_LOGG
 
 + (id<FBSimulatorLogger>)defaultLogger
 {
-  return [FBSimulatorLogger withASLWritingToStderr:self.simulatorStandardLoggingEnabled debugLogging:self.simulatorDebugLoggingEnabled];
+  static dispatch_once_t onceToken;
+  static id<FBSimulatorLogger> logger;
+  dispatch_once(&onceToken, ^{
+    logger = [[FBSimulatorLogger aslLogger] writeToStderrr:self.simulatorStandardLoggingEnabled withDebugLogging:self.simulatorDebugLoggingEnabled];
+  });
+  return logger;
 }
 
 + (NSString *)description

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction.m
@@ -46,10 +46,6 @@
   FBSimulator *simulator = self.simulator;
 
   return [self interact:^ BOOL (NSError **error, id _) {
-    if (!simulator.simulatorApplication) {
-      return [[FBSimulatorError describe:@"Could not boot Simulator as no Simulator Application was provided"] failBool:error];
-    }
-
     // Construct the Arguments
     NSMutableArray *arguments = [NSMutableArray arrayWithArray:@[
       @"--args",
@@ -69,7 +65,7 @@
 
     // Construct and start the task.
     id<FBTask> task = [[[[[FBTaskExecutor.sharedInstance
-      withLaunchPath:simulator.simulatorApplication.binary.path]
+      withLaunchPath:FBSimulatorApplication.simulatorApplication.binary.path]
       withArguments:[arguments copy]]
       withEnvironmentAdditions:@{ FBSimulatorControlSimulatorLaunchEnvironmentSimulatorUDID : simulator.udid }]
       build]

--- a/FBSimulatorControl/Management/FBSimulator.h
+++ b/FBSimulatorControl/Management/FBSimulator.h
@@ -111,11 +111,6 @@ typedef NS_ENUM(NSInteger, FBSimulatorProductFamily) {
 @property (nonatomic, copy, readonly) NSString *dataDirectory;
 
 /**
- The Application that the Simulator should be launched with.
- */
-@property (nonatomic, copy, readonly) FBSimulatorApplication *simulatorApplication;
-
-/**
  The FBSimulatorConfiguration representing this Simulator.
  */
 @property (nonatomic, copy, readonly) FBSimulatorConfiguration *configuration;

--- a/FBSimulatorControl/Management/FBSimulator.m
+++ b/FBSimulatorControl/Management/FBSimulator.m
@@ -113,11 +113,6 @@
   return [FBSimulator stateStringFromSimulatorState:self.state];
 }
 
-- (FBSimulatorApplication *)simulatorApplication
-{
-  return self.pool.configuration.simulatorApplication;
-}
-
 - (NSString *)dataDirectory
 {
   return self.device.dataPath;

--- a/FBSimulatorControl/Model/FBSimulatorApplication.h
+++ b/FBSimulatorControl/Model/FBSimulatorApplication.h
@@ -114,10 +114,10 @@
 
 /**
  Returns the FBSimulatorApplication for the current version of Xcode's Simulator.app
-
- @param error an error out.
+ 
+ @return A FBSimulatorApplication instance for the Simulator.app.
  */
-+ (instancetype)simulatorApplicationWithError:(NSError **)error;
++ (instancetype)simulatorApplication;
 
 /**
  Returns the System Application with the provided name.

--- a/FBSimulatorControl/Model/FBSimulatorApplication.m
+++ b/FBSimulatorControl/Model/FBSimulatorApplication.m
@@ -214,9 +214,12 @@
   return [self applicationWithPath:[self pathForSystemApplicationNamed:appName] error:error];
 }
 
-+ (instancetype)simulatorApplicationWithError:(NSError **)error
++ (instancetype)simulatorApplication;
 {
-  return [self applicationWithPath:self.pathForSimulatorApplication error:error];
+  NSError *error = nil;
+  FBSimulatorApplication *application = [self applicationWithPath:self.pathForSimulatorApplication error:&error];
+  NSAssert(application, @"Expected to be able to build an Application, got an error %@", application);
+  return application;
 }
 
 #pragma mark Private

--- a/FBSimulatorControl/Utility/FBSimulatorLogger.h
+++ b/FBSimulatorControl/Utility/FBSimulatorLogger.h
@@ -45,6 +45,15 @@
  */
 - (id<FBSimulatorLogger>)error;
 
+/**
+ Updates the Logger to write to stderr.
+
+ @param writeToStdErr YES if all future log messages should be written to stderr, NO otherwise.
+ @param debugLogging YES if Debug messages should be written to stderr, NO otherwise.
+ @return the reciever, for chaining.
+ */
+- (instancetype)writeToStderrr:(BOOL)writeToStdErr withDebugLogging:(BOOL)debugLogging;
+
 @end
 
 @interface FBSimulatorLogger : NSObject
@@ -52,10 +61,8 @@
 /**
  An implementation of `FBSimulatorLogger` that logs all events using ASL.
 
- @param writeToStdErr YES if logged messages should be written to stderr, NO otherwise.
- @param debugLogging YES if logged messages should include debug messages, NO otherwise.
  @return an FBSimulatorLogger instance.
  */
-+ (id<FBSimulatorLogger>)withASLWritingToStderr:(BOOL)writeToStdErr debugLogging:(BOOL)debugLogging;
++ (id<FBSimulatorLogger>)aslLogger;
 
 @end

--- a/FBSimulatorControlTests/Tests/FBSimulatorControlConfigurationTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorControlConfigurationTests.m
@@ -19,11 +19,8 @@
 
 - (FBSimulatorControlConfiguration *)configuration
 {
-  FBSimulatorApplication *application = [FBSimulatorApplication simulatorApplicationWithError:nil];
-
   return [FBSimulatorControlConfiguration
-    configurationWithSimulatorApplication:application
-    deviceSetPath:nil
+    configurationWithDeviceSetPath:nil
     options:FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart];
 }
 
@@ -32,7 +29,6 @@
   FBSimulatorControlConfiguration *config = self.configuration;
   FBSimulatorControlConfiguration *configCopy = [config copy];
 
-  XCTAssertEqualObjects(config.simulatorApplication, configCopy.simulatorApplication);
   XCTAssertEqual(config.options, configCopy.options);
   XCTAssertEqualObjects(config, configCopy);
 }
@@ -43,7 +39,6 @@
   NSData *configData = [NSKeyedArchiver archivedDataWithRootObject:config];
   FBSimulatorControlConfiguration *configUnarchived = [NSKeyedUnarchiver unarchiveObjectWithData:configData];
 
-  XCTAssertEqualObjects(config.simulatorApplication, configUnarchived.simulatorApplication);
   XCTAssertEqual(config.options, configUnarchived.options);
   XCTAssertEqualObjects(config, configUnarchived);
 }

--- a/FBSimulatorControlTests/Tests/FBSimulatorPoolTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorPoolTests.m
@@ -69,10 +69,7 @@
   FBSimulatorControlTests_SimDeviceSet_Double *deviceSet = [FBSimulatorControlTests_SimDeviceSet_Double new];
   deviceSet.availableDevices = [simulators copy];
 
-  FBSimulatorControlConfiguration *poolConfig = [FBSimulatorControlConfiguration
-    configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
-    deviceSetPath:nil
-    options:0];
+  FBSimulatorControlConfiguration *poolConfig = [FBSimulatorControlConfiguration configurationWithDeviceSetPath:nil options:0];
   self.pool = [[FBSimulatorPool alloc] initWithConfiguration:poolConfig deviceSet:(id)deviceSet logger:nil];
 
   return deviceSet.availableDevices;

--- a/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
@@ -35,10 +35,7 @@ __attribute__((constructor)) static void EntryPoint()
 - (FBSimulatorControl *)control
 {
   if (!_control) {
-    FBSimulatorControlConfiguration *configuration = [FBSimulatorControlConfiguration
-      configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
-      deviceSetPath:self.deviceSetPath
-      options:self.managementOptions];
+    FBSimulatorControlConfiguration *configuration = [FBSimulatorControlConfiguration configurationWithDeviceSetPath:self.deviceSetPath options:self.managementOptions];
 
     NSError *error;
     FBSimulatorControl *control = [FBSimulatorControl withConfiguration:configuration error:&error];

--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ To launch Safari on an iPhone 5, you can use the following:
     // This Configuration will ensure that no other Simulators are running.
     FBSimulatorManagementOptions managementOptions = FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart;    
     FBSimulatorControlConfiguration *controlConfiguration = [FBSimulatorControlConfiguration
-      configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
-      deviceSetPath:nil
+      configurationWithDeviceSetPath:nil
       options:managementOptions];
     
     // The principal class, must be retained as long as the Framework is used.

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -208,11 +208,7 @@ extension Configuration : Parsable {
         FBSimulatorManagementOptions.parser().fallback(FBSimulatorManagementOptions())
       )
       .fmap { setPath, options in
-        return Configuration(
-          simulatorApplication: try! FBSimulatorApplication(error: ()),
-          deviceSetPath: setPath,
-          options: options
-        )
+        return Configuration(deviceSetPath: setPath, options: options)
       }
   }
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/Defaults.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Defaults.swift
@@ -16,11 +16,7 @@ public protocol Default {
 
 extension Configuration : Default {
   public static func defaultValue() -> Configuration {
-    return Configuration(
-      simulatorApplication: try! FBSimulatorApplication(error: ()),
-      deviceSetPath: nil,
-      options: FBSimulatorManagementOptions()
-    )
+    return Configuration(deviceSetPath: nil, options: FBSimulatorManagementOptions())
   }
 }
 

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
@@ -133,7 +133,6 @@ class FBSimulatorAllocationOptionsParserTests : XCTestCase {
 class ConfigurationParserTests : XCTestCase {
   func testParsesEmpty() {
     self.assertParses(Configuration.parser(), [], Configuration(
-      simulatorApplication: try! FBSimulatorApplication(error: ()),
       deviceSetPath: nil,
       options: FBSimulatorManagementOptions()
     ))
@@ -144,7 +143,6 @@ class ConfigurationParserTests : XCTestCase {
       Configuration.parser(),
       ["--device-set", "/usr/bin"],
       Configuration(
-        simulatorApplication: try! FBSimulatorApplication(error: ()),
         deviceSetPath: "/usr/bin",
         options: FBSimulatorManagementOptions()
       )
@@ -163,7 +161,6 @@ class ConfigurationParserTests : XCTestCase {
       Configuration.parser(),
       ["--kill-all", "--process-killing"],
       Configuration(
-        simulatorApplication: try! FBSimulatorApplication(error: ()),
         deviceSetPath: nil,
         options: FBSimulatorManagementOptions.KillAllOnFirstStart.union(.UseProcessKilling)
       )
@@ -175,7 +172,6 @@ class ConfigurationParserTests : XCTestCase {
       Configuration.parser(),
       ["--device-set", "/usr/bin", "--delete-all", "--kill-spurious"],
       Configuration(
-        simulatorApplication: try! FBSimulatorApplication(error: ()),
         deviceSetPath: "/usr/bin",
         options: FBSimulatorManagementOptions.DeleteAllOnFirstStart.union(.KillSpuriousSimulatorsOnFirstStart)
       )


### PR DESCRIPTION
Passing the Debug logging flags after the creation of the global logger object is inconvenient since it makes controlling this at runtime impossible without making assumptions about initialization order in the CLI. `asl` makes it easy to pipe to additional files.