### PR TITLE
Move Query & Format to Top Level of an Action

### DIFF
--- a/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
@@ -42,13 +42,22 @@ public indirect enum Query {
 }
 
 /**
- An Action that can be performed provided a FBSimulatorControl instance.
+ An Interaction represents a Single, synchronous interaction with a Simulator.
+ */
+public enum Interaction {
+  case List
+  case Boot
+  case Shutdown
+  case Diagnose
+}
+
+/**
+ An Action represents an Interaction that is performed on a particular Query of Simulators.
 */
-public indirect enum Action {
-  case List(Query, Format)
-  case Boot(Query)
-  case Shutdown(Query)
-  case Diagnose(Query)
+public struct Action {
+  let interaction: Interaction
+  let query: Query
+  let format: Format
 }
 
 /**
@@ -57,7 +66,7 @@ public indirect enum Action {
 public enum Command {
   case Perform(Configuration, [Action])
   case Interact(Configuration, Int?)
-  case Help(Action?)
+  case Help(Interaction?)
 }
 
 public extension Query {
@@ -136,18 +145,7 @@ public func == (left: Command, right: Command) -> Bool {
 
 extension Action : Equatable { }
 public func == (left: Action, right: Action) -> Bool {
-  switch (left, right) {
-  case (.List(let left, let leftFormat), .List(let right, let rightFormat)):
-    return left == right && leftFormat == rightFormat
-  case (.Boot(let left), .Boot(let right)):
-    return left == right
-  case (.Shutdown(let left), .Shutdown(let right)):
-    return left == right
-  case (.Diagnose(let left), .Diagnose(let right)):
-    return left == right
-  default:
-    return false
-  }
+  return left.format == right.format && left.query == right.query && left.interaction == right.interaction
 }
 
 extension Query : Equatable { }

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -228,45 +228,28 @@ extension Configuration : Parsable {
   }
 }
 
-extension Action : Parsable {
-  public static func parser() -> Parser<Action> {
+extension Interaction : Parsable {
+  public static func parser() -> Parser<Interaction> {
     return Parser.alternative([
-      self.listParser(),
-      self.bootParser(),
-      self.shutdownParser(),
-      self.diagnoseParser(),
+      Parser.ofString("list", Interaction.List),
+      Parser.ofString("boot", Interaction.Boot),
+      Parser.ofString("shutdown", Interaction.Shutdown),
+      Parser.ofString("diagnose", Interaction.Diagnose)
     ])
   }
+}
 
-  static func listParser() -> Parser<Action> {
-    let followingParser = Parser
-      .ofTwoSequenced(
+extension Action : Parsable {
+  public static func parser() -> Parser<Action> {
+    return Parser
+      .ofThreeSequenced(
+        Interaction.parser(),
         Query.parser().fallback(Query.defaultValue()),
         Format.parser().fallback(Format.defaultValue())
       )
-      .fmap { (query, format) in
-        Action.List(query, format)
-    }
-
-    return Parser.succeeded("list", followingParser)
-  }
-
-  static func bootParser() -> Parser<Action> {
-    return Parser
-      .succeeded("boot", Query.parser().fallback(Query.defaultValue()))
-      .fmap { Action.Boot($0) }
-  }
-
-  static func shutdownParser() -> Parser<Action> {
-    return Parser
-      .succeeded("shutdown", Query.parser().fallback(Query.defaultValue()))
-      .fmap { Action.Shutdown($0) }
-  }
-
-  static func diagnoseParser() -> Parser<Action> {
-    return Parser
-      .succeeded("diagnose", Query.parser().fallback(Query.defaultValue()))
-      .fmap { Action.Diagnose($0) }
+      .fmap { (interaction, query, format) in
+        return Action(interaction: interaction, query: query, format: format)
+      }
   }
 }
 

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
@@ -205,41 +205,60 @@ class ConfigurationParserTests : XCTestCase {
   }
 }
 
+class InteractionParserTests : XCTestCase {
+  func testParsesAllCases() {
+    self.assertParsesAll(Interaction.parser(), [
+      (["list"], Interaction.List),
+      (["boot"], Interaction.Boot),
+      (["shutdown"], Interaction.Shutdown),
+      (["diagnose"], Interaction.Diagnose)
+    ])
+  }
+
+  func testDoesNotParseInvalidTokens() {
+    self.assertFailsToParseAll(Interaction.parser(), [
+      ["listaa"],
+      ["aboota"],
+      ["ddshutdown"]
+    ])
+  }
+}
+
 class ActionParserTests : XCTestCase {
   func testParsesList() {
     self.assertParsesAll(Action.parser(), [
-      (["list"], Action.List(Query.defaultValue(), Format.defaultValue())),
-      (["list", "booted"], Action.List(Query.State([.Booted]), Format.defaultValue())),
-      (["list", "--name"], Action.List(Query.defaultValue(), Format.Name)),
-      (["list", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139", "--os"], Action.List(Query.UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]), Format.OSVersion)),
-      (["list", "booted", "iPhone 5", "--device-name", "--os"], Action.List(Query.And([.State([.Booted]), .Configured([FBSimulatorConfiguration.iPhone5()])]), Format.Compound([.DeviceName, .OSVersion])))
+      (["list"], Action(interaction: .List, query: Query.defaultValue(), format: Format.defaultValue())),
+      (["list", "booted"], Action(interaction: .List, query: Query.State([.Booted]), format: Format.defaultValue())),
+      (["list", "--name"], Action(interaction: .List, query: Query.defaultValue(), format: Format.Name)),
+      (["list", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139", "--os"], Action(interaction: .List, query: Query.UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]), format: Format.OSVersion)),
+      (["list", "booted", "iPhone 5", "--device-name", "--os"], Action(interaction: .List, query: Query.And([.State([.Booted]), .Configured([FBSimulatorConfiguration.iPhone5()])]), format: Format.Compound([.DeviceName, .OSVersion])))
     ])
   }
 
   func testParsesBoot() {
     self.assertParsesAll(Action.parser(), [
-      (["boot"], Action.Boot(Query.defaultValue())),
-      (["boot", "iPad 2"], Action.Boot(.Configured([FBSimulatorConfiguration.iPad2()]))),
-      (["boot", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Action.Boot(.UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]))),
-      (["boot", "iPhone 5", "shutdown", "iPhone 6"], Action.Boot(.And([.Configured([FBSimulatorConfiguration.iPhone5(), FBSimulatorConfiguration.iPhone6()]), .State([.Shutdown])]))),
+      (["boot"], Action(interaction: .Boot, query: Query.defaultValue(), format: Format.defaultValue())),
+      (["boot", "iPad 2"], Action(interaction: .Boot, query: .Configured([FBSimulatorConfiguration.iPad2()]), format: Format.defaultValue())),
+      (["boot", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Action(interaction: .Boot, query: .UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]), format: Format.defaultValue())),
+      (["boot", "iPhone 5", "shutdown", "iPhone 6"], Action(interaction: .Boot, query: .And([.Configured([FBSimulatorConfiguration.iPhone5(), FBSimulatorConfiguration.iPhone6()]), .State([.Shutdown])]), format: Format.defaultValue()))
     ])
   }
 
   func testParsesShutdown() {
     self.assertParsesAll(Action.parser(), [
-      (["shutdown"], Action.Shutdown(Query.defaultValue())),
-      (["shutdown", "iPad 2"], Action.Shutdown(.Configured([FBSimulatorConfiguration.iPad2()]))),
-      (["shutdown", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Action.Shutdown(.UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]))),
-      (["shutdown", "iPhone 5", "shutdown", "iPhone 6"], Action.Shutdown(.And([.Configured([FBSimulatorConfiguration.iPhone5(), FBSimulatorConfiguration.iPhone6()]), .State([.Shutdown])]))),
+      (["shutdown"], Action(interaction: .Shutdown, query: Query.defaultValue(), format: Format.defaultValue())),
+      (["shutdown", "iPad 2"], Action(interaction: .Shutdown, query: .Configured([FBSimulatorConfiguration.iPad2()]), format: Format.defaultValue())),
+      (["shutdown", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Action(interaction: .Shutdown, query: .UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]), format: Format.defaultValue())),
+      (["shutdown", "iPhone 5", "shutdown", "iPhone 6"], Action(interaction: .Shutdown, query: .And([.Configured([FBSimulatorConfiguration.iPhone5(), FBSimulatorConfiguration.iPhone6()]), .State([.Shutdown])]), format: Format.defaultValue())),
     ])
   }
 
   func testParsesDiagnose() {
     self.assertParsesAll(Action.parser(), [
-      (["diagnose"], Action.Diagnose(Query.defaultValue())),
-      (["diagnose", "iPad 2"], Action.Diagnose(.Configured([FBSimulatorConfiguration.iPad2()]))),
-      (["diagnose", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Action.Diagnose(.UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]))),
-      (["diagnose", "iPhone 5", "shutdown", "iPhone 6"], Action.Diagnose(.And([.Configured([FBSimulatorConfiguration.iPhone5(), FBSimulatorConfiguration.iPhone6()]), .State([.Shutdown])]))),
+      (["diagnose"], Action(interaction: .Diagnose, query: Query.defaultValue(), format: Format.defaultValue())),
+      (["diagnose", "iPad 2"], Action(interaction: .Diagnose, query: .Configured([FBSimulatorConfiguration.iPad2()]), format: Format.defaultValue())),
+      (["diagnose", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Action(interaction: .Diagnose, query: .UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]), format: Format.defaultValue())),
+      (["diagnose", "iPhone 5", "shutdown", "iPhone 6"], Action(interaction: .Diagnose, query: .And([.Configured([FBSimulatorConfiguration.iPhone5(), FBSimulatorConfiguration.iPhone6()]), .State([.Shutdown])]), format: Format.defaultValue())),
     ])
   }
 }
@@ -247,13 +266,16 @@ class ActionParserTests : XCTestCase {
 class CommandParserTests : XCTestCase {
   func testParsesSingleAction() {
     self.assertParsesAll(Command.parser(), [
-      (["boot", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Command.Perform(Configuration.defaultValue(), [Action.Boot(.UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]))])),
+      (["boot", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Command.Perform(Configuration.defaultValue(), [Action(interaction: .Boot, query: .UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]), format: Format.defaultValue())])),
     ])
   }
 
   func testParsesMultipleActions() {
     self.assertParsesAll(Command.parser(), [
-      (["list", "booted", "boot", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Command.Perform(Configuration.defaultValue(), [Action.List(Query.State([.Booted]), Format.defaultValue()), Action.Boot(.UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]))])),
+      (["list", "booted", "boot", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Command.Perform(Configuration.defaultValue(), [
+        Action(interaction: .List, query: Query.State([.Booted]), format: Format.defaultValue()),
+        Action(interaction: .Boot, query: .UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]), format: Format.defaultValue())
+      ])),
     ])
   }
 


### PR DESCRIPTION
`Action` has moved to a struct with members `Query`, `Format` & `Interaction`. This fulfills a few needs:
- There is far less duplication of performing queries on an `Action` since all actions have a query.
- The output format of all actions uses the `Format`
- Future `Interaction` cases that don't rely on any associated types are simpler to implement
- `Interaction` cases map closer to `FBSimulatorInteraction`.
- `Help` should be easier to define.