### PR TITLE
Use NSWorkspace API for Launching Simulator Applications

### DIFF
--- a/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration.h
@@ -19,6 +19,7 @@ typedef NS_OPTIONS(NSUInteger, FBSimulatorLaunchOptions) {
   FBSimulatorLaunchOptionsEnableDirectLaunch = 1 << 0, /** Launches Simulators directly with a Framebuffer instead of with Simulator.app */
   FBSimulatorLaunchOptionsRecordVideo = 1 << 1, /** Records the Framebuffer to a video */
   FBSimulatorLaunchOptionsShowDebugWindow = 1 << 2, /** Relays the Simulator Framebuffer to a window */
+  FBSimulatorLaunchOptionsUseNSWorkspace = 1 << 4, /** Uses -[NSWorkspace launchApplicationAtURL:options:configuration::error:] to launch Simulator.app */
 };
 
 /**


### PR DESCRIPTION
`NSWorkspace` provides a very nice API for launching Applications, and will even fit our requirements of:
- Providing launch arguments
- Providing launch environment
- Always launching a new Application instance, even if one or more is already running.

Weaning ourselves of `FBTask` is a good idea in general since It's another thing to go wrong™️. We'll get better error messaging from the `NSWorkspace` API. Additionally, the work for `fbsimctl` to ensure that the `Simulator.app` process lifetime is not dictated by the lifetime of the containing `FBSimulatorControl` process means that `FBSimulatorTerminationStrategy` is the most suitable place for knowledge for how to terminate an application, rather than a subprocess.