### PR TITLE
Create FBSimulatorLaunchConfiguration

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -164,6 +164,10 @@
 		AACA2C381C2976B100979C45 /* FBAddVideoPolyfill.m in Sources */ = {isa = PBXBuildFile; fileRef = AACA2C361C2976B100979C45 /* FBAddVideoPolyfill.m */; };
 		AAD3051F1BD4D5B10047376E /* photo0.png in Resources */ = {isa = PBXBuildFile; fileRef = AAD3051D1BD4D5B10047376E /* photo0.png */; };
 		AAD305201BD4D5B10047376E /* photo1.png in Resources */ = {isa = PBXBuildFile; fileRef = AAD3051E1BD4D5B10047376E /* photo1.png */; };
+		AAD51E9F1C3ADECA00A763D0 /* FBSimulatorLaunchConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = AAD51E9D1C3ADECA00A763D0 /* FBSimulatorLaunchConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AAD51EA01C3ADECA00A763D0 /* FBSimulatorLaunchConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD51E9E1C3ADECA00A763D0 /* FBSimulatorLaunchConfiguration.m */; };
+		AAD51EA31C3AEFEA00A763D0 /* FBSimulatorLaunchConfiguration+Helpers.h in Headers */ = {isa = PBXBuildFile; fileRef = AAD51EA11C3AEFEA00A763D0 /* FBSimulatorLaunchConfiguration+Helpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AAD51EA41C3AEFEA00A763D0 /* FBSimulatorLaunchConfiguration+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD51EA21C3AEFEA00A763D0 /* FBSimulatorLaunchConfiguration+Helpers.m */; };
 		AAF2D3561C33EA3100434516 /* FBSimulatorInteraction+Lifecycle.h in Headers */ = {isa = PBXBuildFile; fileRef = AAF2D3541C33EA3100434516 /* FBSimulatorInteraction+Lifecycle.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AAF2D3571C33EA3100434516 /* FBSimulatorInteraction+Lifecycle.m in Sources */ = {isa = PBXBuildFile; fileRef = AAF2D3551C33EA3100434516 /* FBSimulatorInteraction+Lifecycle.m */; };
 		AAF8DA651C1AFF81003B519E /* FBProcessInfo+Helpers.h in Headers */ = {isa = PBXBuildFile; fileRef = AAF8DA631C1AFF81003B519E /* FBProcessInfo+Helpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -944,6 +948,10 @@
 		AACA2C361C2976B100979C45 /* FBAddVideoPolyfill.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBAddVideoPolyfill.m; sourceTree = "<group>"; };
 		AAD3051D1BD4D5B10047376E /* photo0.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = photo0.png; sourceTree = "<group>"; };
 		AAD3051E1BD4D5B10047376E /* photo1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = photo1.png; sourceTree = "<group>"; };
+		AAD51E9D1C3ADECA00A763D0 /* FBSimulatorLaunchConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorLaunchConfiguration.h; sourceTree = "<group>"; };
+		AAD51E9E1C3ADECA00A763D0 /* FBSimulatorLaunchConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorLaunchConfiguration.m; sourceTree = "<group>"; };
+		AAD51EA11C3AEFEA00A763D0 /* FBSimulatorLaunchConfiguration+Helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FBSimulatorLaunchConfiguration+Helpers.h"; sourceTree = "<group>"; };
+		AAD51EA21C3AEFEA00A763D0 /* FBSimulatorLaunchConfiguration+Helpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "FBSimulatorLaunchConfiguration+Helpers.m"; sourceTree = "<group>"; };
 		AAF2D3541C33EA3100434516 /* FBSimulatorInteraction+Lifecycle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FBSimulatorInteraction+Lifecycle.h"; sourceTree = "<group>"; };
 		AAF2D3551C33EA3100434516 /* FBSimulatorInteraction+Lifecycle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "FBSimulatorInteraction+Lifecycle.m"; sourceTree = "<group>"; };
 		AAF8DA631C1AFF81003B519E /* FBProcessInfo+Helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FBProcessInfo+Helpers.h"; sourceTree = "<group>"; };
@@ -1700,6 +1708,10 @@
 				AA9516CF1C15F54600A89CAD /* FBSimulatorControlConfiguration.m */,
 				AA9516D01C15F54600A89CAD /* FBSimulatorControlGlobalConfiguration.h */,
 				AA9516D11C15F54600A89CAD /* FBSimulatorControlGlobalConfiguration.m */,
+				AAD51E9D1C3ADECA00A763D0 /* FBSimulatorLaunchConfiguration.h */,
+				AAD51E9E1C3ADECA00A763D0 /* FBSimulatorLaunchConfiguration.m */,
+				AAD51EA11C3AEFEA00A763D0 /* FBSimulatorLaunchConfiguration+Helpers.h */,
+				AAD51EA21C3AEFEA00A763D0 /* FBSimulatorLaunchConfiguration+Helpers.m */,
 			);
 			path = Configuration;
 			sourceTree = "<group>";
@@ -1982,6 +1994,7 @@
 				AA9517571C15F54600A89CAD /* FBSimulatorResourceManager.h in Headers */,
 				AA95174A1C15F54600A89CAD /* FBProcessLaunchConfiguration.h in Headers */,
 				AA9517A91C15F54600A89CAD /* FBTaskExecutor+Private.h in Headers */,
+				AAD51E9F1C3ADECA00A763D0 /* FBSimulatorLaunchConfiguration.h in Headers */,
 				AA9517601C15F54600A89CAD /* FBSimulatorNotificationEventSink.h in Headers */,
 				AA9517791C15F54600A89CAD /* FBWritableLog+Private.h in Headers */,
 				AA9517491C15F54600A89CAD /* FBProcessLaunchConfiguration+Private.h in Headers */,
@@ -2008,6 +2021,7 @@
 				AA9517551C15F54600A89CAD /* FBSimulatorControlGlobalConfiguration.h in Headers */,
 				AA9517B61C15F54600A89CAD /* FBSimDeviceWrapper.h in Headers */,
 				AA9517C21C15F60B00A89CAD /* FBCompositeSimulatorEventSink.h in Headers */,
+				AAD51EA31C3AEFEA00A763D0 /* FBSimulatorLaunchConfiguration+Helpers.h in Headers */,
 				AA9517A71C15F54600A89CAD /* FBTaskExecutor+Convenience.h in Headers */,
 				AA95175B1C15F54600A89CAD /* FBSimulatorEventSink.h in Headers */,
 				AA95179B1C15F54600A89CAD /* FBProcessQuery+Simulators.h in Headers */,
@@ -2146,12 +2160,14 @@
 				AA9517AF1C15F54600A89CAD /* FBSimulatorWindowHelpers.m in Sources */,
 				AA95179C1C15F54600A89CAD /* FBProcessQuery+Simulators.m in Sources */,
 				AA9517C31C15F60B00A89CAD /* FBCompositeSimulatorEventSink.m in Sources */,
+				AAD51EA41C3AEFEA00A763D0 /* FBSimulatorLaunchConfiguration+Helpers.m in Sources */,
 				AA9517831C15F54600A89CAD /* FBSimulatorControl+PrincipalClass.m in Sources */,
 				AA95179A1C15F54600A89CAD /* FBDispatchSourceNotifier.m in Sources */,
 				AA9517681C15F54600A89CAD /* FBSimulatorInteraction+Applications.m in Sources */,
 				AA9517781C15F54600A89CAD /* FBSimulatorLogs.m in Sources */,
 				AA95177D1C15F54600A89CAD /* FBSimulator+Helpers.m in Sources */,
 				AA9517B91C15F54600A89CAD /* FBSimulatorError.m in Sources */,
+				AAD51EA01C3ADECA00A763D0 /* FBSimulatorLaunchConfiguration.m in Sources */,
 				AA9517BB1C15F54600A89CAD /* FBSimulatorLogger.m in Sources */,
 				AAF8DA6A1C1AFFB1003B519E /* FBProcessInfo.m in Sources */,
 				AA9517861C15F54600A89CAD /* FBSimulatorPool.m in Sources */,

--- a/FBSimulatorControl/Configuration/FBSimulatorConfiguration+CoreSimulator.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorConfiguration+CoreSimulator.h
@@ -94,14 +94,4 @@
  */
 - (SimDeviceType *)obtainDeviceTypeWithError:(NSError **)error;
 
-#pragma mark Scale
-
-/**
- The Command Line Arguments to pass to the Simulator Application, based on the reciever's Device Type.
-
- @param error an error out for any error that occurs obtaining the SimDeviceType.
- @return an Array of Command Line Arguments if one could be constructed, nil otherwise.
- */
-- (NSArray *)lastScaleCommandLineArgumentsWithError:(NSError **)error;
-
 @end

--- a/FBSimulatorControl/Configuration/FBSimulatorConfiguration+CoreSimulator.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorConfiguration+CoreSimulator.m
@@ -103,21 +103,6 @@
   return [matchingDeviceTypes firstObject];
 }
 
-#pragma mark Scale
-
-- (NSArray *)lastScaleCommandLineArgumentsWithError:(NSError **)error;
-{
-  SimDeviceType *deviceType = [self obtainDeviceTypeWithError:error];
-  if (!deviceType) {
-    return nil;
-  }
-  NSString *lastScaleKey = [NSString stringWithFormat: @"SimulatorWindowLastScale-%@", deviceType.identifier];
-  return @[
-    [NSString stringWithFormat:@"-%@", lastScaleKey],
-    self.scale.scaleString
-  ];
-}
-
 #pragma mark Private
 
 + (NSArray *)supportedRuntimes

--- a/FBSimulatorControl/Configuration/FBSimulatorConfiguration+Private.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorConfiguration+Private.h
@@ -160,32 +160,10 @@
 @interface FBSimulatorConfiguration_watchOS_2_1 : FBSimulatorConfiguration_watchOS_Base
 @end
 
-#pragma mark Scales
-
-@protocol FBSimulatorConfigurationScale <NSObject>
-
-- (NSString *)scaleString;
-
-@end
-
-@interface FBSimulatorConfigurationScale_25 : FBSimulatorConfigurationVariant_Base <FBSimulatorConfigurationScale>
-@end
-
-@interface FBSimulatorConfigurationScale_50 : FBSimulatorConfigurationVariant_Base <FBSimulatorConfigurationScale>
-@end
-
-@interface FBSimulatorConfigurationScale_75 : FBSimulatorConfigurationVariant_Base <FBSimulatorConfigurationScale>
-@end
-
-@interface FBSimulatorConfigurationScale_100 : FBSimulatorConfigurationVariant_Base <FBSimulatorConfigurationScale>
-@end
-
 @interface FBSimulatorConfiguration ()
 
 @property (nonatomic, strong, readwrite) id<FBSimulatorConfiguration_Device> device;
 @property (nonatomic, strong, readwrite) id<FBSimulatorConfiguration_OS> os;
-@property (nonatomic, strong, readwrite) id<FBSimulatorConfigurationScale> scale;
-@property (nonatomic, strong, readwrite) NSLocale *locale;
 
 - (instancetype)updateNamedDevice:(id<FBSimulatorConfiguration_Device>)device;
 - (instancetype)updateOSVersion:(id<FBSimulatorConfiguration_OS>)OS;

--- a/FBSimulatorControl/Configuration/FBSimulatorConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorConfiguration.h
@@ -35,32 +35,10 @@
 @property (nonatomic, copy, readonly) NSString *osVersionString;
 
 /**
- The Locale in which to Simulate, may be nil.
- */
-@property (nonatomic, strong, readonly) NSLocale *locale;
-
-/**
- A String representing the Scale at which to launch the Simulator.
- */
-@property (nonatomic, copy, readonly) NSString *scaleString;
-
-/**
  Returns the Default Configuration.
  The OS Version is derived from the SDK Version.
  */
 + (instancetype)defaultConfiguration;
-
-#pragma mark Description
-
-/**
- A Full Description of the reciever.
- */
-- (NSString *)debugDescription;
-
-/**
- A Partial Description of the reciever.
- */
-- (NSString *)shortDescription;
 
 #pragma mark Devices
 
@@ -225,39 +203,5 @@
  tvOS 9.1
  */
 - (instancetype)watchOS_2_1;
-
-#pragma mark Device Scale
-
-/**
- Launch at 25% Scale.
- */
-- (instancetype)scale25Percent;
-
-/**
- Launch at 50% Scale.
- */
-- (instancetype)scale50Percent;
-
-/**
- Launch at 75% Scale.
- */
-- (instancetype)scale75Percent;
-
-/**
- Launch at 100% Scale.
- */
-- (instancetype)scale100Percent;
-
-#pragma mark Locale
-
-/**
- A new configuration with the provided locale
- */
-- (instancetype)withLocale:(NSLocale *)locale;
-
-/**
- A new configuration with the provided localeIdentifier.
- */
-- (instancetype)withLocaleNamed:(NSString *)localeIdentifier;
 
 @end

--- a/FBSimulatorControl/Configuration/FBSimulatorConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorConfiguration.m
@@ -540,7 +540,7 @@
 
 - (NSUInteger)hash
 {
-  return self.deviceName.hash | self.osVersionString.hash;
+  return self.deviceName.hash ^ self.osVersionString.hash;
 }
 
 - (BOOL)isEqual:(FBSimulatorConfiguration *)object

--- a/FBSimulatorControl/Configuration/FBSimulatorConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorConfiguration.m
@@ -457,44 +457,6 @@
 
 @end
 
-#pragma mark Scales
-
-@implementation FBSimulatorConfigurationScale_25
-
-- (NSString *)scaleString
-{
-  return @"0.25";
-}
-
-@end
-
-@implementation FBSimulatorConfigurationScale_50
-
-- (NSString *)scaleString
-{
-  return @"0.50";
-}
-
-@end
-
-@implementation FBSimulatorConfigurationScale_75
-
-- (NSString *)scaleString
-{
-  return @"0.75";
-}
-
-@end
-
-@implementation FBSimulatorConfigurationScale_100
-
-- (NSString *)scaleString
-{
-  return @"1.00";
-}
-
-@end
-
 @implementation FBSimulatorConfiguration
 
 + (void)initialize
@@ -504,11 +466,10 @@
 
 #pragma mark Initializers
 
-- (instancetype)initWithNamedDevice:(id<FBSimulatorConfiguration_Device>)device os:(id<FBSimulatorConfiguration_OS>)os locale:(NSLocale *)locale scale:(id<FBSimulatorConfigurationScale>)scale
+- (instancetype)initWithNamedDevice:(id<FBSimulatorConfiguration_Device>)device os:(id<FBSimulatorConfiguration_OS>)os
 {
   NSParameterAssert(device);
   NSParameterAssert(os);
-  NSParameterAssert(scale);
 
   self = [super init];
   if (!self) {
@@ -517,8 +478,6 @@
 
   _device = device;
   _os = os;
-  _locale = locale;
-  _scale = scale;
 
   return self;
 }
@@ -530,8 +489,7 @@
   dispatch_once(&onceToken, ^{
     id<FBSimulatorConfiguration_Device> device = FBSimulatorConfiguration_Device_iPhone5.new;
     id<FBSimulatorConfiguration_OS> os = [FBSimulatorConfiguration newestAvailableOSForDevice:device];
-    id<FBSimulatorConfigurationScale> scale = FBSimulatorConfigurationScale_50.new;
-    configuration = [[FBSimulatorConfiguration alloc] initWithNamedDevice:device os:os locale:nil scale:scale];
+    configuration = [[FBSimulatorConfiguration alloc] initWithNamedDevice:device os:os];
   });
   return configuration;
 }
@@ -542,9 +500,7 @@
 {
   return [[self.class alloc]
     initWithNamedDevice:self.device
-    os:self.os
-    locale:self.locale
-    scale:self.scale];
+    os:self.os];
 }
 
 #pragma mark NSCoding
@@ -558,8 +514,6 @@
 
   _device = [coder decodeObjectForKey:NSStringFromSelector(@selector(device))];
   _os = [coder decodeObjectForKey:NSStringFromSelector(@selector(os))];
-  _locale = [coder decodeObjectForKey:NSStringFromSelector(@selector(locale))];
-  _scale = [coder decodeObjectForKey:NSStringFromSelector(@selector(scale))];
 
   return self;
 }
@@ -568,8 +522,6 @@
 {
   [coder encodeObject:self.device forKey:NSStringFromSelector(@selector(device))];
   [coder encodeObject:self.os forKey:NSStringFromSelector(@selector(os))];
-  [coder encodeObject:self.locale forKey:NSStringFromSelector(@selector(locale))];
-  [coder encodeObject:self.scale forKey:NSStringFromSelector(@selector(scale))];
 }
 
 #pragma mark Accessors
@@ -584,16 +536,11 @@
   return self.os.name;
 }
 
-- (NSString *)scaleString
-{
-  return self.scale.scaleString;
-}
-
 #pragma mark NSObject
 
 - (NSUInteger)hash
 {
-  return self.deviceName.hash | self.osVersionString.hash | self.locale.hash | self.scaleString.hash;
+  return self.deviceName.hash | self.osVersionString.hash;
 }
 
 - (BOOL)isEqual:(FBSimulatorConfiguration *)object
@@ -603,35 +550,18 @@
   }
 
   return [self.deviceName isEqualToString:object.deviceName] &&
-         [self.osVersionString isEqualToString:object.osVersionString] &&
-         [self.scaleString isEqualToString:object.scaleString] &&
-         ((self.locale == nil && object.locale == nil) || [self.locale isEqual:object.locale]);
+         [self.osVersionString isEqualToString:object.osVersionString];
 }
 
 #pragma mark Description
 
-- (NSString *)debugDescription
-{
-  return [NSString stringWithFormat:
-    @"%@ | Locale '%@' | Scale '%@'",
-    self.shortDescription,
-    self.locale,
-    self.scaleString
-  ];
-}
-
-- (NSString *)shortDescription
+- (NSString *)description
 {
   return [NSString stringWithFormat:
     @"Device '%@' | OS Version '%@'",
     self.deviceName,
     self.osVersionString
   ];
-}
-
-- (NSString *)description
-{
-  return [self shortDescription];
 }
 
 #pragma mark Devices
@@ -843,40 +773,6 @@
   return [self updateOSVersion:self.class.nameToOSVersion[osName]];
 }
 
-#pragma mark Scale
-
-- (instancetype)scale25Percent
-{
-  return [self updateScale:[FBSimulatorConfigurationScale_25 new]];
-}
-
-- (instancetype)scale50Percent
-{
-  return [self updateScale:[FBSimulatorConfigurationScale_50 new]];
-}
-
-- (instancetype)scale75Percent
-{
-  return [self updateScale:[FBSimulatorConfigurationScale_75 new]];
-}
-
-- (instancetype)scale100Percent
-{
-  return [self updateScale:[FBSimulatorConfigurationScale_100 new]];
-}
-
-- (instancetype)withLocale:(NSLocale *)locale
-{
-  FBSimulatorConfiguration *configuration = [self copy];
-  configuration.locale = locale;
-  return configuration;
-}
-
-- (instancetype)withLocaleNamed:(NSString *)localeIdentifier
-{
-  return [self withLocale:[NSLocale localeWithLocaleIdentifier:localeIdentifier]];
-}
-
 #pragma mark Private
 
 #pragma mark Deriving new Configurations
@@ -914,15 +810,6 @@
   return configuration;
 }
 
-- (instancetype)updateScale:(id<FBSimulatorConfigurationScale>)scale
-{
-  if (!scale) {
-    return nil;
-  }
-  FBSimulatorConfiguration *configuration = [self copy];
-  configuration.scale = scale;
-  return configuration;
-}
 
 + (BOOL)device:(id<FBSimulatorConfiguration_Device>)device andOSPairSupported:(id<FBSimulatorConfiguration_OS>)os
 {

--- a/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration+Helpers.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration+Helpers.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <FBSimulatorControl/FBSimulatorLaunchConfiguration.h>
+
+@class FBSimulator;
+
+@interface FBSimulatorLaunchConfiguration (Helpers)
+
+/**
+ Creates and returns the arguments to pass to Xcode's Simulator.app for the reciever's configuration.
+
+ @param simulator the Simulator construct boot args for.
+ @param error an error out for any error that occurs.
+ @return an NSArray<NSString> of boot arguments, or nil if an error occurred.
+ */
+ - (NSArray *)xcodeSimulatorApplicationArgumentsForSimulator:(FBSimulator *)simulator error:(NSError **)error;
+
+@end

--- a/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration+Helpers.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration+Helpers.m
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBSimulatorLaunchConfiguration+Helpers.h"
+
+#import <CoreSimulator/SimDevice.h>
+
+#import "FBSimulator.h"
+#import "FBSimulatorPool.h"
+#import "FBSimulatorControlConfiguration.h"
+#import "FBSimulatorControlGlobalConfiguration.h"
+#import "FBSimulatorError.h"
+
+@implementation FBSimulatorLaunchConfiguration (Helpers)
+
+ - (NSArray *)xcodeSimulatorApplicationArgumentsForSimulator:(FBSimulator *)simulator error:(NSError **)error
+{
+  // Construct the Arguments
+  NSMutableArray *arguments = [NSMutableArray arrayWithArray:@[
+    @"--args",
+    @"-CurrentDeviceUDID", simulator.udid,
+    @"-ConnectHardwareKeyboard", @"0",
+    [self lastScaleCommandLineSwitchForSimulator:simulator], self.scaleString
+  ]];
+  if (simulator.pool.configuration.deviceSetPath) {
+    if (!FBSimulatorControlGlobalConfiguration.supportsCustomDeviceSets) {
+      return [[[FBSimulatorError describe:@"Cannot use custom Device Set on current platform"] inSimulator:simulator] fail:error];
+    }
+    [arguments addObjectsFromArray:@[@"-DeviceSetPath", simulator.pool.configuration.deviceSetPath]];
+  }
+  return [arguments copy];
+}
+
+#pragma mark Scale
+
+- (NSString *)lastScaleCommandLineSwitchForSimulator:(FBSimulator *)simulator
+{
+  return [NSString stringWithFormat:@"SimulatorWindowLastScale-%@", simulator.device.deviceTypeIdentifier];
+}
+
+@end

--- a/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration.h
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+/**
+ A Value Object for defining how to launch a Simulator.
+ */
+@interface FBSimulatorLaunchConfiguration : NSObject <NSCoding, NSCopying>
+
+/**
+ The Locale in which to Simulate, may be nil.
+ */
+@property (nonatomic, strong, readonly) NSLocale *locale;
+
+/**
+ A String representing the Scale at which to launch the Simulator.
+ */
+@property (nonatomic, copy, readonly) NSString *scaleString;
+
+#pragma mark Default Instance
+
++ (instancetype)defaultConfiguration;
+
+#pragma mark Device Scale
+
+/**
+ Launch at 25% Scale.
+ */
++ (instancetype)scale25Percent;
+- (instancetype)scale25Percent;
+
+/**
+ Launch at 50% Scale.
+ */
++ (instancetype)scale50Percent;
+- (instancetype)scale50Percent;
+
+/**
+ Launch at 75% Scale.
+ */
++ (instancetype)scale75Percent;
+- (instancetype)scale75Percent;
+
+/**
+ Launch at 100% Scale.
+ */
++ (instancetype)scale100Percent;
+- (instancetype)scale100Percent;
+
+#pragma mark Locale
+
+/**
+ Set the Locale
+ */
++ (instancetype)withLocaleNamed:(NSString *)localeName;
+- (instancetype)withLocaleNamed:(NSString *)localeName;
++ (instancetype)withLocale:(NSLocale *)locale;
+- (instancetype)withLocale:(NSLocale *)locale;
+
+@end

--- a/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration.m
@@ -1,0 +1,242 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBSimulatorLaunchConfiguration.h"
+
+#import "FBSimulatorConfiguration+Private.h"
+
+@protocol FBSimulatorLaunchConfiguration_Scale <NSObject>
+
+- (NSString *)scaleString;
+
+@end
+
+@interface FBSimulatorLaunchConfiguration_Scale_25 : FBSimulatorConfigurationVariant_Base <FBSimulatorLaunchConfiguration_Scale>
+@end
+
+@interface FBSimulatorLaunchConfiguration_Scale_50 : FBSimulatorConfigurationVariant_Base <FBSimulatorLaunchConfiguration_Scale>
+@end
+
+@interface FBSimulatorLaunchConfiguration_Scale_75 : FBSimulatorConfigurationVariant_Base <FBSimulatorLaunchConfiguration_Scale>
+@end
+
+@interface FBSimulatorLaunchConfiguration_Scale_100 : FBSimulatorConfigurationVariant_Base <FBSimulatorLaunchConfiguration_Scale>
+@end
+
+#pragma mark Scales
+
+@implementation FBSimulatorLaunchConfiguration_Scale_25
+
+- (NSString *)scaleString
+{
+  return @"0.25";
+}
+
+@end
+
+@implementation FBSimulatorLaunchConfiguration_Scale_50
+
+- (NSString *)scaleString
+{
+  return @"0.50";
+}
+
+@end
+
+@implementation FBSimulatorLaunchConfiguration_Scale_75
+
+- (NSString *)scaleString
+{
+  return @"0.75";
+}
+
+@end
+
+@implementation FBSimulatorLaunchConfiguration_Scale_100
+
+- (NSString *)scaleString
+{
+  return @"1.00";
+}
+
+@end
+
+@interface FBSimulatorLaunchConfiguration ()
+
+@property (nonatomic, strong, readonly) id<FBSimulatorLaunchConfiguration_Scale> scale;
+
+@end
+
+@implementation FBSimulatorLaunchConfiguration
+
+@synthesize scale = _scale;
+@synthesize locale = _locale;
+
+#pragma mark Initializers
+
++ (instancetype)defaultConfiguration
+{
+  static dispatch_once_t onceToken;
+  static FBSimulatorLaunchConfiguration *configuration;
+  dispatch_once(&onceToken, ^{
+    id<FBSimulatorLaunchConfiguration_Scale> scale = FBSimulatorLaunchConfiguration_Scale_100.new;
+    configuration = [[self alloc] initWithScale:scale locale:nil];
+  });
+  return configuration;
+}
+
+- (instancetype)initWithScale:(id<FBSimulatorLaunchConfiguration_Scale>)scale locale:(NSLocale *)locale
+{
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  _scale = scale;
+  _locale = locale;
+
+  return self;
+}
+
+#pragma mark NSCopying
+
+- (instancetype)copyWithZone:(NSZone *)zone
+{
+  return [[self.class alloc] initWithScale:self.scale locale:self.locale];
+}
+
+#pragma mark NSCoding
+
+- (instancetype)initWithCoder:(NSCoder *)coder
+{
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  _scale = [coder decodeObjectForKey:NSStringFromSelector(@selector(scale))];
+  _locale = [coder decodeObjectForKey:NSStringFromSelector(@selector(locale))];
+
+  return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder
+{
+  [coder encodeObject:self.scale forKey:NSStringFromSelector(@selector(scale))];
+  [coder encodeObject:self.locale forKey:NSStringFromSelector(@selector(locale))];
+}
+
+#pragma mark NSObject
+
+- (BOOL)isEqual:(FBSimulatorLaunchConfiguration *)configuration
+{
+  if (![configuration isKindOfClass:self.class]) {
+    return NO;
+  }
+
+  return [self.scaleString isEqualToString:configuration.scaleString] &&
+         (self.locale == configuration.locale || [self.locale isEqual:configuration.locale]);
+}
+
+- (NSUInteger)hash
+{
+  return self.scaleString.hash ^ self.locale.hash;
+}
+
+- (NSString *)description
+{
+  return [NSString stringWithFormat:
+    @"Scale %@ | Locale %@",
+    self.scaleString,
+    self.locale
+  ];
+}
+
+#pragma mark Accessors
+
+- (NSString *)scaleString
+{
+  return self.scale.scaleString;
+}
+
+#pragma mark Scale
+
++ (instancetype)scale25Percent
+{
+  return [self.defaultConfiguration scale25Percent];
+}
+
+- (instancetype)scale25Percent
+{
+  return [self updateScale:FBSimulatorLaunchConfiguration_Scale_25.new];
+}
+
++ (instancetype)scale50Percent
+{
+  return [self.defaultConfiguration scale50Percent];
+}
+
+- (instancetype)scale50Percent
+{
+  return [self updateScale:FBSimulatorLaunchConfiguration_Scale_50.new];
+}
+
++ (instancetype)scale75Percent
+{
+  return [self.defaultConfiguration scale75Percent];
+}
+
+- (instancetype)scale75Percent
+{
+  return [self updateScale:FBSimulatorLaunchConfiguration_Scale_75.new];
+}
+
++ (instancetype)scale100Percent
+{
+  return [self.defaultConfiguration scale25Percent];
+}
+
+- (instancetype)scale100Percent
+{
+  return [self updateScale:FBSimulatorLaunchConfiguration_Scale_100.new];
+}
+
+#pragma mark Locale
+
++ (instancetype)withLocale:(NSLocale *)locale
+{
+  return [self.defaultConfiguration withLocale:locale];
+}
+
+- (instancetype)withLocale:(NSLocale *)locale
+{
+  return [[self.class alloc] initWithScale:self.scale locale:locale];
+}
+
++ (instancetype)withLocaleNamed:(NSString *)localeName
+{
+  return [self.defaultConfiguration withLocaleNamed:localeName];
+}
+
+- (instancetype)withLocaleNamed:(NSString *)localeIdentifier
+{
+  return [self withLocale:[NSLocale localeWithLocaleIdentifier:localeIdentifier]];
+}
+
+#pragma mark Private
+
+- (instancetype)updateScale:(id<FBSimulatorLaunchConfiguration_Scale>)scale
+{
+  if (!scale) {
+    return nil;
+  }
+  return [[self.class alloc] initWithScale:scale locale:self.locale];
+}
+
+@end

--- a/FBSimulatorControl/FBSimulatorControl.h
+++ b/FBSimulatorControl/FBSimulatorControl.h
@@ -7,8 +7,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <FBSimulatorControl/FBASLParser.h>
 #import <FBSimulatorControl/FBAddVideoPolyfill.h>
+#import <FBSimulatorControl/FBASLParser.h>
 #import <FBSimulatorControl/FBBinaryParser.h>
 #import <FBSimulatorControl/FBCollectionDescriptions.h>
 #import <FBSimulatorControl/FBCompositeSimulatorEventSink.h>
@@ -54,6 +54,8 @@
 #import <FBSimulatorControl/FBSimulatorInteraction+Upload.h>
 #import <FBSimulatorControl/FBSimulatorInteraction+Video.h>
 #import <FBSimulatorControl/FBSimulatorInteraction.h>
+#import <FBSimulatorControl/FBSimulatorLaunchConfiguration+Helpers.h>
+#import <FBSimulatorControl/FBSimulatorLaunchConfiguration.h>
 #import <FBSimulatorControl/FBSimulatorLaunchInfo.h>
 #import <FBSimulatorControl/FBSimulatorLogger.h>
 #import <FBSimulatorControl/FBSimulatorLoggingEventSink.h>

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.h
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.h
@@ -11,17 +11,26 @@
 
 #import <FBSimulatorControl/FBSimulatorInteraction.h>
 
+@class FBSimulatorLaunchConfiguration;
+
 /**
  Interactions for the Lifecycle of the Simulator.
  */
 @interface FBSimulatorInteraction (Lifecycle)
 
 /**
- Boots the Simulator.
+ Boots the Simulator with the default Simulator Launch Configuration.
 
  @return the reciever, for chaining.
  */
 - (instancetype)bootSimulator;
+
+/**
+ Boots the Simulator with the default Simulator Launch Configuration.
+
+ @return the reciever, for chaining.
+ */
+- (instancetype)bootSimulator:(FBSimulatorLaunchConfiguration *)configuration;
 
 /**
  Shuts the Simulator down.

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Setup.h
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Setup.h
@@ -9,12 +9,27 @@
 
 #import <FBSimulatorControl/FBSimulatorInteraction.h>
 
+@class FBSimulatorLaunchConfiguration;
+
+/**
+ Interactions for Simulators that should occur Prior to the launch of the Simulator.
+ */
 @interface FBSimulatorInteraction (Setup)
+
+/**
+ Prepares the Simulator for Launch:
+ - Sets the Locale (if set)
+ - Sets up the keyboard.
+ 
+ @param configuration the configuration to use.
+ @return the reciever, for chaining.
+ */
+- (instancetype)prepareForLaunch:(FBSimulatorLaunchConfiguration *)configuration;
 
 /**
  Sets the locale for the simulator.
 
- @param locale the locale to set, must not be nil.
+ @param locale the locale to set.
  @return the reciever, for chaining.
  */
 - (instancetype)setLocale:(NSLocale *)locale;

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Setup.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Setup.m
@@ -16,12 +16,22 @@
 #import "FBSimulatorApplication.h"
 #import "FBSimulatorError.h"
 #import "FBSimulatorInteraction+Private.h"
+#import "FBSimulatorLaunchConfiguration.h"
 
 @implementation FBSimulatorInteraction (Setup)
 
+- (instancetype)prepareForLaunch:(FBSimulatorLaunchConfiguration *)configuration
+{
+  return [[self
+    setLocale:configuration.locale]
+    setupKeyboard];
+}
+
 - (instancetype)setLocale:(NSLocale *)locale
 {
-  NSParameterAssert(locale);
+  if (!locale) {
+    return [self succeed];
+  }
 
   return [self interactWithShutdownSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
     NSString *localeIdentifier = [locale localeIdentifier];

--- a/FBSimulatorControl/Management/FBSimulatorPool.m
+++ b/FBSimulatorControl/Management/FBSimulatorPool.m
@@ -473,26 +473,6 @@
     }
   }
 
-  // Do the other configuration that is dependent on a shutdown Simulator.
-  if (shutdown || erase) {
-    if (configuration.locale && ![[simulator.interact setLocale:configuration.locale] performInteractionWithError:&innerError]) {
-      return [[[[[FBSimulatorError
-        describe:@"Failed to set the locale on a Simulator when allocating it"]
-        causedBy:innerError]
-        inSimulator:simulator]
-        logger:self.logger]
-        failBool:error];
-    }
-    if (![[simulator.interact setupKeyboard] performInteractionWithError:&innerError]) {
-      return [[[[[FBSimulatorError
-        describe:@"Failed to setup the keyboard of a Simulator when allocating it"]
-        causedBy:innerError]
-        inSimulator:simulator]
-        logger:self.logger]
-        failBool:error];
-    }
-  }
-
   // Enable/Disable Persistence
   simulator.historyGenerator.peristenceEnabled = enablePersistence;
 

--- a/FBSimulatorControlTests/Tests/FBSimulatorWindowTilingTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorWindowTilingTests.m
@@ -21,11 +21,6 @@
 
 @implementation FBSimulatorWindowTilingTests
 
-- (FBSimulatorConfiguration *)simulatorConfiguration
-{
-  return FBSimulatorConfiguration.iPhone5.scale50Percent;
-}
-
 - (void)testTilesSingleiPhoneSimulatorInTopLeft
 {
   // Approval is required externally to the Test Runner. Without approval, the tests can't run


### PR DESCRIPTION
Adds `FBSimulatorLaunchConfiguration` which is an immutable configuration object passed to `bootSimulator:`. This achieves a number of things:
- `FBSimulatorConfiguration` was never the right place to have `scale` and `locale` arguments, is configuration for the pre-launch interactions of a Simulator
- A common container for options to `bootSimulator` as I plan to add more configurability to the boot process.
- Removal of configuration of a simulator from `allocateSimulator`. The `FBSimulatorInteraction+Setup` suite of interactions should be used directly prior to `bootSimulator` instead. Allocation does not imply pre-boot configuration and this is unnecessarily surprising.
- A neat place to factory arguments to the Simulator Application process.