### PR TITLE
Install Action

### DIFF
--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.m
@@ -56,7 +56,7 @@
 
     // Construct and start the task.
     id<FBTask> task = [[[[[FBTaskExecutor.sharedInstance
-      withLaunchPath:FBSimulatorApplication.simulatorApplication.binary.path]
+      withLaunchPath:FBSimulatorApplication.xcodeSimulator.binary.path]
       withArguments:[arguments copy]]
       withEnvironmentAdditions:@{ FBSimulatorControlSimulatorLaunchEnvironmentSimulatorUDID : simulator.udid }]
       build]

--- a/FBSimulatorControl/Model/FBSimulatorApplication.h
+++ b/FBSimulatorControl/Model/FBSimulatorApplication.h
@@ -117,7 +117,7 @@
 
  @return A FBSimulatorApplication instance for the Simulator.app.
  */
-+ (instancetype)simulatorApplication;
++ (instancetype)xcodeSimulator;
 
 /**
  Returns the System Application with the provided name.

--- a/FBSimulatorControl/Model/FBSimulatorApplication.m
+++ b/FBSimulatorControl/Model/FBSimulatorApplication.m
@@ -214,7 +214,7 @@
   return [self applicationWithPath:[self pathForSystemApplicationNamed:appName] error:error];
 }
 
-+ (instancetype)simulatorApplication;
++ (instancetype)xcodeSimulator;
 {
   NSError *error = nil;
   FBSimulatorApplication *application = [self applicationWithPath:self.pathForSimulatorApplication error:&error];

--- a/FBSimulatorControl/Processes/FBProcessQuery+Simulators.m
+++ b/FBSimulatorControl/Processes/FBProcessQuery+Simulators.m
@@ -58,7 +58,7 @@
 + (NSPredicate *)simulatorProcessesWithCorrectLaunchPath
 {
   return [NSPredicate predicateWithBlock:^ BOOL (FBProcessInfo *process, NSDictionary *_) {
-    return [process.launchPath isEqualToString:FBSimulatorApplication.simulatorApplication.binary.path];
+    return [process.launchPath isEqualToString:FBSimulatorApplication.xcodeSimulator.binary.path];
   }];
 }
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
@@ -49,6 +49,7 @@ public enum Interaction {
   case Boot
   case Shutdown
   case Diagnose
+  case Install(FBSimulatorApplication)
 }
 
 /**
@@ -135,7 +136,7 @@ public func == (left: Command, right: Command) -> Bool {
   case (.Perform(let leftConfiguration, let lefts), .Perform(let rightConfiguration, let rights)):
     return leftConfiguration == rightConfiguration && lefts == rights
   case (.Interact(let leftConfiguration, let leftPort), .Interact(let rightConfiguration, let rightPort)):
-    return leftConfiguration == rightConfiguration &&  leftPort == rightPort
+    return leftConfiguration == rightConfiguration && leftPort == rightPort
   case (.Help(let left), .Help(let right)):
     return left == right
   default:
@@ -146,6 +147,24 @@ public func == (left: Command, right: Command) -> Bool {
 extension Action : Equatable { }
 public func == (left: Action, right: Action) -> Bool {
   return left.format == right.format && left.query == right.query && left.interaction == right.interaction
+}
+
+extension Interaction : Equatable { }
+public func == (left: Interaction, right: Interaction) -> Bool {
+  switch (left, right) {
+  case (.List, .List):
+    return true
+  case (.Boot, .Boot):
+    return true
+  case (.Shutdown, .Shutdown):
+    return true
+  case (.Diagnose, .Diagnose):
+    return true
+  case (.Install(let leftApp), .Install(let rightApp)):
+    return leftApp == rightApp
+  default:
+    return false
+  }
 }
 
 extension Query : Equatable { }

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -243,7 +243,7 @@ extension Interaction : Parsable {
     return Parser
       .succeeded("install", Parser<String>.ofDirectory())
       .fmap { appPath in
-        let application = try! FBSimulatorApplication(path: appPath)
+        let application = try FBSimulatorApplication(path: appPath)
         return Interaction.Install(application)
       }
   }

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -234,8 +234,18 @@ extension Interaction : Parsable {
       Parser.ofString("list", Interaction.List),
       Parser.ofString("boot", Interaction.Boot),
       Parser.ofString("shutdown", Interaction.Shutdown),
-      Parser.ofString("diagnose", Interaction.Diagnose)
+      Parser.ofString("diagnose", Interaction.Diagnose),
+      self.installParser()
     ])
+  }
+
+  private static func installParser() -> Parser<Interaction> {
+    return Parser
+      .succeeded("install", Parser<String>.ofDirectory())
+      .fmap { appPath in
+        let application = try! FBSimulatorApplication(path: appPath)
+        return Interaction.Install(application)
+      }
   }
 }
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
@@ -71,10 +71,11 @@ public struct Parser<A> : CustomStringConvertible {
   Primitives
 */
 extension Parser {
-  func fmap<B>(f: A -> B) -> Parser<B> {
+  func fmap<B>(f: A throws -> B) -> Parser<B> {
     return Parser<B>(self.matchDescription) { input in
       let (tokensOut, a) = try self.output(input)
-      return (tokensOut, f(a))
+      let b = try f(a)
+      return (tokensOut, b)
     }
   }
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
@@ -15,7 +15,11 @@ public extension Command {
     do {
       let (_, command) = try Command.parser().parse(arguments)
       return command
-    } catch {
+    } catch let error as ParseError {
+      print("Failed to Parse Command \(error)")
+      return Command.Help(nil)
+    } catch let error as NSError {
+      print("Failed to Parse Command \(error)")
       return Command.Help(nil)
     }
   }

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -97,6 +97,10 @@ private struct SimulatorRunner : Runner {
         if let sysLog = simulator.logs.systemLog() {
           writer.write("\(sysLog.shortName) \(sysLog.asPath)")
         }
+      case .Install(let application):
+        writer.write("Installing \(application.path) on \(self.formattedSimulator())")
+        try simulator.interact().installApplication(application).performInteraction()
+        writer.write("Installed \(application.path) on \(self.formattedSimulator())")
       }
     } catch let error as NSError {
       return .Failure(error.description)

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -84,23 +84,23 @@ private struct SimulatorRunner : Runner {
     do {
       switch self.interaction {
       case .List:
-        writer.write(self.formattedSimulator())
+        writer.write(self.formattedSimulator)
       case .Boot:
-        writer.write("Booting \(self.formattedSimulator())")
+        writer.write("Booting \(self.formattedSimulator)")
         try simulator.interact().bootSimulator().performInteraction()
-        writer.write("Booted \(self.formattedSimulator())")
+        writer.write("Booted \(self.formattedSimulator)")
       case .Shutdown:
-        writer.write("Shutting Down \(self.formattedSimulator())")
+        writer.write("Shutting Down \(self.formattedSimulator)")
         try simulator.interact().shutdownSimulator().performInteraction()
-        writer.write("Shutdown \(self.formattedSimulator())")
+        writer.write("Shutdown \(self.formattedSimulator)")
       case .Diagnose:
         if let sysLog = simulator.logs.systemLog() {
           writer.write("\(sysLog.shortName) \(sysLog.asPath)")
         }
       case .Install(let application):
-        writer.write("Installing \(application.path) on \(self.formattedSimulator())")
+        writer.write("Installing \(application.path) on \(self.formattedSimulator)")
         try simulator.interact().installApplication(application).performInteraction()
-        writer.write("Installed \(application.path) on \(self.formattedSimulator())")
+        writer.write("Installed \(application.path) on \(self.formattedSimulator)")
       }
     } catch let error as NSError {
       return .Failure(error.description)
@@ -108,8 +108,10 @@ private struct SimulatorRunner : Runner {
     return .Success
   }
 
-  private func formattedSimulator() -> String {
-    return Format.format(self.format, simulator: self.simulator)
+  private var formattedSimulator: String {
+    get {
+      return Format.format(self.format, simulator: self.simulator)
+    }
   }
 }
 

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
@@ -211,7 +211,8 @@ class InteractionParserTests : XCTestCase {
       (["list"], Interaction.List),
       (["boot"], Interaction.Boot),
       (["shutdown"], Interaction.Shutdown),
-      (["diagnose"], Interaction.Diagnose)
+      (["diagnose"], Interaction.Diagnose),
+      (["install", FBSimulatorApplication.xcodeSimulator().path], Interaction.Install(FBSimulatorApplication.xcodeSimulator()))
     ])
   }
 

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTest.swift
@@ -220,7 +220,9 @@ class InteractionParserTests : XCTestCase {
     self.assertFailsToParseAll(Interaction.parser(), [
       ["listaa"],
       ["aboota"],
-      ["ddshutdown"]
+      ["ddshutdown"],
+      ["install"],
+      ["install", "/dev/null"],
     ])
   }
 }


### PR DESCRIPTION
Adds `install` to the cli actions. Utilizes the validation in `FBSimulatorApplication` constructors to parse the App path. Had to change the poorly-named `+[FBSimulatorApplication simulatorApplication]` as it (understandably) confuses the Objective-C to Swift module export.