### PR TITLE
Convenience for Fetching Installed App by Bundle ID

### DIFF
--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.m
@@ -48,14 +48,11 @@
 
   return [self interactWithBootedSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
     NSError *innerError = nil;
-    NSDictionary *installedApps = [simulator.device installedAppsWithError:&innerError];
-    if (!installedApps) {
-      return [[[FBSimulatorError describe:@"Failed to get installed apps"] inSimulator:simulator] failBool:error];
-    }
-    if (!installedApps[appLaunch.application.bundleID]) {
+    FBSimulatorApplication *application = [simulator installedApplicationWithBundleID:appLaunch.application.bundleID error:&innerError];
+    if (!application) {
       return [[[[FBSimulatorError
         describeFormat:@"App %@ can't be launched as it isn't installed", appLaunch.application.bundleID]
-        extraInfo:@"installed_apps" value:installedApps]
+        causedBy:innerError]
         inSimulator:simulator]
         failBool:error];
     }

--- a/FBSimulatorControl/Management/FBSimulator+Helpers.h
+++ b/FBSimulatorControl/Management/FBSimulator+Helpers.h
@@ -15,6 +15,11 @@
 @interface FBSimulator (Helpers)
 
 /**
+ Creates an `FBSimulatorInteraction` for the reciever.
+ */
+- (FBSimulatorInteraction *)interact;
+
+/**
  Synchronously waits on the provided state.
 
  @param state the state to wait on
@@ -76,9 +81,13 @@
 - (BOOL)eraseWithError:(NSError **)error;
 
 /**
- Creates an `FBSimulatorInteraction` for the reciever.
+ Fetches the FBSimulatorApplication instance by Bundle ID, on the Simulator.
+
+ @param bundleID the Bundle ID to fetch an installed application for.
+ @param error an error out for any error that occurs.
+ @return a FBSimulatorApplication instance if one could be obtained, NO otherwise.
  */
-- (FBSimulatorInteraction *)interact;
+- (FBSimulatorApplication *)installedApplicationWithBundleID:(NSString *)bundleID error:(NSError **)error;
 
 /**
  Creates a FBSimDeviceWrapper for the Simulator.


### PR DESCRIPTION
Providing a higher-level query for finding installed apps by bundle ID will help for the case where an Application launched and it's not known whether the Application needs to be installed or not.