### PR TITLE
Continuous console output for runners

### DIFF
--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -14,7 +14,7 @@ extension Parser {
   static func ofUDID() -> Parser<NSUUID> {
     return Parser<NSUUID>.single { token in
       guard let uuid = NSUUID(UUIDString: token) else {
-        throw ParseError.InvalidNumber
+        throw ParseError.CouldNotInterpret(NSStringFromClass(NSUUID.self), token)
       }
       return uuid
     }
@@ -24,10 +24,10 @@ extension Parser {
     return Parser<String>.single { token in
       var isDirectory: ObjCBool = false
       if !NSFileManager.defaultManager().fileExistsAtPath(token, isDirectory: &isDirectory) {
-        throw ParseError.InvalidNumber
+        throw ParseError.Custom("'\(token)' should exist, but doesn't")
       }
       if (!isDirectory) {
-        throw ParseError.InvalidNumber
+        throw ParseError.Custom("'\(token)' should be a directory, but isn't")
       }
       return token
     }
@@ -37,10 +37,10 @@ extension Parser {
     return Parser<String>.single { token in
       var isDirectory: ObjCBool = false
       if !NSFileManager.defaultManager().fileExistsAtPath(token, isDirectory: &isDirectory) {
-        throw ParseError.InvalidNumber
+        throw ParseError.Custom("'\(token)' should exist, but doesn't")
       }
       if (isDirectory) {
-        throw ParseError.InvalidNumber
+        throw ParseError.Custom("'\(token)' should be a file, but isn't")
       }
       return token
     }
@@ -282,7 +282,7 @@ extension Query : Parsable {
       let deviceConfigurations = FBSimulatorConfiguration.deviceConfigurations() as! [FBSimulatorConfiguration_Device]
       let deviceNames = Set(deviceConfigurations.map { $0.deviceName() })
       if (!deviceNames.contains(token)) {
-        throw ParseError.InvalidNumber
+        throw ParseError.Custom("\(token) is not a valid device name")
       }
       let configuration: FBSimulatorConfiguration! = FBSimulatorConfiguration.withDeviceNamed(token)
       return Query.Configured([configuration])

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -12,16 +12,18 @@ import FBSimulatorControl
 
 extension Parser {
   static func ofUDID() -> Parser<NSUUID> {
-    return Parser<NSUUID>.single { token in
+    let expected = NSStringFromClass(NSUUID.self)
+    return Parser<NSUUID>.single("A \(expected)") { token in
       guard let uuid = NSUUID(UUIDString: token) else {
-        throw ParseError.CouldNotInterpret(NSStringFromClass(NSUUID.self), token)
+        throw ParseError.CouldNotInterpret(expected, token)
       }
       return uuid
     }
   }
 
   static func ofDirectory() -> Parser<String> {
-    return Parser<String>.single { token in
+    let expected = "A Directory"
+    return Parser<String>.single(expected) { token in
       var isDirectory: ObjCBool = false
       if !NSFileManager.defaultManager().fileExistsAtPath(token, isDirectory: &isDirectory) {
         throw ParseError.Custom("'\(token)' should exist, but doesn't")
@@ -34,7 +36,8 @@ extension Parser {
   }
 
   static func ofFile() -> Parser<String> {
-    return Parser<String>.single { token in
+    let expected = "A Directory"
+    return Parser<String>.single(expected) { token in
       var isDirectory: ObjCBool = false
       if !NSFileManager.defaultManager().fileExistsAtPath(token, isDirectory: &isDirectory) {
         throw ParseError.Custom("'\(token)' should exist, but doesn't")
@@ -49,17 +52,18 @@ extension Parser {
 
 extension FBSimulatorState : Parsable {
   public static func parser() -> Parser<FBSimulatorState> {
-    return Parser<FBSimulatorState>.single { token in
+    return Parser<FBSimulatorState>.single("A Simulator State") { token in
       let state = FBSimulator.simulatorStateFromStateString(token)
       switch (state) {
       case .Unknown:
-        throw ParseError.DoesNotMatchAnyOf([
+        let possible = [
           FBSimulatorState.Creating.description,
           FBSimulatorState.Shutdown.description,
           FBSimulatorState.Booting.description,
           FBSimulatorState.Booted.description,
           FBSimulatorState.ShuttingDown.description
-        ])
+        ]
+        throw ParseError.DoesNotMatch(possible.description, token)
       default:
         return state
       }
@@ -278,7 +282,7 @@ extension Query : Parsable {
   }
 
   private static func nameParser() -> Parser<Query> {
-    return Parser.single { token in
+    return Parser.single("A Device Name") { token in
       let deviceConfigurations = FBSimulatorConfiguration.deviceConfigurations() as! [FBSimulatorConfiguration_Device]
       let deviceNames = Set(deviceConfigurations.map { $0.deviceName() })
       if (!deviceNames.contains(token)) {

--- a/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
@@ -27,11 +27,6 @@ public enum ParseError : ErrorType, CustomStringConvertible {
   case CouldNotInterpret(String, String)
   case Custom(String)
 
-  static func DoesNotMatchAnyOf(matches: [String]) -> ParseError {
-    let inner = (matches as NSArray).componentsJoinedByString(", ")
-    return .DoesNotMatch("any of", "[\(inner)]")
-  }
-
   public var description: String {
     get {
       switch self {
@@ -51,12 +46,24 @@ public enum ParseError : ErrorType, CustomStringConvertible {
 /**
  Protocol for parsing a list of tokens.
  */
-public struct Parser<A> {
+public struct Parser<A> : CustomStringConvertible {
+  let matchDescription: String
   let output: [String] throws -> ([String], A)
+
+  init(_ matchDescription: String, output: [String] throws -> ([String], A)) {
+    self.matchDescription = matchDescription
+    self.output = output
+  }
 
   func parse(tokens: [String]) throws -> ([String], A) {
     let (nextTokens, value) = try output(tokens)
     return (nextTokens, value)
+  }
+
+  public var description: String {
+    get {
+      return self.matchDescription
+    }
   }
 }
 
@@ -65,14 +72,14 @@ public struct Parser<A> {
 */
 extension Parser {
   func fmap<B>(f: A -> B) -> Parser<B> {
-    return Parser<B>() { input in
+    return Parser<B>(self.matchDescription) { input in
       let (tokensOut, a) = try self.output(input)
       return (tokensOut, f(a))
     }
   }
 
   func bind<B>(f: A -> Parser<B>) -> Parser<B> {
-    return Parser<B> { tokens in
+    return Parser<B>(self.matchDescription) { tokens in
       let (tokensA, valueA) = try self.parse(tokens)
       let (tokensB, valueB) = try f(valueA).parse(tokensA)
       return (tokensB, valueB)
@@ -80,7 +87,7 @@ extension Parser {
   }
 
   func optional() -> Parser<A?> {
-    return Parser<A?> { tokens in
+    return Parser<A?>(self.matchDescription) { tokens in
       do {
         let (nextTokens, value) = try self.parse(tokens)
         return (nextTokens, Optional.Some(value))
@@ -91,7 +98,9 @@ extension Parser {
   }
 
   func sequence<B>(p: Parser<B>) -> Parser<B> {
-    return self.bind { _ in p }
+    return self
+      .bind({ _ in p })
+      .describe("\(self) followed by \(p)")
   }
 }
 
@@ -114,14 +123,18 @@ extension Parser {
     return self.handle { _ in a }
   }
 
+  func describe(description: String) -> Parser<A> {
+    return Parser(description, output: self.output)
+  }
+
   static func fail(error: ParseError) -> Parser<A> {
-    return Parser<A> { _ in
+    return Parser<A>("fail Parser") { _ in
       throw error
     }
   }
 
-  static func single(f: String throws -> A) -> Parser<A> {
-    return Parser<A>() { tokens in
+  static func single(description: String, f: String throws -> A) -> Parser<A> {
+    return Parser<A>(description) { tokens in
       guard let actual = tokens.first else {
         throw ParseError.EndOfInput
       }
@@ -130,7 +143,7 @@ extension Parser {
   }
 
   static func ofString(string: String, _ constant: A) -> Parser<A> {
-    return Parser.single { token in
+    return Parser.single(string) { token in
       if token != string {
         throw ParseError.DoesNotMatch(token, string)
       }
@@ -142,10 +155,11 @@ extension Parser {
     return Parser<Bool>
       .ofString(flag, true)
       .fallback(false)
+      .describe("Flag \(flag)")
   }
 
   static func ofInt() -> Parser<Int> {
-    return Parser<Int>.single { token in
+    return Parser<Int>.single("Of Int") { token in
       guard let integer = NSNumberFormatter().numberFromString(token)?.integerValue else {
         throw ParseError.CouldNotInterpret("Int", token)
       }
@@ -157,55 +171,60 @@ extension Parser {
     return Parser<()>
       .ofString(token, ())
       .sequence(by)
+      .describe("\(token) followed by \(by)")
   }
 
   static func ofTwoSequenced<B>(a: Parser<A>, _ b: Parser<B>) -> Parser<(A, B)> {
-    return a.bind { valueA in
-      return b.fmap { valueB in
-        return (valueA, valueB)
-      }
-    }
+    return
+      a.bind({ valueA in
+        return b.fmap { valueB in
+          return (valueA, valueB)
+        }
+      })
+      .describe("\(a) followed by \(b)")
   }
 
   static func ofThreeSequenced<B, C>(a: Parser<A>, _ b: Parser<B>, _ c: Parser<C>) -> Parser<(A, B, C)> {
-    return a.bind { valueA in
-      return b.bind { valueB in
-        return c.fmap { valueC in
-          return (valueA, valueB, valueC)
+    return
+      a.bind({ valueA in
+        return b.bind { valueB in
+          return c.fmap { valueC in
+            return (valueA, valueB, valueC)
+          }
         }
-      }
-    }
+      })
+      .describe("\(a) followed by \(b) followed by \(c)")
   }
 
   static func alternative(parsers: [Parser<A>]) -> Parser<A> {
-    return Parser<A>() { tokens in
+    return Parser<A>("Any of \(parsers)") { tokens in
       for parser in parsers {
         do {
           return try parser.parse(tokens)
         } catch {}
       }
-      throw ParseError.EndOfInput
+      throw ParseError.DoesNotMatch(parsers.description, tokens.description)
     }
   }
 
   static func manyCount(count: Int, _ parser: Parser<A>) -> Parser<[A]> {
     assert(count >= 0, "Count should be >= 0")
-    return Parser<[A]>() { tokens in
+    return Parser<[A]>("At least \(count) of \(parser)") { tokens in
       var values: [A] = []
       var runningArgs = tokens
-      var applicationCount = 0
+      var parseCount = 0
 
       do {
         while (runningArgs.count > 0) {
           let output = try parser.parse(runningArgs)
-          applicationCount++
+          parseCount++
           runningArgs = output.0
           values.append(output.1)
         }
       } catch { }
 
-      if (applicationCount < count) {
-        throw ParseError.EndOfInput
+      if (parseCount < count) {
+        throw ParseError.Custom("Only \(parseCount) of \(parser)")
       }
       return (runningArgs, values)
     }

--- a/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
@@ -21,15 +21,30 @@ public extension Command {
   }
 }
 
-public enum ParseError : ErrorType {
+public enum ParseError : ErrorType, CustomStringConvertible {
   case EndOfInput
   case DoesNotMatch(String, String)
-  case InvalidNumber
-  case InvalidPath
+  case CouldNotInterpret(String, String)
+  case Custom(String)
 
   static func DoesNotMatchAnyOf(matches: [String]) -> ParseError {
     let inner = (matches as NSArray).componentsJoinedByString(", ")
     return .DoesNotMatch("any of", "[\(inner)]")
+  }
+
+  public var description: String {
+    get {
+      switch self {
+      case .EndOfInput:
+        return "End of Input"
+      case .DoesNotMatch(let expected, let actual):
+        return "'\(actual)' does not match '\(expected)'"
+      case .CouldNotInterpret(let typeName, let actual):
+        return "\(actual) could not be interpreted as \(typeName)"
+      case .Custom(let message):
+        return message
+      }
+    }
   }
 }
 
@@ -132,7 +147,7 @@ extension Parser {
   static func ofInt() -> Parser<Int> {
     return Parser<Int>.single { token in
       guard let integer = NSNumberFormatter().numberFromString(token)?.integerValue else {
-        throw ParseError.InvalidNumber
+        throw ParseError.CouldNotInterpret("Int", token)
       }
       return integer
     }

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -157,10 +157,10 @@ private class InteractionRunner : Runner, RelayTransformer {
       let (_, action) = try Action.parser().parse(arguments)
       let runner = ActionRunner(action: action, control: self.control)
       return runner.run(writer)
+    } catch let error as ParseError {
+      return .Failure("Error: \(error.description)")
     } catch let error as NSError {
       return .Failure(error.description)
-    } catch _ as ParseError {
-      return .Failure("Failed to parse '\(input)'")
     }
   }
 }

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -157,8 +157,10 @@ private class InteractionRunner : Runner, RelayTransformer {
       let (_, action) = try Action.parser().parse(arguments)
       let runner = ActionRunner(action: action, control: self.control)
       return runner.run(writer)
-    } catch {
-      return .Failure("NOPE")
+    } catch let error as NSError {
+      return .Failure(error.description)
+    } catch _ as ParseError {
+      return .Failure("Failed to parse '\(input)'")
     }
   }
 }

--- a/fbsimctl/FBSimulatorControlKit/Sources/Writer.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Writer.swift
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import Foundation
+
+/**
+ A Protocol for writing Strings out.
+ */
+protocol Writer {
+  func write(string: String)
+}
+
+/**
+ Enum for defining the result of a translation.
+ */
+public enum ActionResult {
+  case Success
+  case Failure(String)
+
+  func append(second: ActionResult) -> ActionResult {
+    switch (self, second) {
+    case (.Success, .Success):
+      return .Success
+    case (.Success, .Failure(let secondString)):
+      return .Failure(secondString)
+    case (.Failure(let firstString), .Success):
+      return .Failure(firstString)
+    case (.Failure(let firstString), .Failure(let secondString)):
+      return .Failure("\(firstString)\n\(secondString)")
+    }
+  }
+}
+
+/**
+ A Protocol for writing an ActionResult.
+ */
+protocol ActionResultWriter : Writer {
+  func writeActionResult(actionResult: ActionResult)
+}

--- a/fbsimctl/fbsimctl.xcodeproj/project.pbxproj
+++ b/fbsimctl/fbsimctl.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		AA6085DC1C287E02009B500E /* StdIORelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B7F691C2867EE0038C6A5 /* StdIORelay.swift */; };
 		AAE35AC51C2865C10073CC70 /* FBSimulatorControlKit.h in Headers */ = {isa = PBXBuildFile; fileRef = AAE35AC41C2865C10073CC70 /* FBSimulatorControlKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AAE35ACC1C2865C10073CC70 /* FBSimulatorControlKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAE35AC21C2865C10073CC70 /* FBSimulatorControlKit.framework */; };
+		AAF2D34E1C32EA4D00434516 /* Writer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF2D34D1C32EA4D00434516 /* Writer.swift */; };
+		AAF2D34F1C32EAE100434516 /* Writer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF2D34D1C32EA4D00434516 /* Writer.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -96,6 +98,7 @@
 		AAE35AC61C2865C10073CC70 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AAE35ACB1C2865C10073CC70 /* FBSimulatorControlKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FBSimulatorControlKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AAE35AD21C2865C10073CC70 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AAF2D34D1C32EA4D00434516 /* Writer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Writer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -144,6 +147,7 @@
 				AA1B7F671C2867EE0038C6A5 /* SignalHandler.swift */,
 				AA1B7F681C2867EE0038C6A5 /* SocketRelay.swift */,
 				AA1B7F691C2867EE0038C6A5 /* StdIORelay.swift */,
+				AAF2D34D1C32EA4D00434516 /* Writer.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -349,6 +353,7 @@
 				AA6085D11C287E02009B500E /* Bridging.swift in Sources */,
 				AA6085D21C287E02009B500E /* Command.swift in Sources */,
 				AA6085D31C287E02009B500E /* CommandParsers.swift in Sources */,
+				AAF2D34F1C32EAE100434516 /* Writer.swift in Sources */,
 				AA6085D41C287E02009B500E /* Constants.m in Sources */,
 				AA6085D51C287E02009B500E /* Help.swift in Sources */,
 				AA6085D61C287E02009B500E /* LineBuffer.swift in Sources */,
@@ -373,6 +378,7 @@
 				AA1B7F6F1C2867EE0038C6A5 /* Constants.m in Sources */,
 				AA1B7F771C2867EE0038C6A5 /* SocketRelay.swift in Sources */,
 				AA1B7F6A1C2867EE0038C6A5 /* Arguments.swift in Sources */,
+				AAF2D34E1C32EA4D00434516 /* Writer.swift in Sources */,
 				AA1B7F701C2867EE0038C6A5 /* Help.swift in Sources */,
 				AA1B7F731C2867EE0038C6A5 /* Parser.swift in Sources */,
 				AA1B7F6B1C2867EE0038C6A5 /* Bridging.swift in Sources */,


### PR DESCRIPTION
Since a `Query` can result in multiple Simulators being matched it's important to be able to output success messages incrementally (for example in Booting). It's also important to be able to distinguish between 'logger' messages and 'output' messages; logger messages are informational and fine grained, output messages represent the result of an API call which would closely map to the return value of API calls.