### PR TITLE
Non-Arbitrary Ordering for Process Launch Configs in History

### DIFF
--- a/FBSimulatorControl/Model/FBSimulatorHistory+Queries.h
+++ b/FBSimulatorControl/Model/FBSimulatorHistory+Queries.h
@@ -62,7 +62,7 @@
  Returns all Process Launch Configurations.
  Reaches into previous states in order to find Processes that have terminated.
 
- @return An NSArray<FBProcessLaunchConfiguration> of all historical Process Launches. Ordering is arbitrary.
+ @return An NSArray<FBProcessLaunchConfiguration> of all historical Process Launches, most recent first.
  */
 - (NSArray *)allProcessLaunches;
 
@@ -70,7 +70,7 @@
  Returns all Application Launch Configurations.
  Reaches into previous states in order to find Applications that have terminated.
 
- @return An NSArray<FBApplicationLaunchConfiguration> of all historical Application Launches. Ordering is arbitrary.
+ @return An NSArray<FBApplicationLaunchConfiguration> of all historical Application Launches, most recent first.
  */
 - (NSArray *)allApplicationLaunches;
 
@@ -78,7 +78,7 @@
  Returns all Agent Launch Configurations.
  Reaches into previous states in order to find Agents that have terminated.
 
- @return An NSArray<FBAgentLaunchConfiguration> of all historical Application Launches. Ordering is arbitrary.
+ @return An NSArray<FBAgentLaunchConfiguration> of all historical Application Launches, most recent first.
  */
 - (NSArray *)allAgentLaunches;
 

--- a/FBSimulatorControl/Model/FBSimulatorHistory+Queries.m
+++ b/FBSimulatorControl/Model/FBSimulatorHistory+Queries.m
@@ -81,7 +81,7 @@
 
 - (NSArray *)allProcessLaunches
 {
-  return self.processLaunchConfigurations.allValues;
+  return [self.processLaunchConfigurations objectsForKeys:self.launchedProcesses notFoundMarker:NSNull.null];
 }
 
 - (NSArray *)allApplicationLaunches

--- a/FBSimulatorControlTests/Fixtures/FBSimulatorControlFixtures.h
+++ b/FBSimulatorControlTests/Fixtures/FBSimulatorControlFixtures.h
@@ -89,4 +89,9 @@
  */
 - (FBProcessInfo *)processInfo2;
 
+/**
+ Another Process Info, like 'processInfo2a' but with a different pid. Does not represent a real process.
+ */
+- (FBProcessInfo *)processInfo2a;
+
 @end

--- a/FBSimulatorControlTests/Fixtures/FBSimulatorControlFixtures.m
+++ b/FBSimulatorControlTests/Fixtures/FBSimulatorControlFixtures.m
@@ -117,4 +117,13 @@
     environment:self.appLaunch2.environment];
 }
 
+- (FBProcessInfo *)processInfo2a
+{
+  return [[FBProcessInfo alloc]
+    initWithProcessIdentifier:30
+    launchPath:self.appLaunch2.application.binary.path
+    arguments:self.appLaunch2.arguments
+    environment:self.appLaunch2.environment];
+}
+
 @end

--- a/FBSimulatorControlTests/Tests/FBSimulatorHistoryGeneratorTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorHistoryGeneratorTests.m
@@ -56,6 +56,15 @@
   XCTAssertEqualObjects(self.appLaunch2, lastLaunchedApp);
 }
 
+- (void)testRecencyOfApplicationLaunchConfigurations
+{
+  [self.generator applicationDidLaunch:self.appLaunch1 didStart:self.processInfo1 stdOut:nil stdErr:nil];
+  [self.generator applicationDidLaunch:self.appLaunch2 didStart:self.processInfo2 stdOut:nil stdErr:nil];
+  [self.generator applicationDidLaunch:self.appLaunch2 didStart:self.processInfo2a stdOut:nil stdErr:nil];
+
+  XCTAssertEqualObjects(self.generator.history.allApplicationLaunches, (@[self.appLaunch2, self.appLaunch2, self.appLaunch1]));
+}
+
 - (void)testAppendsDiagnosticInformationToState
 {
   [self.generator applicationDidLaunch:self.appLaunch1 didStart:self.processInfo1 stdOut:nil stdErr:nil];


### PR DESCRIPTION
The `allProcessLaunches` value previously relied on the ordering of the `allValues` array in a dictionary, which has arbitrary ordering. Instead the array of `allProcessLaunches` can be constructed from the ordered `processLaunchConfigurations` collection.