### PR TITLE
'launch' Action

### DIFF
--- a/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
@@ -50,6 +50,7 @@ public enum Interaction {
   case Shutdown
   case Diagnose
   case Install(FBSimulatorApplication)
+  case Launch(FBProcessLaunchConfiguration)
 }
 
 /**
@@ -162,6 +163,8 @@ public func == (left: Interaction, right: Interaction) -> Bool {
     return true
   case (.Install(let leftApp), .Install(let rightApp)):
     return leftApp == rightApp
+  case (.Launch(let leftLaunch), .Launch(let rightLaunch)):
+    return leftLaunch == rightLaunch
   default:
     return false
   }

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -101,6 +101,15 @@ private struct SimulatorRunner : Runner {
         writer.write("Installing \(application.path) on \(self.formattedSimulator)")
         try simulator.interact().installApplication(application).performInteraction()
         writer.write("Installed \(application.path) on \(self.formattedSimulator)")
+      case .Launch(let launch):
+        writer.write("Launching \(launch.shortDescription()) on \(self.formattedSimulator)")
+        if let appLaunch = launch as? FBApplicationLaunchConfiguration {
+          try simulator.interact().launchApplication(appLaunch).performInteraction()
+        }
+        else if let agentLaunch = launch as? FBAgentLaunchConfiguration {
+          try simulator.interact().launchAgent(agentLaunch).performInteraction()
+        }
+        writer.write("Launched \(launch.shortDescription()) on \(self.formattedSimulator)")
       }
     } catch let error as NSError {
       return .Failure(error.description)

--- a/fbsimctl/FBSimulatorControlKitTests/Helpers/Fixtures.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Helpers/Fixtures.swift
@@ -15,4 +15,11 @@ public struct Fixtures {
   static func application() -> FBSimulatorApplication {
     return FBSimulatorApplication.xcodeSimulator()
   }
+
+  static func binary() -> FBSimulatorBinary {
+    let basePath: NSString = FBSimulatorControlGlobalConfiguration.developerDirectory()
+    return try! FBSimulatorBinary(
+      path: basePath.stringByAppendingPathComponent("Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/sbin/launchd_sim")
+    )
+  }
 }

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
@@ -212,7 +212,9 @@ class InteractionParserTests : XCTestCase {
       (["boot"], Interaction.Boot),
       (["shutdown"], Interaction.Shutdown),
       (["diagnose"], Interaction.Diagnose),
-      (["install", Fixtures.application().path], Interaction.Install(Fixtures.application()))
+      (["install", Fixtures.application().path], Interaction.Install(Fixtures.application())),
+      (["launch", Fixtures.application().path], Interaction.Launch(FBApplicationLaunchConfiguration(application: Fixtures.application(), arguments: [], environment: [:]))),
+      (["launch", Fixtures.binary().path], Interaction.Launch(FBAgentLaunchConfiguration(binary: Fixtures.binary(), arguments: [], environment: [:])))
     ])
   }
 
@@ -250,6 +252,30 @@ class ActionParserTests : XCTestCase {
   func testParsesInstall() {
     let interaction = Interaction.Install(Fixtures.application())
     let prefix: [String] = ["install", Fixtures.application().path]
+
+    self.assertParsesAll(Action.parser(), [
+      (prefix, Action(interaction: interaction, query: Query.defaultValue(), format: Format.defaultValue())),
+      (prefix + ["iPad 2"], Action(interaction: interaction, query: .Configured([FBSimulatorConfiguration.iPad2()]), format: Format.defaultValue())),
+      (prefix + ["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Action(interaction: interaction, query: .UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]), format: Format.defaultValue())),
+      (prefix + ["iPhone 5", "shutdown", "iPhone 6"], Action(interaction: interaction, query: .And([.Configured([FBSimulatorConfiguration.iPhone5(), FBSimulatorConfiguration.iPhone6()]), .State([.Shutdown])]), format: Format.defaultValue())),
+    ])
+  }
+
+  func testParsesAppLaunch() {
+    let interaction = Interaction.Launch(FBApplicationLaunchConfiguration(application: Fixtures.application(), arguments: [], environment: [:]))
+    let prefix: [String] = ["launch", Fixtures.application().path]
+
+    self.assertParsesAll(Action.parser(), [
+      (prefix, Action(interaction: interaction, query: Query.defaultValue(), format: Format.defaultValue())),
+      (prefix + ["iPad 2"], Action(interaction: interaction, query: .Configured([FBSimulatorConfiguration.iPad2()]), format: Format.defaultValue())),
+      (prefix + ["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Action(interaction: interaction, query: .UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]), format: Format.defaultValue())),
+      (prefix + ["iPhone 5", "shutdown", "iPhone 6"], Action(interaction: interaction, query: .And([.Configured([FBSimulatorConfiguration.iPhone5(), FBSimulatorConfiguration.iPhone6()]), .State([.Shutdown])]), format: Format.defaultValue())),
+    ])
+  }
+
+  func testParsesAgentLaunch() {
+    let interaction = Interaction.Launch(FBAgentLaunchConfiguration(binary: Fixtures.binary(), arguments: [], environment: [:]))
+    let prefix: [String] = ["launch", Fixtures.binary().path]
 
     self.assertParsesAll(Action.parser(), [
       (prefix, Action(interaction: interaction, query: Query.defaultValue(), format: Format.defaultValue())),


### PR DESCRIPTION
Adds a 'Launch' Action for launching agents and applications. Current implementation won't take arguments but I plan on fixing this by changing the ordering of the grammar so the `Interaction` is parsed after the `Query` thereby making variadic arguments apply to the `Interaction`.