### PR TITLE
Update Launch Configs with Environment Variables

### DIFF
--- a/fbsimctl/FBSimulatorControlKit/Sources/Environment.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Environment.swift
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import Foundation
+import FBSimulatorControl
+
+let EnvironmentPrefix = "FBSIMCTL_CHILD_"
+
+public extension Command {
+  func appendEnvironment(environment: [String : String]) -> Command {
+    switch self {
+    case .Perform(let config, let action):
+      return .Perform(config, action.map { $0.appendEnvironment(environment) })
+    default:
+      return self
+    }
+  }
+}
+
+public extension Action {
+  func appendEnvironment(environment: [String : String]) -> Action {
+    return Action(
+      interaction: self.interaction.appendEnvironment(environment),
+      query: self.query,
+      format: self.format
+    )
+  }
+}
+
+public extension Interaction {
+  func appendEnvironment(environment: [String : String]) -> Interaction {
+    switch self {
+    case .Launch(let configuration):
+      return .Launch(
+        configuration.withEnvironmentAdditions(
+          Interaction.subprocessEnvironment(environment)
+        )
+      )
+    default:
+      return self
+    }
+  }
+
+  private static func subprocessEnvironment(environment: [String : String]) -> [String : String] {
+    var additions: [String : String] = [:]
+    for (key, value) in environment {
+      if !key.hasPrefix(EnvironmentPrefix) {
+        continue
+      }
+      additions[key.stringByReplacingOccurrencesOfString(EnvironmentPrefix, withString: "")] = value
+    }
+    return additions
+  }
+}

--- a/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
@@ -11,10 +11,10 @@ import Foundation
 import FBSimulatorControl
 
 public extension Command {
-  public static func fromArguments(arguments: [String]) -> Command {
+  public static func fromArguments(arguments: [String], environment: [String : String]) -> Command {
     do {
       let (_, command) = try Command.parser().parse(arguments)
-      return command
+      return command.appendEnvironment(environment)
     } catch let error as ParseError {
       print("Failed to Parse Command \(error)")
       return Command.Help(nil)

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/EnvironmentTests.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/EnvironmentTests.swift
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import XCTest
+import FBSimulatorControl
+@testable import FBSimulatorControlKit
+
+class EnvironmentTests : XCTestCase {
+  func testAppendsEnvironmentToLaunchConfiguration() {
+    let environment = [
+      "FBSIMCTL_CHILD_FOO" : "BAR",
+      "PATH" : "IGNORE",
+      "FBSIMCTL_CHILD_BING" : "BONG",
+    ]
+    let launchConfig = FBApplicationLaunchConfiguration(application: Fixtures.application(), arguments: [], environment: [:])
+    let actual = Interaction.Launch(launchConfig).appendEnvironment(environment)
+    let expteced  = Interaction.Launch(launchConfig.withEnvironmentAdditions([
+      "FOO" : "BAR",
+      "BING" : "BONG",
+    ]))
+    XCTAssertEqual(expteced, actual)
+  }
+}

--- a/fbsimctl/fbsimctl.xcodeproj/project.pbxproj
+++ b/fbsimctl/fbsimctl.xcodeproj/project.pbxproj
@@ -42,6 +42,9 @@
 		AA6085DA1C287E02009B500E /* SignalHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B7F671C2867EE0038C6A5 /* SignalHandler.swift */; };
 		AA6085DB1C287E02009B500E /* SocketRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B7F681C2867EE0038C6A5 /* SocketRelay.swift */; };
 		AA6085DC1C287E02009B500E /* StdIORelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B7F691C2867EE0038C6A5 /* StdIORelay.swift */; };
+		AAA27E721C478F4C00C9EC28 /* EnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA27E711C478F4C00C9EC28 /* EnvironmentTests.swift */; };
+		AACF9F531C46E5C100B17E82 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACF9F521C46E5C100B17E82 /* Environment.swift */; };
+		AACF9F541C46E85800B17E82 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACF9F521C46E5C100B17E82 /* Environment.swift */; };
 		AAE35AC51C2865C10073CC70 /* FBSimulatorControlKit.h in Headers */ = {isa = PBXBuildFile; fileRef = AAE35AC41C2865C10073CC70 /* FBSimulatorControlKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AAE35ACC1C2865C10073CC70 /* FBSimulatorControlKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAE35AC21C2865C10073CC70 /* FBSimulatorControlKit.framework */; };
 		AAF2D34E1C32EA4D00434516 /* Writer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF2D34D1C32EA4D00434516 /* Writer.swift */; };
@@ -93,6 +96,8 @@
 		AA6085BF1C287B36009B500E /* fbsimctl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fbsimctl.h; sourceTree = "<group>"; };
 		AA93B7B01BE8351000CF6A56 /* fbsimctl */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = fbsimctl; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA93B7C91BE8361800CF6A56 /* FBSimulatorControl.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = FBSimulatorControl.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AAA27E711C478F4C00C9EC28 /* EnvironmentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnvironmentTests.swift; sourceTree = "<group>"; };
+		AACF9F521C46E5C100B17E82 /* Environment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		AAE35A7C1C2863EB0073CC70 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		AAE35AC21C2865C10073CC70 /* FBSimulatorControlKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FBSimulatorControlKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AAE35AC41C2865C10073CC70 /* FBSimulatorControlKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBSimulatorControlKit.h; sourceTree = "<group>"; };
@@ -141,6 +146,7 @@
 				AA1B7F5F1C2867EE0038C6A5 /* Constants.h */,
 				AA1B7F601C2867EE0038C6A5 /* Constants.m */,
 				AA3ADDB71C2B0B2D004E4FA9 /* Defaults.swift */,
+				AACF9F521C46E5C100B17E82 /* Environment.swift */,
 				AA1B7F611C2867EE0038C6A5 /* Help.swift */,
 				AA1B7F621C2867EE0038C6A5 /* LineBuffer.swift */,
 				AA1B7F641C2867EE0038C6A5 /* Parser.swift */,
@@ -167,6 +173,7 @@
 			isa = PBXGroup;
 			children = (
 				AA2AFD721C29412C000123BA /* CommandParsersTests.swift */,
+				AAA27E711C478F4C00C9EC28 /* EnvironmentTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -368,6 +375,7 @@
 				AA3ADDB91C2B19A4004E4FA9 /* Defaults.swift in Sources */,
 				AA6085DC1C287E02009B500E /* StdIORelay.swift in Sources */,
 				AA6085CF1C287DBD009B500E /* main.swift in Sources */,
+				AACF9F541C46E85800B17E82 /* Environment.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -376,6 +384,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA1B7F711C2867EE0038C6A5 /* LineBuffer.swift in Sources */,
+				AACF9F531C46E5C100B17E82 /* Environment.swift in Sources */,
 				AA3ADDB81C2B0B2D004E4FA9 /* Defaults.swift in Sources */,
 				AA1B7F781C2867EE0038C6A5 /* StdIORelay.swift in Sources */,
 				AA1B7F6F1C2867EE0038C6A5 /* Constants.m in Sources */,
@@ -398,6 +407,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA2AFD731C29412C000123BA /* CommandParsersTests.swift in Sources */,
+				AAA27E721C478F4C00C9EC28 /* EnvironmentTests.swift in Sources */,
 				AA2AFD751C294158000123BA /* TestHelpers.swift in Sources */,
 				AAF6DC801C466E7600C7E1E2 /* Fixtures.swift in Sources */,
 			);

--- a/fbsimctl/fbsimctl/main.swift
+++ b/fbsimctl/fbsimctl/main.swift
@@ -10,9 +10,12 @@
 import Foundation
 import FBSimulatorControl
 
-let argumentSet = Set(NSProcessInfo.processInfo().arguments)
+let arguments = NSProcessInfo.processInfo().arguments.dropFirst(1)
+let argumentSet = Set(arguments)
 FBSimulatorControlGlobalConfiguration.setDebugLoggingEnabled(argumentSet.contains(Configuration.DEBUG_LOGGING_FLAG))
 
+let environment = NSProcessInfo.processInfo().environment
+
 Command
-  .fromArguments(Array(NSProcessInfo.processInfo().arguments.dropFirst(1)))
+  .fromArguments(Array(NSProcessInfo.processInfo().arguments.dropFirst(1)), environment: environment)
   .runFromCLI()


### PR DESCRIPTION
Apes `simctl` with it's `SIMCTL_CHILD`. Instead we use `FBSIMCTL_CHILD`