### PR TITLE
Added wait with timeout when looking for launchInfo of FBSimulatorControled simulator

### DIFF
--- a/FBSimulatorControl/Events/FBSimulatorEventRelay.m
+++ b/FBSimulatorControl/Events/FBSimulatorEventRelay.m
@@ -226,7 +226,7 @@
 
   NSRunningApplication *launchedApplication = notification.userInfo[NSWorkspaceApplicationKey];
   FBProcessInfo *simulatorProcess =[self.processQuery processInfoFor:launchedApplication.processIdentifier];
-  if (!simulatorProcess.environment[FBSimulatorControlSimulatorLaunchEnvironmentSimulatorUDID]) {
+  if (![simulatorProcess.environment[FBSimulatorControlSimulatorLaunchEnvironmentSimulatorUDID] isEqual:self.simDevice.UDID.UUIDString]) {
     return;
   }
   FBSimulatorLaunchInfo *launchInfo = [FBSimulatorLaunchInfo fromSimDevice:self.simDevice simulatorApplication:launchedApplication query:self.processQuery timeout:FBSimulatorControlGlobalConfiguration.regularTimeout];

--- a/FBSimulatorControl/Events/FBSimulatorEventRelay.m
+++ b/FBSimulatorControl/Events/FBSimulatorEventRelay.m
@@ -18,6 +18,7 @@
 #import "FBProcessInfo.h"
 #import "FBProcessQuery+Simulators.h"
 #import "FBProcessQuery.h"
+#import "FBSimulatorControlGlobalConfiguration.h"
 #import "FBSimulatorLaunchInfo.h"
 
 @interface FBSimulatorEventRelay ()
@@ -224,7 +225,11 @@
   }
 
   NSRunningApplication *launchedApplication = notification.userInfo[NSWorkspaceApplicationKey];
-  FBSimulatorLaunchInfo *launchInfo = [FBSimulatorLaunchInfo fromSimDevice:self.simDevice simulatorApplication:launchedApplication query:self.processQuery];
+  FBProcessInfo *simulatorProcess =[self.processQuery processInfoFor:launchedApplication.processIdentifier];
+  if (!simulatorProcess.environment[FBSimulatorControlSimulatorLaunchEnvironmentSimulatorUDID]) {
+    return;
+  }
+  FBSimulatorLaunchInfo *launchInfo = [FBSimulatorLaunchInfo fromSimDevice:self.simDevice simulatorApplication:launchedApplication query:self.processQuery timeout:FBSimulatorControlGlobalConfiguration.regularTimeout];
   if (!launchInfo) {
     return;
   }

--- a/FBSimulatorControl/Model/FBSimulatorLaunchInfo.h
+++ b/FBSimulatorControl/Model/FBSimulatorLaunchInfo.h
@@ -50,6 +50,17 @@
 + (instancetype)fromSimDevice:(SimDevice *)simDevice simulatorApplication:(NSRunningApplication *)simulatorApplication query:(FBProcessQuery *)query;
 
 /**
+ Creates a FBSimulatorLaunchInfo object from the provided SimDevice & NSRunningApplication combination.
+
+ @param simDevice the SimDevice to create the launch info from.
+ @param simulatorApplication the Simulator Application to create the launch info from. If this conflicts with the SimDevice, nil is returned.
+ @param query the Process Query object to obtain Process/Application info from.
+ @param timeout the maximum time to wait for information to appear.
+ @return a FBSimulatorLaunchInfo instance if process information could be obtained, nil otherwise.
+ */
++ (instancetype)fromSimDevice:(SimDevice *)simDevice simulatorApplication:(NSRunningApplication *)simulatorApplication query:(FBProcessQuery *)query timeout:(NSTimeInterval)timeout;
+
+/**
  Process Information for the Simulator.app
  */
 @property (nonatomic, copy, readonly) FBProcessInfo *simulatorProcess;

--- a/FBSimulatorControl/Model/FBSimulatorLaunchInfo.m
+++ b/FBSimulatorControl/Model/FBSimulatorLaunchInfo.m
@@ -63,6 +63,13 @@
   return launchInfo;
 }
 
++ (instancetype)fromSimDevice:(SimDevice *)simDevice simulatorApplication:(NSRunningApplication *)simulatorApplication query:(FBProcessQuery *)query timeout:(NSTimeInterval)timeout
+{
+  return [NSRunLoop.currentRunLoop spinRunLoopWithTimeout:timeout untilExists:^id{
+    return [FBSimulatorLaunchInfo fromSimDevice:simDevice simulatorApplication:simulatorApplication query:query];
+  }];
+}
+
 + (instancetype)fromSimDevice:(SimDevice *)simDevice simulatorApplication:(NSRunningApplication *)simulatorApplication query:(FBProcessQuery *)query
 {
   FBProcessInfo *simulatorProcess = [query simulatorApplicationProcessForSimDevice:simDevice];


### PR DESCRIPTION
It's good to have the state update for simulators that are not launched directly via FBSimulatorControl, but FBSimulatorControl is used as a helper to manage them and for some helpful APIs.