### PR TITLE
Add All Process/Agent/User launch configuration query

### DIFF
--- a/FBSimulatorControl/Model/FBSimulatorHistory+Queries.h
+++ b/FBSimulatorControl/Model/FBSimulatorHistory+Queries.h
@@ -65,9 +65,14 @@
  @return An NSArray<FBProcessLaunchConfiguration> of all historical Process Launches. Ordering is arbitrary.
  */
 - (NSArray *)allProcessLaunches;
+
+/**
+ Returns all Application Launch Configurations.
+ Reaches into previous states in order to find Applications that have terminated.
+
  @return An NSArray<FBApplicationLaunchConfiguration> of all historical Application Launches. Ordering is arbitrary.
  */
-- (NSArray *)allProcessLaunches;
+- (NSArray *)allApplicationLaunches;
 
 /**
  Returns Process Info for the Application that was launched most recently.

--- a/FBSimulatorControl/Model/FBSimulatorHistory+Queries.h
+++ b/FBSimulatorControl/Model/FBSimulatorHistory+Queries.h
@@ -59,6 +59,17 @@
 - (NSArray *)allLaunchedAgentProcesses;
 
 /**
+ Returns all Process Launch Configurations.
+ Reaches into previous states in order to find Processes that have terminated.
+
+ @return An NSArray<FBProcessLaunchConfiguration> of all historical Process Launches. Ordering is arbitrary.
+ */
+- (NSArray *)allProcessLaunches;
+ @return An NSArray<FBApplicationLaunchConfiguration> of all historical Application Launches. Ordering is arbitrary.
+ */
+- (NSArray *)allProcessLaunches;
+
+/**
  Returns Process Info for the Application that was launched most recently.
  Reaches into previous states in order to find Applications that have been terminated.
 
@@ -67,20 +78,20 @@
 - (FBProcessInfo *)lastLaunchedApplicationProcess;
 
 /**
- Returns the Launch Configration for the Application that was launched most recently.
- Reaches into previous states in order to find Applications that have been terminated.
-
- @return A FBApplicationLaunchConfiguration for the most recently launched Application, nil if no Application has been launched.
- */
-- (FBApplicationLaunchConfiguration *)lastLaunchedApplication;
-
-/**
  Returns Process Info for the Agent that was launched most recently.
  Reaches into previous states in order to find Agents that have been terminated.
 
  @return An FBProcessInfo for the most recently launched Agent, nil if no Agent has been launched.
  */
 - (FBProcessInfo *)lastLaunchedAgentProcess;
+
+/**
+ Returns the Launch Configration for the Application that was launched most recently.
+ Reaches into previous states in order to find Applications that have been terminated.
+
+ @return A FBApplicationLaunchConfiguration for the most recently launched Application, nil if no Application has been launched.
+ */
+- (FBApplicationLaunchConfiguration *)lastLaunchedApplication;
 
 /**
  Returns the Launch Configration for the Agent that was launched most recently.

--- a/FBSimulatorControl/Model/FBSimulatorHistory+Queries.h
+++ b/FBSimulatorControl/Model/FBSimulatorHistory+Queries.h
@@ -75,6 +75,14 @@
 - (NSArray *)allApplicationLaunches;
 
 /**
+ Returns all Agent Launch Configurations.
+ Reaches into previous states in order to find Agents that have terminated.
+
+ @return An NSArray<FBAgentLaunchConfiguration> of all historical Application Launches. Ordering is arbitrary.
+ */
+- (NSArray *)allAgentLaunches;
+
+/**
  Returns Process Info for the Application that was launched most recently.
  Reaches into previous states in order to find Applications that have been terminated.
 

--- a/FBSimulatorControl/Model/FBSimulatorHistory+Queries.h
+++ b/FBSimulatorControl/Model/FBSimulatorHistory+Queries.h
@@ -19,22 +19,24 @@
 @interface FBSimulatorHistory (Queries)
 
 /**
- Returns Application State for all running applications, does not reach into previous states.
+ Returns Process Info for currently-running applications.
+ Does not reach into previous states.
 
  @return an NSArray<FBProcessInfo> of the currently running, User Launched Applications.
  */
-- (NSArray *)launchedApplications;
+- (NSArray *)launchedApplicationProcesses;
 
 /**
- Returns Agent State for all running agents, does not reach into previous states.
+ Returns Process Info for currently-running agents.
+ Does not reach into history.
 
  @return an NSArray<FBProcessInfo> of the currently running, User Launched Agents.
  */
-- (NSArray *)launchedAgents;
+- (NSArray *)launchedAgentProcesses;
 
 /**
  Returns all of the Agents and Applications that have been launched, in the order that they were launched.
- Reaches into previous states in order to find Agents and Applications that have been terminated.
+ Reaches into history in order to find Agents and Applications that have terminated.
 
  @return An NSArray<FBProcessInfo> of All Launched Processes, most recent first.
  */
@@ -42,19 +44,19 @@
 
 /**
  Returns all of the Applications that have been launched, in the order that they were launched.
- Reaches into previous states in order to find Applications that have been terminated.
+ Reaches into history in order to find Applications that have terminated.
 
  @return An NSArray<FBProcessInfo> of All Launched Application Processes, most recent first.
  */
-- (NSArray *)allLaunchedApplications;
+- (NSArray *)allLaunchedApplicationProcesses;
 
 /**
  Returns all of the Agents that have been launched, in the order that they were launched.
- Reaches into previous states in order to find Agents that have been terminated.
+ Reaches into previous states in order to find Agents that have terminated.
 
  @return An NSArray<FBProcessInfo> of All Launched Agent Processes, most recent first.
  */
-- (NSArray *)allLaunchedAgents;
+- (NSArray *)allLaunchedAgentProcesses;
 
 /**
  Returns Process Info for the Application that was launched most recently.

--- a/FBSimulatorControl/Model/FBSimulatorHistory+Queries.m
+++ b/FBSimulatorControl/Model/FBSimulatorHistory+Queries.m
@@ -84,6 +84,11 @@
   return self.processLaunchConfigurations.allValues;
 }
 
+- (NSArray *)allApplicationLaunches
+{
+  return [self.allProcessLaunches filteredArrayUsingPredicate:[FBSimulatorHistory predicateForApplicationLaunches]];
+}
+
 - (FBProcessInfo *)lastLaunchedApplicationProcess
 {
   // launchedProcesses has last event based ordering. Message-to-nil will return immediately in base-case.
@@ -194,6 +199,13 @@
 {
   return [NSPredicate predicateWithBlock:^ BOOL (FBProcessInfo *process, NSDictionary *_) {
     return [process.launchPath isEqualToString:binary.path];
+  }];
+}
+
++ (NSPredicate *)predicateForApplicationLaunches
+{
+  return [NSPredicate predicateWithBlock:^ BOOL (FBProcessLaunchConfiguration *processLaunch, NSDictionary *_) {
+    return [processLaunch isKindOfClass:FBApplicationLaunchConfiguration.class];
   }];
 }
 

--- a/FBSimulatorControl/Model/FBSimulatorHistory+Queries.m
+++ b/FBSimulatorControl/Model/FBSimulatorHistory+Queries.m
@@ -79,21 +79,26 @@
   return [self.allUserLaunchedProcesses filteredArrayUsingPredicate:self.predicateForUserLaunchedAgentProcesses];
 }
 
+- (NSArray *)allProcessLaunches
+{
+  return self.processLaunchConfigurations.allValues;
+}
+
 - (FBProcessInfo *)lastLaunchedApplicationProcess
 {
   // launchedProcesses has last event based ordering. Message-to-nil will return immediately in base-case.
   return self.launchedApplicationProcesses.firstObject ?: self.previousState.lastLaunchedApplicationProcess;
 }
 
-- (FBApplicationLaunchConfiguration *)lastLaunchedApplication
-{
-  return self.processLaunchConfigurations[self.lastLaunchedApplicationProcess];
-}
-
 - (FBProcessInfo *)lastLaunchedAgentProcess
 {
   // launchedProcesses has last event based ordering. Message-to-nil will return immediately in base-case.
   return self.launchedAgentProcesses.firstObject ?: self.previousState.lastLaunchedAgentProcess;
+}
+
+- (FBApplicationLaunchConfiguration *)lastLaunchedApplication
+{
+  return self.processLaunchConfigurations[self.lastLaunchedApplicationProcess];
 }
 
 - (FBAgentLaunchConfiguration *)lastLaunchedAgent

--- a/FBSimulatorControl/Model/FBSimulatorHistory+Queries.m
+++ b/FBSimulatorControl/Model/FBSimulatorHistory+Queries.m
@@ -89,6 +89,13 @@
   return [self.allProcessLaunches filteredArrayUsingPredicate:[FBSimulatorHistory predicateForApplicationLaunches]];
 }
 
+- (NSArray *)allAgentLaunches
+{
+  return [self.allProcessLaunches
+    filteredArrayUsingPredicate:[NSCompoundPredicate notPredicateWithSubpredicate:[FBSimulatorHistory predicateForApplicationLaunches]]
+  ];
+}
+
 - (FBProcessInfo *)lastLaunchedApplicationProcess
 {
   // launchedProcesses has last event based ordering. Message-to-nil will return immediately in base-case.

--- a/FBSimulatorControl/Model/FBSimulatorHistory+Queries.m
+++ b/FBSimulatorControl/Model/FBSimulatorHistory+Queries.m
@@ -48,12 +48,12 @@
 
 @implementation FBSimulatorHistory (Queries)
 
-- (NSArray *)launchedApplications
+- (NSArray *)launchedApplicationProcesses
 {
   return [self.launchedProcesses filteredArrayUsingPredicate:self.predicateForUserLaunchedApplicationProcesses];
 }
 
-- (NSArray *)launchedAgents
+- (NSArray *)launchedAgentProcesses
 {
   return [self.launchedProcesses filteredArrayUsingPredicate:self.predicateForUserLaunchedAgentProcesses];
 }
@@ -69,12 +69,12 @@
   return [set array];
 }
 
-- (NSArray *)allLaunchedApplications
+- (NSArray *)allLaunchedApplicationProcesses
 {
   return [self.allUserLaunchedProcesses filteredArrayUsingPredicate:self.predicateForUserLaunchedApplicationProcesses];
 }
 
-- (NSArray *)allLaunchedAgents
+- (NSArray *)allLaunchedAgentProcesses
 {
   return [self.allUserLaunchedProcesses filteredArrayUsingPredicate:self.predicateForUserLaunchedAgentProcesses];
 }
@@ -82,7 +82,7 @@
 - (FBProcessInfo *)lastLaunchedApplicationProcess
 {
   // launchedProcesses has last event based ordering. Message-to-nil will return immediately in base-case.
-  return self.launchedApplications.firstObject ?: self.previousState.lastLaunchedApplicationProcess;
+  return self.launchedApplicationProcesses.firstObject ?: self.previousState.lastLaunchedApplicationProcess;
 }
 
 - (FBApplicationLaunchConfiguration *)lastLaunchedApplication
@@ -93,7 +93,7 @@
 - (FBProcessInfo *)lastLaunchedAgentProcess
 {
   // launchedProcesses has last event based ordering. Message-to-nil will return immediately in base-case.
-  return self.launchedAgents.firstObject ?: self.previousState.lastLaunchedAgentProcess;
+  return self.launchedAgentProcesses.firstObject ?: self.previousState.lastLaunchedAgentProcess;
 }
 
 - (FBAgentLaunchConfiguration *)lastLaunchedAgent
@@ -108,7 +108,7 @@
 
 - (FBProcessInfo *)runningProcessForBinary:(FBSimulatorBinary *)binary
 {
-  return [[self.launchedApplications
+  return [[self.launchedApplicationProcesses
     filteredArrayUsingPredicate:[FBSimulatorHistory predicateForBinary:binary]]
     firstObject];
 }

--- a/FBSimulatorControlTests/Tests/FBSimulatorLaunchTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorLaunchTests.m
@@ -47,8 +47,8 @@
   [self.assert noNotificationsToConsume];
 
   XCTAssertEqual(session.simulator.state, FBSimulatorStateBooted);
-  XCTAssertEqual(session.history.launchedAgents.count, 0u);
-  XCTAssertEqual(session.history.launchedApplications.count, 0u);
+  XCTAssertEqual(session.history.launchedAgentProcesses.count, 0u);
+  XCTAssertEqual(session.history.launchedApplicationProcesses.count, 0u);
   XCTAssertNotNil(session.simulator.launchInfo);
 
   [self assertShutdownSimulatorAndTerminateSession:session];
@@ -103,8 +103,8 @@
   for (FBSimulatorSession *session in sessions) {
     XCTAssertEqual(session.simulator.state, FBSimulatorStateBooted);
     XCTAssertEqual(session.state, FBSimulatorSessionStateStarted);
-    XCTAssertEqual(session.history.launchedAgents.count, 0u);
-    XCTAssertEqual(session.history.launchedApplications.count, 0u);
+    XCTAssertEqual(session.history.launchedAgentProcesses.count, 0u);
+    XCTAssertEqual(session.history.launchedApplicationProcesses.count, 0u);
     XCTAssertNotNil(session.simulator.launchInfo);
   }
 


### PR DESCRIPTION
It can be helpful to access launch configurations for launches that may be more than n-1 (and therefore re-launchable with `relaunchApp`)