### PR TITLE
Killing Simulators accounts for Simulator.app-less booted Simulators.

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		AA1D65471C21CD2A0069F90D /* FBASLParser.m in Sources */ = {isa = PBXBuildFile; fileRef = AA1D65451C21CD2A0069F90D /* FBASLParser.m */; };
 		AA2219911C3D868300371B01 /* FBProcessTerminationStrategy.h in Headers */ = {isa = PBXBuildFile; fileRef = AA22198F1C3D868300371B01 /* FBProcessTerminationStrategy.h */; };
 		AA2219921C3D868300371B01 /* FBProcessTerminationStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = AA2219901C3D868300371B01 /* FBProcessTerminationStrategy.m */; };
+		AA2219951C3E752800371B01 /* FBCoreSimulatorTerminationStrategy.h in Headers */ = {isa = PBXBuildFile; fileRef = AA2219931C3E752800371B01 /* FBCoreSimulatorTerminationStrategy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA2219961C3E752800371B01 /* FBCoreSimulatorTerminationStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = AA2219941C3E752800371B01 /* FBCoreSimulatorTerminationStrategy.m */; };
 		AA3230CB1BDA387700C5BA01 /* FBSimulatorControlAssertions.m in Sources */ = {isa = PBXBuildFile; fileRef = AA3230CA1BDA387700C5BA01 /* FBSimulatorControlAssertions.m */; };
 		AA5639551C060005009BAFAA /* FBSimulatorControl.h in Headers */ = {isa = PBXBuildFile; fileRef = AA5639541C05FFF5009BAFAA /* FBSimulatorControl.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA819DB71B9FB40D002F58CA /* FBSimulatorControl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E291A4B50E500000001 /* FBSimulatorControl.framework */; };
@@ -245,6 +247,8 @@
 		AA1D65451C21CD2A0069F90D /* FBASLParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBASLParser.m; sourceTree = "<group>"; };
 		AA22198F1C3D868300371B01 /* FBProcessTerminationStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBProcessTerminationStrategy.h; sourceTree = "<group>"; };
 		AA2219901C3D868300371B01 /* FBProcessTerminationStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBProcessTerminationStrategy.m; sourceTree = "<group>"; };
+		AA2219931C3E752800371B01 /* FBCoreSimulatorTerminationStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBCoreSimulatorTerminationStrategy.h; sourceTree = "<group>"; };
+		AA2219941C3E752800371B01 /* FBCoreSimulatorTerminationStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBCoreSimulatorTerminationStrategy.m; sourceTree = "<group>"; };
 		AA2DDC231C283F40000689C6 /* __SimKitPlaceholderClass.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = __SimKitPlaceholderClass.h; sourceTree = "<group>"; };
 		AA2DDC241C283F40000689C6 /* CDStructures.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CDStructures.h; sourceTree = "<group>"; };
 		AA2DDC251C283F40000689C6 /* NSError-SimulatorKitNSErrorAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSError-SimulatorKitNSErrorAdditions.h"; sourceTree = "<group>"; };
@@ -1786,6 +1790,8 @@
 		AA9516FA1C15F54600A89CAD /* Management */ = {
 			isa = PBXGroup;
 			children = (
+				AA2219931C3E752800371B01 /* FBCoreSimulatorTerminationStrategy.h */,
+				AA2219941C3E752800371B01 /* FBCoreSimulatorTerminationStrategy.m */,
 				AA22198F1C3D868300371B01 /* FBProcessTerminationStrategy.h */,
 				AA2219901C3D868300371B01 /* FBProcessTerminationStrategy.m */,
 				AA9516FE1C15F54600A89CAD /* FBSimulator.h */,
@@ -2048,6 +2054,7 @@
 				AAF2D3561C33EA3100434516 /* FBSimulatorInteraction+Lifecycle.h in Headers */,
 				AA95179D1C15F54600A89CAD /* FBProcessQuery.h in Headers */,
 				AA9517A11C15F54600A89CAD /* FBSimulatorSession+Private.h in Headers */,
+				AA2219951C3E752800371B01 /* FBCoreSimulatorTerminationStrategy.h in Headers */,
 				AA9517871C15F54600A89CAD /* FBSimulatorPredicates.h in Headers */,
 				AA9517811C15F54600A89CAD /* FBSimulatorControl+PrincipalClass.h in Headers */,
 				AA9517BA1C15F54600A89CAD /* FBSimulatorLogger.h in Headers */,
@@ -2184,6 +2191,7 @@
 				AA9517981C15F54600A89CAD /* FBCoreSimulatorNotifier.m in Sources */,
 				AA9517731C15F54600A89CAD /* FBSimulatorInteraction+Video.m in Sources */,
 				AA9517BD1C15F54600A89CAD /* NSRunLoop+SimulatorControlAdditions.m in Sources */,
+				AA2219961C3E752800371B01 /* FBCoreSimulatorTerminationStrategy.m in Sources */,
 				AA9517AB1C15F54600A89CAD /* FBTaskExecutor.m in Sources */,
 				AA9517751C15F54600A89CAD /* FBSimulatorInteraction.m in Sources */,
 				AA95175A1C15F54600A89CAD /* FBSimulatorEventRelay.m in Sources */,

--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		AA1D65431C21B38D0069F90D /* FBCrashLogInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = AA1D65411C21B38D0069F90D /* FBCrashLogInfo.m */; };
 		AA1D65461C21CD2A0069F90D /* FBASLParser.h in Headers */ = {isa = PBXBuildFile; fileRef = AA1D65441C21CD2A0069F90D /* FBASLParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA1D65471C21CD2A0069F90D /* FBASLParser.m in Sources */ = {isa = PBXBuildFile; fileRef = AA1D65451C21CD2A0069F90D /* FBASLParser.m */; };
+		AA2219911C3D868300371B01 /* FBProcessTerminationStrategy.h in Headers */ = {isa = PBXBuildFile; fileRef = AA22198F1C3D868300371B01 /* FBProcessTerminationStrategy.h */; };
+		AA2219921C3D868300371B01 /* FBProcessTerminationStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = AA2219901C3D868300371B01 /* FBProcessTerminationStrategy.m */; };
 		AA3230CB1BDA387700C5BA01 /* FBSimulatorControlAssertions.m in Sources */ = {isa = PBXBuildFile; fileRef = AA3230CA1BDA387700C5BA01 /* FBSimulatorControlAssertions.m */; };
 		AA5639551C060005009BAFAA /* FBSimulatorControl.h in Headers */ = {isa = PBXBuildFile; fileRef = AA5639541C05FFF5009BAFAA /* FBSimulatorControl.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA819DB71B9FB40D002F58CA /* FBSimulatorControl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E291A4B50E500000001 /* FBSimulatorControl.framework */; };
@@ -241,6 +243,8 @@
 		AA1D65411C21B38D0069F90D /* FBCrashLogInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBCrashLogInfo.m; sourceTree = "<group>"; };
 		AA1D65441C21CD2A0069F90D /* FBASLParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBASLParser.h; sourceTree = "<group>"; };
 		AA1D65451C21CD2A0069F90D /* FBASLParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBASLParser.m; sourceTree = "<group>"; };
+		AA22198F1C3D868300371B01 /* FBProcessTerminationStrategy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBProcessTerminationStrategy.h; sourceTree = "<group>"; };
+		AA2219901C3D868300371B01 /* FBProcessTerminationStrategy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBProcessTerminationStrategy.m; sourceTree = "<group>"; };
 		AA2DDC231C283F40000689C6 /* __SimKitPlaceholderClass.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = __SimKitPlaceholderClass.h; sourceTree = "<group>"; };
 		AA2DDC241C283F40000689C6 /* CDStructures.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CDStructures.h; sourceTree = "<group>"; };
 		AA2DDC251C283F40000689C6 /* NSError-SimulatorKitNSErrorAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSError-SimulatorKitNSErrorAdditions.h"; sourceTree = "<group>"; };
@@ -1782,6 +1786,8 @@
 		AA9516FA1C15F54600A89CAD /* Management */ = {
 			isa = PBXGroup;
 			children = (
+				AA22198F1C3D868300371B01 /* FBProcessTerminationStrategy.h */,
+				AA2219901C3D868300371B01 /* FBProcessTerminationStrategy.m */,
 				AA9516FE1C15F54600A89CAD /* FBSimulator.h */,
 				AA9516FF1C15F54600A89CAD /* FBSimulator.m */,
 				AA9516FB1C15F54600A89CAD /* FBSimulator+Helpers.h */,
@@ -1981,6 +1987,7 @@
 				AA95176B1C15F54600A89CAD /* FBSimulatorInteraction+Diagnostics.h in Headers */,
 				AA9517991C15F54600A89CAD /* FBDispatchSourceNotifier.h in Headers */,
 				AA95178E1C15F54600A89CAD /* FBSimulatorApplication.h in Headers */,
+				AA2219911C3D868300371B01 /* FBProcessTerminationStrategy.h in Headers */,
 				AA9517951C15F54600A89CAD /* FBSimulatorLaunchInfo.h in Headers */,
 				AA9517851C15F54600A89CAD /* FBSimulatorPool.h in Headers */,
 				AA9517621C15F54600A89CAD /* FBInteraction+Private.h in Headers */,
@@ -2202,6 +2209,7 @@
 				AA95176F1C15F54600A89CAD /* FBSimulatorInteraction+Setup.m in Sources */,
 				AA95175F1C15F54600A89CAD /* FBSimulatorHistoryGenerator.m in Sources */,
 				AA95178A1C15F54600A89CAD /* FBSimulatorTerminationStrategy.m in Sources */,
+				AA2219921C3D868300371B01 /* FBProcessTerminationStrategy.m in Sources */,
 				AA9517B51C15F54600A89CAD /* FBConcurrentCollectionOperations.m in Sources */,
 				AACA2C381C2976B100979C45 /* FBAddVideoPolyfill.m in Sources */,
 				AA9517921C15F54600A89CAD /* FBSimulatorHistory+Queries.m in Sources */,

--- a/FBSimulatorControl/FBSimulatorControl.h
+++ b/FBSimulatorControl/FBSimulatorControl.h
@@ -14,6 +14,7 @@
 #import <FBSimulatorControl/FBCompositeSimulatorEventSink.h>
 #import <FBSimulatorControl/FBConcurrentCollectionOperations.h>
 #import <FBSimulatorControl/FBCoreSimulatorNotifier.h>
+#import <FBSimulatorControl/FBCoreSimulatorTerminationStrategy.h>
 #import <FBSimulatorControl/FBCrashLogInfo.h>
 #import <FBSimulatorControl/FBDispatchSourceNotifier.h>
 #import <FBSimulatorControl/FBInteraction+Private.h>

--- a/FBSimulatorControl/Management/FBCoreSimulatorTerminationStrategy.h
+++ b/FBSimulatorControl/Management/FBCoreSimulatorTerminationStrategy.h
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class FBProcessQuery;
+@protocol FBSimulatorLogger;
+
+/**
+ A Strategy for killing 'com.apple.CoreSimulatorService' processes that are not from the current Xcode version.
+ */
+@interface FBCoreSimulatorTerminationStrategy : NSObject
+
+/**
+ Creates and returns a new Core Simulator Termination Strategy from the arguments.
+ 
+ @param processQuery the Process Query object to use.
+ @param logger the logger to use.
+ */
++ (instancetype)withProcessQuery:(FBProcessQuery *)processQuery logger:(id<FBSimulatorLogger>)logger;
+
+/**
+ Kills all of the 'com.apple.CoreSimulatorService' processes that are not used by the current `FBSimulatorControl` configuration.
+ Running multiple versions of the Service on the same machine can lead to instability such as Simulator statuses not updating.
+
+ @param error an error out if any error occured.
+ @return an YES if successful, nil otherwise.
+ */
+- (BOOL)killSpuriousCoreSimulatorServicesWithError:(NSError **)error;
+
+@end

--- a/FBSimulatorControl/Management/FBCoreSimulatorTerminationStrategy.m
+++ b/FBSimulatorControl/Management/FBCoreSimulatorTerminationStrategy.m
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBCoreSimulatorTerminationStrategy.h"
+
+#import "FBCollectionDescriptions.h"
+#import "FBSimulatorLogger.h"
+#import "FBProcessTerminationStrategy.h"
+#import "FBProcessQuery+Simulators.h"
+
+@interface FBCoreSimulatorTerminationStrategy ()
+
+@property (nonatomic, strong, readonly) FBProcessQuery *processQuery;
+@property (nonatomic, strong, readonly) id<FBSimulatorLogger> logger;
+@property (nonatomic, strong, readonly) FBProcessTerminationStrategy *processTerminationStrategy;
+
+@end
+
+@implementation FBCoreSimulatorTerminationStrategy
+
+#pragma mark Initializers
+
++ (instancetype)withProcessQuery:(FBProcessQuery *)processQuery logger:(id<FBSimulatorLogger>)logger
+{
+  return [[self alloc] initWithProcessQuery:processQuery logger:logger];
+}
+
+- (instancetype)initWithProcessQuery:(FBProcessQuery *)processQuery logger:(id<FBSimulatorLogger>)logger
+{
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  _processQuery = processQuery;
+  _logger = logger;
+  _processTerminationStrategy = [FBProcessTerminationStrategy withProcessKilling:processQuery logger:logger];
+
+  return self;
+}
+
+#pragma mark Public
+
+- (BOOL)killSpuriousCoreSimulatorServicesWithError:(NSError **)error
+{
+  NSPredicate *predicate = [NSCompoundPredicate notPredicateWithSubpredicate:
+    [FBProcessQuery coreSimulatorProcessesForCurrentXcode]
+  ];
+  NSArray *processes = [[self.processQuery coreSimulatorServiceProcesses] filteredArrayUsingPredicate:predicate];
+
+  if (processes.count == 0) {
+    [self.logger.debug log:@"There are no spurious CoreSimulatorService processes to kill"];
+    return YES;
+  }
+
+  [self.logger.debug logFormat:@"Killing Spurious CoreSimulatorServices %@", [FBCollectionDescriptions oneLineDescriptionFromArray:processes atKeyPath:@"debugDescription"]];
+  return [self.processTerminationStrategy killProcesses:processes error:error];
+}
+
+@end

--- a/FBSimulatorControl/Management/FBProcessTerminationStrategy.h
+++ b/FBSimulatorControl/Management/FBProcessTerminationStrategy.h
@@ -38,12 +38,21 @@
 + (instancetype)withRunningApplicationTermination:(FBProcessQuery *)processQuery logger:(id<FBSimulatorLogger>)logger;;
 
 /**
- Uses methods on NSRunningApplication to terminate Applications
+ Terminates a Process of the provided Process Info.
  
  @param process the process to terminate, must not be nil.
  @param error an error out for any error that occurs.
  @return YES if successful, NO otherwise.
  */
 - (BOOL)killProcess:(FBProcessInfo *)process error:(NSError **)error;
+
+/**
+ Terminates a number of Processes of the provided Process Info Array.
+
+ @param processes an NSArray<FBProcessInfo> of processes to terminate.
+ @param error an error out for any error that occurs.
+ @return YES if successful, NO otherwise.
+ */
+- (BOOL)killProcesses:(NSArray *)processes error:(NSError **)error;
 
 @end

--- a/FBSimulatorControl/Management/FBProcessTerminationStrategy.h
+++ b/FBSimulatorControl/Management/FBProcessTerminationStrategy.h
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+@protocol FBSimulatorLogger;
+@class FBProcessInfo;
+@class FBProcessQuery;
+
+/**
+ A Strategy that defines how to terminate Processes.
+ */
+@interface FBProcessTerminationStrategy : NSObject
+
+/**
+ Uses kill(2) to terminate Applications.
+ 
+ @param processQuery the Process Query object to use.
+ @param logger the logger to use.
+ @return a new Process Termination Strategy instance.
+ */
++ (instancetype)withProcessKilling:(FBProcessQuery *)processQuery logger:(id<FBSimulatorLogger>)logger;
+
+/**
+ Uses methods on NSRunningApplication to terminate Applications.
+ Uses kill(2) otherwise
+
+ @param processQuery the Process Query object to use.
+ @param logger the logger to use.
+ @return a new Process Termination Strategy instance.
+ */
++ (instancetype)withRunningApplicationTermination:(FBProcessQuery *)processQuery logger:(id<FBSimulatorLogger>)logger;;
+
+/**
+ Uses methods on NSRunningApplication to terminate Applications
+ 
+ @param process the process to terminate, must not be nil.
+ @param error an error out for any error that occurs.
+ @return YES if successful, NO otherwise.
+ */
+- (BOOL)killProcess:(FBProcessInfo *)process error:(NSError **)error;
+
+@end

--- a/FBSimulatorControl/Management/FBProcessTerminationStrategy.m
+++ b/FBSimulatorControl/Management/FBProcessTerminationStrategy.m
@@ -36,22 +36,27 @@
   NSRunningApplication *application = [self.processQuery runningApplicationForProcess:process];
   // If the Application Handle doesn't exist, assume it isn't an Application and use good-ole kill(2)
   if ([application isKindOfClass:NSNull.class]) {
+    [self.logger.debug logFormat:@"Application Handle for %@ does not exist, falling back to kill(2)", process.shortDescription];
     return [super killProcess:process error:error];
   }
   // Terminate and return if successful.
   if ([application terminate]) {
+    [self.logger.debug logFormat:@"Terminated %@ with Application Termination", process.shortDescription];
     return YES;
   }
   // If the App is already terminated, everything is ok.
   if (application.isTerminated) {
+    [self.logger.debug logFormat:@"Application %@ is Terminated", process.shortDescription];
     return YES;
   }
   // I find your lack of termination disturbing.
   if ([application forceTerminate]) {
+    [self.logger.debug logFormat:@"Terminated %@ with Forced Application Termination", process.shortDescription];
     return YES;
   }
   // If the App is already terminated, everything is ok.
   if (application.isTerminated) {
+    [self.logger.debug logFormat:@"Application %@ terminated after Forced Application Termination", process.shortDescription];
     return YES;
   }
   return [[[[FBSimulatorError

--- a/FBSimulatorControl/Management/FBProcessTerminationStrategy.m
+++ b/FBSimulatorControl/Management/FBProcessTerminationStrategy.m
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBProcessTerminationStrategy.h"
+
+#import <AppKit/AppKit.h>
+
+#import "FBProcessInfo.h"
+#import "FBSimulatorError.h"
+#import "FBSimulatorLogger.h"
+#import "FBProcessQuery+Helpers.h"
+#import "FBProcessQuery.h"
+
+@interface FBProcessTerminationStrategy ()
+
+@property (nonatomic, strong, readonly) FBProcessQuery *processQuery;
+@property (nonatomic, strong, readonly) id<FBSimulatorLogger> logger;
+
+@end
+
+@interface FBApplicationTerminationStrategy_WorkspaceQuit : FBProcessTerminationStrategy
+
+@end
+
+@implementation FBApplicationTerminationStrategy_WorkspaceQuit
+
+- (BOOL)killProcess:(FBProcessInfo *)process error:(NSError **)error
+{
+  // Obtain the NSRunningApplication for the given Application.
+  NSRunningApplication *application = [self.processQuery runningApplicationForProcess:process];
+  // If the Application Handle doesn't exist, assume it isn't an Application and use good-ole kill(2)
+  if ([application isKindOfClass:NSNull.class]) {
+    return [super killProcess:process error:error];
+  }
+  // Terminate and return if successful.
+  if ([application terminate]) {
+    return YES;
+  }
+  // If the App is already terminated, everything is ok.
+  if (application.isTerminated) {
+    return YES;
+  }
+  // I find your lack of termination disturbing.
+  if ([application forceTerminate]) {
+    return YES;
+  }
+  // If the App is already terminated, everything is ok.
+  if (application.isTerminated) {
+    return YES;
+  }
+  return [[[[FBSimulatorError
+    describeFormat:@"Could not terminate Application %@", application]
+    attachProcessInfoForIdentifier:process.processIdentifier query:self.processQuery]
+    logger:self.logger]
+    failBool:error];
+}
+
+@end
+
+@implementation FBProcessTerminationStrategy
+
++ (instancetype)withProcessKilling:(FBProcessQuery *)processQuery logger:(id<FBSimulatorLogger>)logger;
+{
+  return [[self alloc] initWithProcessQuery:processQuery logger:logger];
+}
+
++ (instancetype)withRunningApplicationTermination:(FBProcessQuery *)processQuery logger:(id<FBSimulatorLogger>)logger;
+{
+  return [[FBApplicationTerminationStrategy_WorkspaceQuit alloc] initWithProcessQuery:processQuery logger:logger];
+}
+
+- (instancetype)initWithProcessQuery:(FBProcessQuery *)processQuery logger:(id<FBSimulatorLogger>)logger
+{
+  NSParameterAssert(processQuery);
+
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  _processQuery = processQuery;
+  _logger = logger;
+
+  return self;
+}
+
+- (BOOL)killProcess:(FBProcessInfo *)process error:(NSError **)error
+{
+  // The kill was successful, all is well.
+  [self.logger.debug logFormat:@"Killing %@", process.shortDescription];
+  if (kill(process.processIdentifier, SIGTERM) == 0) {
+    return YES;
+  }
+  int errorCode = errno;
+  if (errorCode == EPERM) {
+    return [[[[FBSimulatorError
+      describeFormat:@"Failed to kill process %@ as the sending process does not have the privelages", process]
+      attachProcessInfoForIdentifier:process.processIdentifier query:self.processQuery]
+      logger:self.logger]
+      failBool:error];
+  }
+  if (errorCode == ESRCH) {
+    return [[[[FBSimulatorError
+      describeFormat:@"Failed to kill process %@ as the sending process does not exist", process]
+      attachProcessInfoForIdentifier:process.processIdentifier query:self.processQuery]
+      logger:self.logger]
+      failBool:error];
+  }
+  if (errorCode == EINVAL) {
+    return [[[[FBSimulatorError
+      describeFormat:@"Failed to kill process %@ as the signal was not a valid signal number", process]
+      attachProcessInfoForIdentifier:process.processIdentifier query:self.processQuery]
+      logger:self.logger]
+      failBool:error];
+  }
+  [self.logger.debug logFormat:@"Killed %@", process.shortDescription];
+  return [[FBSimulatorError describeFormat:@"Failed to kill process %@ with unknown errno %d", process, errorCode] failBool:error];
+}
+
+@end

--- a/FBSimulatorControl/Management/FBProcessTerminationStrategy.m
+++ b/FBSimulatorControl/Management/FBProcessTerminationStrategy.m
@@ -128,4 +128,15 @@
   return [[FBSimulatorError describeFormat:@"Failed to kill process %@ with unknown errno %d", process, errorCode] failBool:error];
 }
 
+- (BOOL)killProcesses:(NSArray *)processes error:(NSError **)error
+{
+  for (FBProcessInfo *process in processes) {
+    NSParameterAssert(process.processIdentifier > 1);
+    if (![self killProcess:process error:error]) {
+      return NO;
+    }
+  }
+  return YES;
+}
+
 @end

--- a/FBSimulatorControl/Management/FBSimulatorPool.h
+++ b/FBSimulatorControl/Management/FBSimulatorPool.h
@@ -61,11 +61,6 @@ typedef NS_OPTIONS(NSUInteger, FBSimulatorAllocationOptions){
 @property (nonatomic, copy, readonly) NSArray *allSimulators;
 
 /**
- Returns the Simulator Termination Strategy associated with the reciever.
- */
-@property (nonatomic, strong, readonly) FBSimulatorTerminationStrategy *terminationStrategy;
-
-/**
  Returns a Device for the given parameters. Will create devices where necessary.
  If you plan on running multiple tests in the lifecycle of a process, you sshould use `freeDevice:error:`
  otherwise devices will continue to be allocated.

--- a/FBSimulatorControl/Management/FBSimulatorPool.m
+++ b/FBSimulatorControl/Management/FBSimulatorPool.m
@@ -420,7 +420,7 @@
 
   // This step ensures that the Simulator is in a known-shutdown state after creation.
   // This prevents racing with any 'booting' interaction that occurs immediately after allocation.
-  if (![self.terminationStrategy safeShutdownSimulator:simulator withError:&innerError]) {
+  if (![simulator.simDeviceWrapper shutdownWithError:&innerError]) {
     return [[[[[FBSimulatorError
       describeFormat:@"Could not get newly-created simulator into a shutdown state"]
       inSimulator:simulator]
@@ -468,7 +468,7 @@
         failBool:error];
     }
     [self.logger.debug logFormat:@"Shutting down Simulator after erase %@", simulator.udid];
-    if (![self.terminationStrategy safeShutdownSimulator:simulator withError:&innerError]) {
+    if (![simulator.simDeviceWrapper shutdownWithError:&innerError]) {
       return [FBSimulatorError failBoolWithError:innerError errorOut:error];
     }
   }

--- a/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.h
+++ b/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.h
@@ -33,7 +33,7 @@
 /**
  Kills the provided Simulators.
  This call ensures that all of the Simulators:
- 1) Have any relevant Simulator.app process killed
+ 1) Have any relevant Simulator.app process killed (if any applicable Simulator.app process is found).
  2) Have the appropriate SimDevice state at 'Shutdown'
 
  @param simulators the Simulators to Kill.
@@ -41,16 +41,6 @@
  @return an array of the Simulators that this were killed if successful, nil otherwise.
  */
 - (NSArray *)killSimulators:(NSArray *)simulators withError:(NSError **)error;
-
-/**
- It's possible a Simulator is in a non-'Shutdown' state, without an associated Simulator process.
- These Simulators will be Shutdown to ensure that CoreSimulator is in a known-consistent state.
-
- @param simulators the Simulators to Kill.
- @param error an error out if any error occured.
- @returns an array of the Simulators that this were killed if successful, nil otherwise.
- */
-- (NSArray *)ensureConsistencyForSimulators:(NSArray *)simulators withError:(NSError **)error;
 
 /**
  Kills all of the Simulators that are not launched by `FBSimulatorControl`.
@@ -65,14 +55,5 @@
  @return an YES if successful, nil otherwise.
  */
 - (BOOL)killSpuriousSimulatorsWithError:(NSError **)error;
-
-/**
- Kills all of the 'com.apple.CoreSimulatorService' processes that are not used by the current `FBSimulatorControl` configuration.
- Running multiple versions of the Service on the same machine can lead to instability such as Simulator statuses not updating.
-
- @param error an error out if any error occured.
- @return an YES if successful, nil otherwise.
- */
-- (BOOL)killSpuriousCoreSimulatorServicesWithError:(NSError **)error;
 
 @end

--- a/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.h
+++ b/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.h
@@ -43,20 +43,6 @@
 - (NSArray *)killSimulators:(NSArray *)simulators withError:(NSError **)error;
 
 /**
- 'Shutting Down' a Simulator can be a little hairier than just calling 'shutdown'.
- This method of shutting down takes into account a variety of error states and attempts to recover from them.
-
- Note that 'Shutting Down' a Simulator is different to 'terminating' or 'killing'.
- Killing a Simulator will kill the Simulator.app process.
- When 'killing' a Simulator is expected that the process will termitate and some time later the state will update to 'Shutdown'.
-
- @param simulator the Simulator to safe shutdown.
- @param error a descriptive error for any error that occurred.
- @return YES if successful, NO otherwise.
- */
-- (BOOL)safeShutdownSimulator:(FBSimulator *)simulator withError:(NSError **)error;
-
-/**
  It's possible a Simulator is in a non-'Shutdown' state, without an associated Simulator process.
  These Simulators will be Shutdown to ensure that CoreSimulator is in a known-consistent state.
 

--- a/FBSimulatorControl/Utility/FBSimDeviceWrapper.h
+++ b/FBSimulatorControl/Utility/FBSimDeviceWrapper.h
@@ -16,7 +16,9 @@
 @class SimDevice;
 
 /**
- Augments SimDevice with Process Info and the ability for a custom timeout.
+ Mirrors the Method Signatures in SimDevice. Augmenting with:
+ - More informative return values.
+ - Implementations that are more resiliant to failure in CoreSimulator.
  */
 @interface FBSimDeviceWrapper : NSObject
 
@@ -29,6 +31,26 @@
  @return a new SimDevice wrapper.
  */
 + (instancetype)withSimulator:(FBSimulator *)simulator configuration:(FBSimulatorControlConfiguration *)configuration processQuery:(FBProcessQuery *)processQuery;
+
+/**
+ 'Shutting Down' a Simulator can be a little hairier than just calling '-[SimDevice shutdownWithError:]'.
+ This method of shutting down takes into account a variety of error states and attempts to recover from them.
+
+ Note that 'Shutting Down' a Simulator is different to 'terminating' or 'killing':
+ - Killing a Simulator will kill the Simulator.app process.
+ - Killing the Simulator.app process will soon-after get the SimDevice into a 'Shutdown' state in CoreSimulator.
+ - This will take a number of seconds and represents an inconsistent state for the Simulator.
+ - Calling Shutdown on a Simulator without terminating the Simulator.app process first will result in a 'Zombie' Simulator.
+ - A 'Zombie' Simulator.app is a Simulator that isn't backed by a running SimDevice in CoreSimulator.
+
+ Therefore this method should be called if:
+ - A Simulator has no corresponding 'Simulator.app'. This is the case if `-[SimDevice bootWithOptions:error]` has been called directly.
+ - After Simulator's corresponding 'Simulator.app' has been killed.
+
+ @param error a descriptive error for any error that occurred.
+ @return YES if successful, NO otherwise.
+ */
+- (BOOL)shutdownWithError:(NSError **)error;
 
 /**
  Boots an Application on the Simulator.


### PR DESCRIPTION
Given that it will soon be possible to boot Simulators (and get a framebuffer #150) without a `Simulator.app` process, it's important that  `FBSimulatorTerminationStrategy` can account for this. 

This change improves things in this regard:
1) Makes `FBSimulatorTerminationStrategy` a bit simpler and easier to comprehend
2) Documentation
3) Doesn't couple Application Termination to the `Simulator.app`, processes that are applications can get use `NSWorkspace` termination for free.
4) Fallback behaviour for `NSWorkspace` termination.
5) Separating the concerns of 'killing the Simulator.app' process vs. 'shutting down a Simulator'. This will be important in #150 as getting `CoreSimulator` into a stable state on launch may not require killing `Simulator.app` processes.