### PR TITLE
Update Global Configuration

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -51,8 +51,8 @@
 		AA9517521C15F54600A89CAD /* FBSimulatorConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = AA9516CD1C15F54600A89CAD /* FBSimulatorConfiguration.m */; };
 		AA9517531C15F54600A89CAD /* FBSimulatorControlConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = AA9516CE1C15F54600A89CAD /* FBSimulatorControlConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA9517541C15F54600A89CAD /* FBSimulatorControlConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = AA9516CF1C15F54600A89CAD /* FBSimulatorControlConfiguration.m */; };
-		AA9517551C15F54600A89CAD /* FBSimulatorControlStaticConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = AA9516D01C15F54600A89CAD /* FBSimulatorControlStaticConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AA9517561C15F54600A89CAD /* FBSimulatorControlStaticConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = AA9516D11C15F54600A89CAD /* FBSimulatorControlStaticConfiguration.m */; };
+		AA9517551C15F54600A89CAD /* FBSimulatorControlGlobalConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = AA9516D01C15F54600A89CAD /* FBSimulatorControlGlobalConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA9517561C15F54600A89CAD /* FBSimulatorControlGlobalConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = AA9516D11C15F54600A89CAD /* FBSimulatorControlGlobalConfiguration.m */; };
 		AA9517571C15F54600A89CAD /* FBSimulatorResourceManager.h in Headers */ = {isa = PBXBuildFile; fileRef = AA9516D31C15F54600A89CAD /* FBSimulatorResourceManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA9517581C15F54600A89CAD /* FBSimulatorResourceManager.m in Sources */ = {isa = PBXBuildFile; fileRef = AA9516D41C15F54600A89CAD /* FBSimulatorResourceManager.m */; };
 		AA9517591C15F54600A89CAD /* FBSimulatorEventRelay.h in Headers */ = {isa = PBXBuildFile; fileRef = AA9516D51C15F54600A89CAD /* FBSimulatorEventRelay.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -831,8 +831,8 @@
 		AA9516CD1C15F54600A89CAD /* FBSimulatorConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorConfiguration.m; sourceTree = "<group>"; };
 		AA9516CE1C15F54600A89CAD /* FBSimulatorControlConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorControlConfiguration.h; sourceTree = "<group>"; };
 		AA9516CF1C15F54600A89CAD /* FBSimulatorControlConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorControlConfiguration.m; sourceTree = "<group>"; };
-		AA9516D01C15F54600A89CAD /* FBSimulatorControlStaticConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorControlStaticConfiguration.h; sourceTree = "<group>"; };
-		AA9516D11C15F54600A89CAD /* FBSimulatorControlStaticConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorControlStaticConfiguration.m; sourceTree = "<group>"; };
+		AA9516D01C15F54600A89CAD /* FBSimulatorControlGlobalConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorControlGlobalConfiguration.h; sourceTree = "<group>"; };
+		AA9516D11C15F54600A89CAD /* FBSimulatorControlGlobalConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorControlGlobalConfiguration.m; sourceTree = "<group>"; };
 		AA9516D31C15F54600A89CAD /* FBSimulatorResourceManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorResourceManager.h; sourceTree = "<group>"; };
 		AA9516D41C15F54600A89CAD /* FBSimulatorResourceManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorResourceManager.m; sourceTree = "<group>"; };
 		AA9516D51C15F54600A89CAD /* FBSimulatorEventRelay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorEventRelay.h; sourceTree = "<group>"; };
@@ -1698,8 +1698,8 @@
 				AA9516CB1C15F54600A89CAD /* FBSimulatorConfiguration+Private.h */,
 				AA9516CE1C15F54600A89CAD /* FBSimulatorControlConfiguration.h */,
 				AA9516CF1C15F54600A89CAD /* FBSimulatorControlConfiguration.m */,
-				AA9516D01C15F54600A89CAD /* FBSimulatorControlStaticConfiguration.h */,
-				AA9516D11C15F54600A89CAD /* FBSimulatorControlStaticConfiguration.m */,
+				AA9516D01C15F54600A89CAD /* FBSimulatorControlGlobalConfiguration.h */,
+				AA9516D11C15F54600A89CAD /* FBSimulatorControlGlobalConfiguration.m */,
 			);
 			path = Configuration;
 			sourceTree = "<group>";
@@ -2006,7 +2006,7 @@
 				AA9517531C15F54600A89CAD /* FBSimulatorControlConfiguration.h in Headers */,
 				AA1D653E1C21A9690069F90D /* FBCollectionDescriptions.h in Headers */,
 				AA95177F1C15F54600A89CAD /* FBSimulator.h in Headers */,
-				AA9517551C15F54600A89CAD /* FBSimulatorControlStaticConfiguration.h in Headers */,
+				AA9517551C15F54600A89CAD /* FBSimulatorControlGlobalConfiguration.h in Headers */,
 				AA9517B61C15F54600A89CAD /* FBSimDeviceWrapper.h in Headers */,
 				AA9517C21C15F60B00A89CAD /* FBCompositeSimulatorEventSink.h in Headers */,
 				AA9517A71C15F54600A89CAD /* FBTaskExecutor+Convenience.h in Headers */,
@@ -2190,7 +2190,7 @@
 				AACA2C381C2976B100979C45 /* FBAddVideoPolyfill.m in Sources */,
 				AA9517921C15F54600A89CAD /* FBSimulatorHistory+Queries.m in Sources */,
 				AA9517581C15F54600A89CAD /* FBSimulatorResourceManager.m in Sources */,
-				AA9517561C15F54600A89CAD /* FBSimulatorControlStaticConfiguration.m in Sources */,
+				AA9517561C15F54600A89CAD /* FBSimulatorControlGlobalConfiguration.m in Sources */,
 				AA9517941C15F54600A89CAD /* FBSimulatorHistory.m in Sources */,
 				AA9517611C15F54600A89CAD /* FBSimulatorNotificationEventSink.m in Sources */,
 				AAF8DA6E1C1AFFF0003B519E /* FBProcessQuery+Helpers.m in Sources */,

--- a/FBSimulatorControl/Configuration/FBSimulatorConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorConfiguration.m
@@ -14,7 +14,7 @@
 
 #import "FBSimulatorConfiguration+CoreSimulator.h"
 #import "FBSimulatorControl+Class.h"
-#import "FBSimulatorControlStaticConfiguration.h"
+#import "FBSimulatorControlGlobalConfiguration.h"
 
 @implementation FBSimulatorConfigurationVariant_Base
 

--- a/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.h
@@ -12,11 +12,6 @@
 @class FBSimulatorApplication;
 
 /**
- The default prefix for Pool-Managed Simulators
- */
-extern NSString *const FBSimulatorControlConfigurationDefaultNamePrefix;
-
-/**
  Options that apply to each FBSimulatorControl instance.
  */
 typedef NS_OPTIONS(NSUInteger, FBSimulatorManagementOptions){
@@ -37,16 +32,11 @@ typedef NS_OPTIONS(NSUInteger, FBSimulatorManagementOptions){
 /**
  Creates and returns a new Configuration with the provided parameters.
 
- @param simulatorApplication the FBSimulatorApplication for the Simulator.app.
  @param options the options for Simulator Management.
+ @param deviceSetPath the Path to the Device Set. If nil, the default Device Set will be used.
  @returns a new Configuration Object with the arguments applied.
  */
-+ (instancetype)configurationWithSimulatorApplication:(FBSimulatorApplication *)simulatorApplication deviceSetPath:(NSString *)deviceSetPath options:(FBSimulatorManagementOptions)options;
-
-/**
- The FBSimulatorApplication for the Simulator.app.
- */
-@property (nonatomic, copy, readonly) FBSimulatorApplication *simulatorApplication;
++ (instancetype)configurationWithDeviceSetPath:(NSString *)deviceSetPath options:(FBSimulatorManagementOptions)options;
 
 /**
  The Location of the SimDeviceSet. If no path is provided, the default device set will be used.

--- a/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.m
@@ -12,11 +12,8 @@
 #import "FBSimulatorApplication.h"
 #import "FBSimulatorControl+Class.h"
 
-NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
-
 @interface FBSimulatorControlConfiguration ()
 
-@property (nonatomic, copy, readwrite) FBSimulatorApplication *simulatorApplication;
 @property (nonatomic, copy, readwrite) NSString *deviceSetPath;
 @property (nonatomic, assign, readwrite) FBSimulatorManagementOptions options;
 
@@ -31,24 +28,18 @@ NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
 
 #pragma mark Initializers
 
-+ (instancetype)configurationWithSimulatorApplication:(FBSimulatorApplication *)simulatorApplication deviceSetPath:(NSString *)deviceSetPath options:(FBSimulatorManagementOptions)options
++ (instancetype)configurationWithDeviceSetPath:(NSString *)deviceSetPath options:(FBSimulatorManagementOptions)options
 {
-  if (!simulatorApplication) {
-    return nil;
-  }
-  return [[self alloc] initWithSimulatorApplication:simulatorApplication deviceSetPath:deviceSetPath options:options];
+  return [[self alloc] initWithDeviceSetPath:deviceSetPath options:options];
 }
 
-- (instancetype)initWithSimulatorApplication:(FBSimulatorApplication *)simulatorApplication deviceSetPath:(NSString *)deviceSetPath options:(FBSimulatorManagementOptions)options
+- (instancetype)initWithDeviceSetPath:(NSString *)deviceSetPath options:(FBSimulatorManagementOptions)options
 {
-  NSParameterAssert(simulatorApplication);
-
   self = [super init];
   if (!self) {
     return nil;
   }
 
-  _simulatorApplication = simulatorApplication;
   _deviceSetPath = deviceSetPath;
   _options = options;
 
@@ -60,8 +51,7 @@ NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
 - (instancetype)copyWithZone:(NSZone *)zone
 {
   return [self.class
-    configurationWithSimulatorApplication:self.simulatorApplication
-    deviceSetPath:self.deviceSetPath
+    configurationWithDeviceSetPath:self.deviceSetPath
     options:self.options];
 }
 
@@ -74,7 +64,6 @@ NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
     return nil;
   }
 
-  _simulatorApplication = [coder decodeObjectForKey:NSStringFromSelector(@selector(simulatorApplication))];
   _deviceSetPath = [coder decodeObjectForKey:NSStringFromSelector(@selector(deviceSetPath))];
   _options = [[coder decodeObjectForKey:NSStringFromSelector(@selector(options))] unsignedIntegerValue];
 
@@ -83,7 +72,6 @@ NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
 
 - (void)encodeWithCoder:(NSCoder *)coder
 {
-  [coder encodeObject:self.simulatorApplication forKey:NSStringFromSelector(@selector(simulatorApplication))];
   [coder encodeObject:self.deviceSetPath forKey:NSStringFromSelector(@selector(deviceSetPath))];
   [coder encodeObject:@(self.options) forKey:NSStringFromSelector(@selector(options))];
 }
@@ -92,7 +80,7 @@ NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
 
 - (NSUInteger)hash
 {
-  return self.simulatorApplication.hash | self.deviceSetPath.hash | self.options;
+  return self.deviceSetPath.hash | self.options;
 }
 
 - (BOOL)isEqual:(FBSimulatorControlConfiguration *)object
@@ -100,17 +88,15 @@ NSString *const FBSimulatorControlConfigurationDefaultNamePrefix = @"E2E";
   if (![object isKindOfClass:self.class]) {
     return NO;
   }
-  return [self.simulatorApplication isEqual:object.simulatorApplication] &&
-         ((self.deviceSetPath == nil && object.deviceSetPath == nil) || [self.deviceSetPath isEqual:object.deviceSetPath]) &&
+  return ((self.deviceSetPath == nil && object.deviceSetPath == nil) || [self.deviceSetPath isEqual:object.deviceSetPath]) &&
          self.options == object.options;
 }
 
 - (NSString *)description
 {
   return [NSString stringWithFormat:
-    @"Pool Config | Set Path %@ | Sim App %@ | Options %ld",
+    @"Pool Config | Set Path %@ | Options %ld",
     self.deviceSetPath,
-    self.simulatorApplication,
     self.options
   ];
 }

--- a/FBSimulatorControl/Configuration/FBSimulatorControlGlobalConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlGlobalConfiguration.h
@@ -20,7 +20,7 @@ extern NSString *const FBSimulatorControlSimulatorLaunchEnvironmentSimulatorUDID
 /**
  An Environment Variable: 'FBSIMULATORCONTROL_LOGGING' to enable logging of Informational Messages to stderr.
  */
-extern NSString *const FBSimulatorControlStandardLogging;
+extern NSString *const FBSimulatorControlStderrLogging;
 
 /**
  An Environment Variable: 'FBSIMULATORCONTROL_DEBUG_LOGGING' to enable logging of Debug Messages to stderr.
@@ -28,9 +28,9 @@ extern NSString *const FBSimulatorControlStandardLogging;
 extern NSString *const FBSimulatorControlDebugLogging;
 
 /**
- Environment Globals & other derived constants
+ Environment Globals & other derived constants.
  */
-@interface FBSimulatorControlStaticConfiguration : NSObject
+@interface FBSimulatorControlGlobalConfiguration : NSObject
 
 /**
  The path to of Xcode's /Xcode.app/Contents/Developer directory.
@@ -75,12 +75,12 @@ extern NSString *const FBSimulatorControlDebugLogging;
 /**
  YES if informattional logging should be written to stderr, NO otherwise.
  */
-+ (BOOL)simulatorStandardLoggingEnabled;
++ (BOOL)stderrLoggingEnabled;
 
 /**
  YES if Debug information should be written to stderr, NO otherwise.
  */
-+ (BOOL)simulatorDebugLoggingEnabled;
++ (BOOL)debugLoggingEnabled;
 
 /**
  The default logger to send log messages to.
@@ -91,5 +91,27 @@ extern NSString *const FBSimulatorControlDebugLogging;
  A Description of the Current Configuration.
  */
 + (NSString *)description;
+
+@end
+
+/**
+ Update the Global Configuration at (early) runtime by modifying the Environment.
+ These Methods should typically be called *before any other* method in FBSimulatorControl.
+ */
+@interface FBSimulatorControlGlobalConfiguration (Environment)
+
+/**
+ Update the current process environment to enable logging to stderr.
+
+ @param enabled YES if stderr logging should be enabled, NO otherwise.
+ */
++ (void)setStderrLoggingEnabled:(BOOL)enabled;
+
+/**
+ Update the current process environment to enable debug logging to stderr.
+
+ @param enabled YES if stderr debuglogging should be enabled, NO otherwise.
+ */
++ (void)setDebugLoggingEnabled:(BOOL)enabled;
 
 @end

--- a/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlStaticConfiguration.m
@@ -122,7 +122,12 @@ NSString *const FBSimulatorControlDebugLogging = @"FBSIMULATORCONTROL_DEBUG_LOGG
 
 + (id<FBSimulatorLogger>)defaultLogger
 {
-  return [FBSimulatorLogger withASLWritingToStderr:self.simulatorStandardLoggingEnabled debugLogging:self.simulatorDebugLoggingEnabled];
+  static dispatch_once_t onceToken;
+  static id<FBSimulatorLogger> logger;
+  dispatch_once(&onceToken, ^{
+    logger = [[FBSimulatorLogger aslLogger] writeToStderrr:self.simulatorStandardLoggingEnabled withDebugLogging:self.simulatorDebugLoggingEnabled];
+  });
+  return logger;
 }
 
 + (NSString *)description

--- a/FBSimulatorControl/Events/FBSimulatorLoggingEventSink.m
+++ b/FBSimulatorControl/Events/FBSimulatorLoggingEventSink.m
@@ -12,7 +12,7 @@
 #import "FBProcessInfo.h"
 #import "FBSimulator+Helpers.h"
 #import "FBSimulator.h"
-#import "FBSimulatorControlStaticConfiguration.h"
+#import "FBSimulatorControlGlobalConfiguration.h"
 #import "FBSimulatorLaunchInfo.h"
 
 @interface FBSimulatorLoggingEventSink ()

--- a/FBSimulatorControl/FBSimulatorControl.h
+++ b/FBSimulatorControl/FBSimulatorControl.h
@@ -36,7 +36,7 @@
 #import <FBSimulatorControl/FBSimulatorControl+Class.h>
 #import <FBSimulatorControl/FBSimulatorControl.h>
 #import <FBSimulatorControl/FBSimulatorControlConfiguration.h>
-#import <FBSimulatorControl/FBSimulatorControlStaticConfiguration.h>
+#import <FBSimulatorControl/FBSimulatorControlGlobalConfiguration.h>
 #import <FBSimulatorControl/FBSimulatorError.h>
 #import <FBSimulatorControl/FBSimulatorEventRelay.h>
 #import <FBSimulatorControl/FBSimulatorEventSink.h>

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Diagnostics.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Diagnostics.m
@@ -10,7 +10,7 @@
 #import "FBSimulatorInteraction+Diagnostics.h"
 
 #import "FBSimulatorApplication.h"
-#import "FBSimulatorControlStaticConfiguration.h"
+#import "FBSimulatorControlGlobalConfiguration.h"
 #import "FBSimulatorError.h"
 #import "FBSimulatorEventSink.h"
 #import "FBSimulatorHistory+Queries.h"
@@ -84,7 +84,7 @@ typedef id<FBTask>(^FBDiagnosticTaskFactory)(FBTaskExecutor *executor, pid_t pro
     id<FBTask> task = taskFactory(FBTaskExecutor.sharedInstance, process.processIdentifier);
     NSCAssert(task, @"Task should not be nil");
 
-    [task startSynchronouslyWithTimeout:FBSimulatorControlStaticConfiguration.regularTimeout];
+    [task startSynchronouslyWithTimeout:FBSimulatorControlGlobalConfiguration.regularTimeout];
     if (task.error) {
       return [FBSimulatorError failBoolWithError:task.error errorOut:error];
     }

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction.m
@@ -23,7 +23,7 @@
 #import "FBSimulatorConfiguration.h"
 #import "FBSimulatorControl.h"
 #import "FBSimulatorControlConfiguration.h"
-#import "FBSimulatorControlStaticConfiguration.h"
+#import "FBSimulatorControlGlobalConfiguration.h"
 #import "FBSimulatorError.h"
 #import "FBSimulatorEventSink.h"
 #import "FBSimulatorLaunchInfo.h"
@@ -57,7 +57,7 @@
       [arguments addObjectsFromArray:scaleArguments];
     }
     if (simulator.pool.configuration.deviceSetPath) {
-      if (!FBSimulatorControlStaticConfiguration.supportsCustomDeviceSets) {
+      if (!FBSimulatorControlGlobalConfiguration.supportsCustomDeviceSets) {
         return [[[FBSimulatorError describe:@"Cannot use custom Device Set on current platform"] inSimulator:simulator] failBool:error];
       }
       [arguments addObjectsFromArray:@[@"-DeviceSetPath", simulator.pool.configuration.deviceSetPath]];
@@ -90,7 +90,7 @@
 
     // Waitng for all required processes to start
     NSSet *requiredProcessNames = simulator.requiredProcessNamesToVerifyBooted;
-    BOOL didStartAllRequiredProcesses = [NSRunLoop.mainRunLoop spinRunLoopWithTimeout:FBSimulatorControlStaticConfiguration.slowTimeout untilTrue:^ BOOL {
+    BOOL didStartAllRequiredProcesses = [NSRunLoop.mainRunLoop spinRunLoopWithTimeout:FBSimulatorControlGlobalConfiguration.slowTimeout untilTrue:^ BOOL {
       NSSet *runningProcessNames = [NSSet setWithArray:[launchInfo.launchedProcesses valueForKey:@"processName"]];
       return [requiredProcessNames isSubsetOfSet:runningProcessNames];
     }];

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction.m
@@ -46,10 +46,6 @@
   FBSimulator *simulator = self.simulator;
 
   return [self interact:^ BOOL (NSError **error, id _) {
-    if (!simulator.simulatorApplication) {
-      return [[FBSimulatorError describe:@"Could not boot Simulator as no Simulator Application was provided"] failBool:error];
-    }
-
     // Construct the Arguments
     NSMutableArray *arguments = [NSMutableArray arrayWithArray:@[
       @"--args",
@@ -69,7 +65,7 @@
 
     // Construct and start the task.
     id<FBTask> task = [[[[[FBTaskExecutor.sharedInstance
-      withLaunchPath:simulator.simulatorApplication.binary.path]
+      withLaunchPath:FBSimulatorApplication.simulatorApplication.binary.path]
       withArguments:[arguments copy]]
       withEnvironmentAdditions:@{ FBSimulatorControlSimulatorLaunchEnvironmentSimulatorUDID : simulator.udid }]
       build]

--- a/FBSimulatorControl/Management/FBSimulator+Helpers.m
+++ b/FBSimulatorControl/Management/FBSimulator+Helpers.m
@@ -13,7 +13,7 @@
 
 #import "FBSimDeviceWrapper.h"
 #import "FBSimulator+Private.h"
-#import "FBSimulatorControlStaticConfiguration.h"
+#import "FBSimulatorControlGlobalConfiguration.h"
 #import "FBSimulatorError.h"
 #import "FBSimulatorInteraction.h"
 #import "FBSimulatorPool.h"
@@ -65,7 +65,7 @@
 
 - (BOOL)waitOnState:(FBSimulatorState)state
 {
-  return [self waitOnState:state timeout:FBSimulatorControlStaticConfiguration.regularTimeout];
+  return [self waitOnState:state timeout:FBSimulatorControlGlobalConfiguration.regularTimeout];
 }
 
 - (BOOL)waitOnState:(FBSimulatorState)state timeout:(NSTimeInterval)timeout

--- a/FBSimulatorControl/Management/FBSimulator.h
+++ b/FBSimulatorControl/Management/FBSimulator.h
@@ -111,11 +111,6 @@ typedef NS_ENUM(NSInteger, FBSimulatorProductFamily) {
 @property (nonatomic, copy, readonly) NSString *dataDirectory;
 
 /**
- The Application that the Simulator should be launched with.
- */
-@property (nonatomic, copy, readonly) FBSimulatorApplication *simulatorApplication;
-
-/**
  The FBSimulatorConfiguration representing this Simulator.
  */
 @property (nonatomic, copy, readonly) FBSimulatorConfiguration *configuration;

--- a/FBSimulatorControl/Management/FBSimulator.m
+++ b/FBSimulatorControl/Management/FBSimulator.m
@@ -24,7 +24,7 @@
 #import "FBSimulatorConfiguration+CoreSimulator.h"
 #import "FBSimulatorConfiguration.h"
 #import "FBSimulatorControlConfiguration.h"
-#import "FBSimulatorControlStaticConfiguration.h"
+#import "FBSimulatorControlGlobalConfiguration.h"
 #import "FBSimulatorError.h"
 #import "FBSimulatorEventRelay.h"
 #import "FBSimulatorEventSink.h"

--- a/FBSimulatorControl/Management/FBSimulator.m
+++ b/FBSimulatorControl/Management/FBSimulator.m
@@ -113,11 +113,6 @@
   return [FBSimulator stateStringFromSimulatorState:self.state];
 }
 
-- (FBSimulatorApplication *)simulatorApplication
-{
-  return self.pool.configuration.simulatorApplication;
-}
-
 - (NSString *)dataDirectory
 {
   return self.device.dataPath;

--- a/FBSimulatorControl/Management/FBSimulatorControl.m
+++ b/FBSimulatorControl/Management/FBSimulatorControl.m
@@ -19,7 +19,7 @@
 #import "FBProcessLaunchConfiguration.h"
 #import "FBSimulatorConfiguration.h"
 #import "FBSimulatorControlConfiguration.h"
-#import "FBSimulatorControlStaticConfiguration.h"
+#import "FBSimulatorControlGlobalConfiguration.h"
 #import "FBSimulatorError.h"
 #import "FBSimulatorHistory.h"
 #import "FBSimulatorLogger.h"
@@ -38,7 +38,7 @@
 
 + (instancetype)withConfiguration:(FBSimulatorControlConfiguration *)configuration logger:(id<FBSimulatorLogger>)logger error:(NSError **)error
 {
-  logger = logger ?: FBSimulatorControlStaticConfiguration.defaultLogger;
+  logger = logger ?: FBSimulatorControlGlobalConfiguration.defaultLogger;
   return [[FBSimulatorControl alloc] initWithConfiguration:configuration logger:logger error:error];
 }
 
@@ -69,7 +69,7 @@
   }
 
   // This will assert if the directory could not be found.
-  NSString *developerDirectory = FBSimulatorControlStaticConfiguration.developerDirectory;
+  NSString *developerDirectory = FBSimulatorControlGlobalConfiguration.developerDirectory;
 
   // A Mapping of Class Names to the Frameworks that they belong to. This serves to:
   // 1) Represent the Frameworks that FBSimulatorControl is dependent on via their classes
@@ -113,7 +113,7 @@
   [logger logFormat:@"Loaded All Private Frameworks %@", [FBCollectionDescriptions oneLineDescriptionFromArray:classMapping.allValues atKeyPath:@"lastPathComponent"]];
 
   // Set CoreSimulator Logging since it is now loaded.
-  [self setCoreSimulatorLoggingEnabled:FBSimulatorControlStaticConfiguration.simulatorDebugLoggingEnabled];
+  [self setCoreSimulatorLoggingEnabled:FBSimulatorControlGlobalConfiguration.debugLoggingEnabled];
 
   return YES;
 }
@@ -121,7 +121,7 @@
 + (void)loadPrivateFrameworksOrAbort
 {
   NSError *error = nil;
-  BOOL success = [FBSimulatorControl loadPrivateFrameworks:FBSimulatorControlStaticConfiguration.defaultLogger.debug error:&error];
+  BOOL success = [FBSimulatorControl loadPrivateFrameworks:FBSimulatorControlGlobalConfiguration.defaultLogger.debug error:&error];
   if (success) {
     return;
   }

--- a/FBSimulatorControl/Management/FBSimulatorPool.m
+++ b/FBSimulatorControl/Management/FBSimulatorPool.m
@@ -287,7 +287,7 @@
   // Deleting the device from the set can still leave it around for a few seconds.
   // This could race with methods that may reallocate the newly-deleted device
   // So we should wait for the device to no longer be present in the underlying set.
-  BOOL wasRemovedFromDeviceSet = [NSRunLoop.currentRunLoop spinRunLoopWithTimeout:FBSimulatorControlStaticConfiguration.regularTimeout untilTrue:^ BOOL {
+  BOOL wasRemovedFromDeviceSet = [NSRunLoop.currentRunLoop spinRunLoopWithTimeout:FBSimulatorControlGlobalConfiguration.regularTimeout untilTrue:^ BOOL {
     NSOrderedSet *udidSet = [self.allSimulators valueForKey:@"udid"];
     return ![udidSet containsObject:udid];
   }];

--- a/FBSimulatorControl/Model/FBSimulatorApplication.h
+++ b/FBSimulatorControl/Model/FBSimulatorApplication.h
@@ -114,10 +114,10 @@
 
 /**
  Returns the FBSimulatorApplication for the current version of Xcode's Simulator.app
-
- @param error an error out.
+ 
+ @return A FBSimulatorApplication instance for the Simulator.app.
  */
-+ (instancetype)simulatorApplicationWithError:(NSError **)error;
++ (instancetype)simulatorApplication;
 
 /**
  Returns the System Application with the provided name.

--- a/FBSimulatorControl/Model/FBSimulatorApplication.m
+++ b/FBSimulatorControl/Model/FBSimulatorApplication.m
@@ -214,9 +214,12 @@
   return [self applicationWithPath:[self pathForSystemApplicationNamed:appName] error:error];
 }
 
-+ (instancetype)simulatorApplicationWithError:(NSError **)error
++ (instancetype)simulatorApplication;
 {
-  return [self applicationWithPath:self.pathForSimulatorApplication error:error];
+  NSError *error = nil;
+  FBSimulatorApplication *application = [self applicationWithPath:self.pathForSimulatorApplication error:&error];
+  NSAssert(application, @"Expected to be able to build an Application, got an error %@", application);
+  return application;
 }
 
 #pragma mark Private

--- a/FBSimulatorControl/Model/FBSimulatorApplication.m
+++ b/FBSimulatorControl/Model/FBSimulatorApplication.m
@@ -11,7 +11,7 @@
 
 #import "FBBinaryParser.h"
 #import "FBConcurrentCollectionOperations.h"
-#import "FBSimulatorControlStaticConfiguration.h"
+#import "FBSimulatorControlGlobalConfiguration.h"
 #import "FBSimulatorError.h"
 #import "FBTaskExecutor.h"
 
@@ -226,18 +226,18 @@
 
 + (NSString *)pathForSimulatorApplication
 {
-  NSString *simulatorBinaryName = [FBSimulatorControlStaticConfiguration.sdkVersionNumber isGreaterThanOrEqualTo:[NSDecimalNumber decimalNumberWithString:@"9.0"]]
+  NSString *simulatorBinaryName = [FBSimulatorControlGlobalConfiguration.sdkVersionNumber isGreaterThanOrEqualTo:[NSDecimalNumber decimalNumberWithString:@"9.0"]]
     ? @"Simulator"
     : @"iOS Simulator";
 
-  return [[FBSimulatorControlStaticConfiguration.developerDirectory
+  return [[FBSimulatorControlGlobalConfiguration.developerDirectory
     stringByAppendingPathComponent:@"Applications"]
     stringByAppendingPathComponent:[NSString stringWithFormat:@"%@.app", simulatorBinaryName]];
 }
 
 + (NSString *)pathForSystemApplicationNamed:(NSString *)name
 {
-  return [[[FBSimulatorControlStaticConfiguration.developerDirectory
+  return [[[FBSimulatorControlGlobalConfiguration.developerDirectory
     stringByAppendingPathComponent:@"/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/Applications"]
     stringByAppendingPathComponent:name]
     stringByAppendingPathExtension:@"app"];

--- a/FBSimulatorControl/Processes/FBProcessQuery+Simulators.m
+++ b/FBSimulatorControl/Processes/FBProcessQuery+Simulators.m
@@ -15,7 +15,7 @@
 #import "FBSimulator.h"
 #import "FBSimulatorApplication.h"
 #import "FBSimulatorControlConfiguration.h"
-#import "FBSimulatorControlStaticConfiguration.h"
+#import "FBSimulatorControlGlobalConfiguration.h"
 
 @implementation FBProcessQuery (Simulators)
 
@@ -118,7 +118,7 @@
 
 + (NSPredicate *)coreSimulatorProcessesForCurrentXcode
 {
-  return [self processesWithLaunchPath:FBSimulatorControlStaticConfiguration.developerDirectory];
+  return [self processesWithLaunchPath:FBSimulatorControlGlobalConfiguration.developerDirectory];
 }
 
 + (NSPredicate *)processesWithLaunchPath:(NSString *)launchPath

--- a/FBSimulatorControl/Tasks/FBTaskExecutor+Convenience.m
+++ b/FBSimulatorControl/Tasks/FBTaskExecutor+Convenience.m
@@ -9,7 +9,7 @@
 
 #import "FBTaskExecutor+Convenience.h"
 
-#import "FBSimulatorControlStaticConfiguration.h"
+#import "FBSimulatorControlGlobalConfiguration.h"
 #import "FBTask.h"
 #import "FBTaskExecutor+Private.h"
 
@@ -23,7 +23,7 @@
 - (NSString *)executeShellCommand:(NSString *)commandString returningError:(NSError **)error
 {
   id<FBTask> command = [self shellTask:commandString];
-  [command startSynchronouslyWithTimeout:FBSimulatorControlStaticConfiguration.regularTimeout];
+  [command startSynchronouslyWithTimeout:FBSimulatorControlGlobalConfiguration.regularTimeout];
 
   if (command.error) {
     if (error) {
@@ -37,7 +37,7 @@
 - (BOOL)repeatedlyRunCommand:(NSString *)commandString withError:(NSError **)error untilTrue:( BOOL(^)(NSString *stdOut) )block
 {
   @autoreleasepool {
-    NSDate *endDate = [NSDate dateWithTimeIntervalSinceNow:FBSimulatorControlStaticConfiguration.regularTimeout];
+    NSDate *endDate = [NSDate dateWithTimeIntervalSinceNow:FBSimulatorControlGlobalConfiguration.regularTimeout];
     while ([endDate timeIntervalSinceNow] < 0) {
       NSError *innerError = nil;
       NSString *stdOut = [self executeShellCommand:commandString returningError:&innerError];

--- a/FBSimulatorControl/Utility/FBAddVideoPolyfill.m
+++ b/FBSimulatorControl/Utility/FBAddVideoPolyfill.m
@@ -13,7 +13,7 @@
 #import "FBSimulator+Helpers.h"
 #import "FBSimulator.h"
 #import "FBSimulatorApplication.h"
-#import "FBSimulatorControlStaticConfiguration.h"
+#import "FBSimulatorControlGlobalConfiguration.h"
 #import "FBSimulatorError.h"
 #import "FBSimulatorInteraction+Applications.h"
 #import "NSRunLoop+SimulatorControlAdditions.h"
@@ -116,7 +116,7 @@
   NSFileManager *fileManager = [NSFileManager defaultManager];
   __block NSError *innerError = nil;
   const BOOL success = [NSRunLoop.currentRunLoop
-    spinRunLoopWithTimeout:FBSimulatorControlStaticConfiguration.regularTimeout
+    spinRunLoopWithTimeout:FBSimulatorControlGlobalConfiguration.regularTimeout
     untilTrue:^ BOOL {
       NSArray *paths = [fileManager subpathsOfDirectoryAtPath:directory error:&innerError];
       paths = [paths filteredArrayUsingPredicate:[self.class predicateForVideoFiles]];

--- a/FBSimulatorControl/Utility/FBSimDeviceWrapper.m
+++ b/FBSimulatorControl/Utility/FBSimDeviceWrapper.m
@@ -17,7 +17,7 @@
 #import "FBProcessQuery.h"
 #import "FBSimulator.h"
 #import "FBSimulatorControlConfiguration.h"
-#import "FBSimulatorControlStaticConfiguration.h"
+#import "FBSimulatorControlGlobalConfiguration.h"
 #import "FBSimulatorError.h"
 #import "NSRunLoop+SimulatorControlAdditions.h"
 
@@ -47,7 +47,7 @@
   [newInvocation setArgument:&semaphore atIndex:3];
   [NSThread detachNewThreadSelector:@selector(invoke) toTarget:newInvocation withObject:nil];
 
-  int64_t timeout = ((int64_t) FBSimulatorControlStaticConfiguration.slowTimeout) * ((int64_t) NSEC_PER_SEC);
+  int64_t timeout = ((int64_t) FBSimulatorControlGlobalConfiguration.slowTimeout) * ((int64_t) NSEC_PER_SEC);
   return dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, timeout)) == 0;
 }
 
@@ -172,7 +172,7 @@
     return nil;
   }
 
-  FBProcessInfo *processInfo = [self.query processInfoFor:processIdentifier timeout:FBSimulatorControlStaticConfiguration.regularTimeout];
+  FBProcessInfo *processInfo = [self.query processInfoFor:processIdentifier timeout:FBSimulatorControlGlobalConfiguration.regularTimeout];
   if (!processInfo) {
     return [[FBSimulatorError describeFormat:@"Timed out waiting for process info for pid %d", processIdentifier] fail:error];
   }

--- a/FBSimulatorControl/Utility/FBSimulatorError.m
+++ b/FBSimulatorControl/Utility/FBSimulatorError.m
@@ -13,7 +13,7 @@
 #import "FBProcessInfo.h"
 #import "FBProcessQuery.h"
 #import "FBSimulator.h"
-#import "FBSimulatorControlStaticConfiguration.h"
+#import "FBSimulatorControlGlobalConfiguration.h"
 #import "FBSimulatorLaunchInfo.h"
 #import "FBSimulatorLogger.h"
 
@@ -40,7 +40,7 @@ NSString *const FBSimulatorControlErrorDomain = @"com.facebook.FBSimulatorContro
 
   _additionalInfo = [NSMutableDictionary dictionary];
   _describeRecursively = YES;
-  _logger = FBSimulatorControlStaticConfiguration.defaultLogger;
+  _logger = FBSimulatorControlGlobalConfiguration.defaultLogger;
 
   return self;
 }

--- a/FBSimulatorControl/Utility/FBSimulatorLogger.h
+++ b/FBSimulatorControl/Utility/FBSimulatorLogger.h
@@ -45,6 +45,15 @@
  */
 - (id<FBSimulatorLogger>)error;
 
+/**
+ Updates the Logger to write to stderr.
+
+ @param writeToStdErr YES if all future log messages should be written to stderr, NO otherwise.
+ @param debugLogging YES if Debug messages should be written to stderr, NO otherwise.
+ @return the reciever, for chaining.
+ */
+- (instancetype)writeToStderrr:(BOOL)writeToStdErr withDebugLogging:(BOOL)debugLogging;
+
 @end
 
 @interface FBSimulatorLogger : NSObject
@@ -52,10 +61,8 @@
 /**
  An implementation of `FBSimulatorLogger` that logs all events using ASL.
 
- @param writeToStdErr YES if logged messages should be written to stderr, NO otherwise.
- @param debugLogging YES if logged messages should include debug messages, NO otherwise.
  @return an FBSimulatorLogger instance.
  */
-+ (id<FBSimulatorLogger>)withASLWritingToStderr:(BOOL)writeToStdErr debugLogging:(BOOL)debugLogging;
++ (id<FBSimulatorLogger>)aslLogger;
 
 @end

--- a/FBSimulatorControlTests/Tests/FBSimulatorControlConfigurationTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorControlConfigurationTests.m
@@ -19,11 +19,8 @@
 
 - (FBSimulatorControlConfiguration *)configuration
 {
-  FBSimulatorApplication *application = [FBSimulatorApplication simulatorApplicationWithError:nil];
-
   return [FBSimulatorControlConfiguration
-    configurationWithSimulatorApplication:application
-    deviceSetPath:nil
+    configurationWithDeviceSetPath:nil
     options:FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart];
 }
 
@@ -32,7 +29,6 @@
   FBSimulatorControlConfiguration *config = self.configuration;
   FBSimulatorControlConfiguration *configCopy = [config copy];
 
-  XCTAssertEqualObjects(config.simulatorApplication, configCopy.simulatorApplication);
   XCTAssertEqual(config.options, configCopy.options);
   XCTAssertEqualObjects(config, configCopy);
 }
@@ -43,7 +39,6 @@
   NSData *configData = [NSKeyedArchiver archivedDataWithRootObject:config];
   FBSimulatorControlConfiguration *configUnarchived = [NSKeyedUnarchiver unarchiveObjectWithData:configData];
 
-  XCTAssertEqualObjects(config.simulatorApplication, configUnarchived.simulatorApplication);
   XCTAssertEqual(config.options, configUnarchived.options);
   XCTAssertEqualObjects(config, configUnarchived);
 }

--- a/FBSimulatorControlTests/Tests/FBSimulatorLaunchTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorLaunchTests.m
@@ -166,7 +166,7 @@
 
 - (void)testLaunchesiPhone
 {
-  if (!FBSimulatorControlStaticConfiguration.supportsCustomDeviceSets) {
+  if (!FBSimulatorControlGlobalConfiguration.supportsCustomDeviceSets) {
     NSLog(@"-[%@ %@] can't run as Custom Device Sets are not supported for this version of Xcode", NSStringFromClass(self.class), NSStringFromSelector(_cmd));
     return;
   }
@@ -175,7 +175,7 @@
 
 - (void)testLaunchesiPad
 {
-  if (!FBSimulatorControlStaticConfiguration.supportsCustomDeviceSets) {
+  if (!FBSimulatorControlGlobalConfiguration.supportsCustomDeviceSets) {
     NSLog(@"-[%@ %@] can't run as Custom Device Sets are not supported for this version of Xcode", NSStringFromClass(self.class), NSStringFromSelector(_cmd));
     return;
   }
@@ -184,7 +184,7 @@
 
 - (void)testLaunchesWatch
 {
-  if (!FBSimulatorControlStaticConfiguration.supportsCustomDeviceSets) {
+  if (!FBSimulatorControlGlobalConfiguration.supportsCustomDeviceSets) {
     NSLog(@"-[%@ %@] can't run as Custom Device Sets are not supported for this version of Xcode", NSStringFromClass(self.class), NSStringFromSelector(_cmd));
     return;
   }
@@ -193,7 +193,7 @@
 
 - (void)testLaunchesTV
 {
-  if (!FBSimulatorControlStaticConfiguration.supportsCustomDeviceSets) {
+  if (!FBSimulatorControlGlobalConfiguration.supportsCustomDeviceSets) {
     NSLog(@"-[%@ %@] can't run as Custom Device Sets are not supported for this version of Xcode", NSStringFromClass(self.class), NSStringFromSelector(_cmd));
     return;
   }
@@ -202,7 +202,7 @@
 
 - (void)testLaunchesMultipleSimulators
 {
-  if (!FBSimulatorControlStaticConfiguration.supportsCustomDeviceSets) {
+  if (!FBSimulatorControlGlobalConfiguration.supportsCustomDeviceSets) {
     NSLog(@"-[%@ %@] can't run as Custom Device Sets are not supported for this version of Xcode", NSStringFromClass(self.class), NSStringFromSelector(_cmd));
     return;
   }

--- a/FBSimulatorControlTests/Tests/FBSimulatorPoolTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorPoolTests.m
@@ -69,10 +69,7 @@
   FBSimulatorControlTests_SimDeviceSet_Double *deviceSet = [FBSimulatorControlTests_SimDeviceSet_Double new];
   deviceSet.availableDevices = [simulators copy];
 
-  FBSimulatorControlConfiguration *poolConfig = [FBSimulatorControlConfiguration
-    configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
-    deviceSetPath:nil
-    options:0];
+  FBSimulatorControlConfiguration *poolConfig = [FBSimulatorControlConfiguration configurationWithDeviceSetPath:nil options:0];
   self.pool = [[FBSimulatorPool alloc] initWithConfiguration:poolConfig deviceSet:(id)deviceSet logger:nil];
 
   return deviceSet.availableDevices;

--- a/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
@@ -35,10 +35,7 @@ __attribute__((constructor)) static void EntryPoint()
 - (FBSimulatorControl *)control
 {
   if (!_control) {
-    FBSimulatorControlConfiguration *configuration = [FBSimulatorControlConfiguration
-      configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
-      deviceSetPath:self.deviceSetPath
-      options:self.managementOptions];
+    FBSimulatorControlConfiguration *configuration = [FBSimulatorControlConfiguration configurationWithDeviceSetPath:self.deviceSetPath options:self.managementOptions];
 
     NSError *error;
     FBSimulatorControl *control = [FBSimulatorControl withConfiguration:configuration error:&error];

--- a/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
@@ -16,9 +16,9 @@
 // Used to print out environment configuration for debugging.
 __attribute__((constructor)) static void EntryPoint()
 {
-  setenv(FBSimulatorControlDebugLogging.UTF8String, "NO", 1);
-  setenv(FBSimulatorControlStandardLogging.UTF8String, "YES", 1);
-  [FBSimulatorControlStaticConfiguration.defaultLogger logFormat:@"Current Configuration => %@", FBSimulatorControlStaticConfiguration.description];
+  [FBSimulatorControlGlobalConfiguration setStderrLoggingEnabled:YES];
+  [FBSimulatorControlGlobalConfiguration setDebugLoggingEnabled:NO];
+  [FBSimulatorControlGlobalConfiguration.defaultLogger logFormat:@"Current Configuration => %@", FBSimulatorControlGlobalConfiguration.description];
 }
 
 @interface FBSimulatorControlTestCase ()

--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ To launch Safari on an iPhone 5, you can use the following:
     // This Configuration will ensure that no other Simulators are running.
     FBSimulatorManagementOptions managementOptions = FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart;    
     FBSimulatorControlConfiguration *controlConfiguration = [FBSimulatorControlConfiguration
-      configurationWithSimulatorApplication:[FBSimulatorApplication simulatorApplicationWithError:nil]
-      deviceSetPath:nil
+      configurationWithDeviceSetPath:nil
       options:managementOptions];
     
     // The principal class, must be retained as long as the Framework is used.

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -208,11 +208,7 @@ extension Configuration : Parsable {
         FBSimulatorManagementOptions.parser().fallback(FBSimulatorManagementOptions())
       )
       .fmap { setPath, options in
-        return Configuration(
-          simulatorApplication: try! FBSimulatorApplication(error: ()),
-          deviceSetPath: setPath,
-          options: options
-        )
+        return Configuration(deviceSetPath: setPath, options: options)
       }
   }
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/Defaults.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Defaults.swift
@@ -16,11 +16,7 @@ public protocol Default {
 
 extension Configuration : Default {
   public static func defaultValue() -> Configuration {
-    return Configuration(
-      simulatorApplication: try! FBSimulatorApplication(error: ()),
-      deviceSetPath: nil,
-      options: FBSimulatorManagementOptions()
-    )
+    return Configuration(deviceSetPath: nil, options: FBSimulatorManagementOptions())
   }
 }
 

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
@@ -133,7 +133,6 @@ class FBSimulatorAllocationOptionsParserTests : XCTestCase {
 class ConfigurationParserTests : XCTestCase {
   func testParsesEmpty() {
     self.assertParses(Configuration.parser(), [], Configuration(
-      simulatorApplication: try! FBSimulatorApplication(error: ()),
       deviceSetPath: nil,
       options: FBSimulatorManagementOptions()
     ))
@@ -144,7 +143,6 @@ class ConfigurationParserTests : XCTestCase {
       Configuration.parser(),
       ["--device-set", "/usr/bin"],
       Configuration(
-        simulatorApplication: try! FBSimulatorApplication(error: ()),
         deviceSetPath: "/usr/bin",
         options: FBSimulatorManagementOptions()
       )
@@ -163,7 +161,6 @@ class ConfigurationParserTests : XCTestCase {
       Configuration.parser(),
       ["--kill-all", "--process-killing"],
       Configuration(
-        simulatorApplication: try! FBSimulatorApplication(error: ()),
         deviceSetPath: nil,
         options: FBSimulatorManagementOptions.KillAllOnFirstStart.union(.UseProcessKilling)
       )
@@ -175,7 +172,6 @@ class ConfigurationParserTests : XCTestCase {
       Configuration.parser(),
       ["--device-set", "/usr/bin", "--delete-all", "--kill-spurious"],
       Configuration(
-        simulatorApplication: try! FBSimulatorApplication(error: ()),
         deviceSetPath: "/usr/bin",
         options: FBSimulatorManagementOptions.DeleteAllOnFirstStart.union(.KillSpuriousSimulatorsOnFirstStart)
       )


### PR DESCRIPTION
Since the `+[NSObject initialize]` method may be called during the parsing of arguments, it is currently essential to have the debug logging flag enabled in order for the information be printed to `stderr`. `setenv` works well for the tests and will also work fine from the CLI. 