### PR TITLE
Add Termination status to Process Diagnostics

### DIFF
--- a/FBSimulatorControl/Events/FBSimulatorHistoryGenerator.m
+++ b/FBSimulatorControl/Events/FBSimulatorHistoryGenerator.m
@@ -146,6 +146,7 @@
 - (void)agentDidTerminate:(FBProcessInfo *)agentProcess expected:(BOOL)expected
 {
   [self processTerminated:agentProcess];
+  [self update:agentProcess withProcessDiagnosticNamed:FBSimulatorHistoryDiagnosticNameTerminationStatus value:@(expected)];
 }
 
 - (void)applicationDidLaunch:(FBApplicationLaunchConfiguration *)launchConfig didStart:(FBProcessInfo *)applicationProcess stdOut:(NSFileHandle *)stdOut stdErr:(NSFileHandle *)stdErr
@@ -156,6 +157,7 @@
 - (void)applicationDidTerminate:(FBProcessInfo *)applicationProcess expected:(BOOL)expected
 {
   [self processTerminated:applicationProcess];
+  [self update:applicationProcess withProcessDiagnosticNamed:FBSimulatorHistoryDiagnosticNameTerminationStatus value:@(expected)];
 }
 
 - (void)diagnosticInformationAvailable:(NSString *)name process:(FBProcessInfo *)process value:(id<NSCopying, NSCoding>)value

--- a/FBSimulatorControl/Model/FBSimulatorHistory+Queries.h
+++ b/FBSimulatorControl/Model/FBSimulatorHistory+Queries.h
@@ -139,6 +139,14 @@
 - (FBProcessInfo *)runningProcessForApplication:(FBSimulatorApplication *)application;
 
 /**
+ Returns a mapping of Process Identifier to Termination Status.
+ The Termination status is @YES if the Termination was expected, @NO otherwise.
+
+ @return a NSDictionary<FBProcessInfo *, NSNumber *> of Process Info to Termination status.
+ */
+- (NSDictionary *)processTerminationStatuses;
+
+/**
  Finds the first diagnostic for the provided name, matching the application.
  Reaches into previous states in order to find Diagnostics for Applications that have been terminated.
 

--- a/FBSimulatorControl/Model/FBSimulatorHistory+Queries.m
+++ b/FBSimulatorControl/Model/FBSimulatorHistory+Queries.m
@@ -192,6 +192,21 @@
   return recursive ? [self.previousState runningProcessForApplication:application recursive:recursive] : nil;
 }
 
+- (NSDictionary *)processTerminationStatuses
+{
+  NSDictionary *processDiagnostics = self.processDiagnostics;
+  NSMutableDictionary *statuses = [NSMutableDictionary dictionary];
+  for (FBProcessInfo *process in processDiagnostics) {
+    NSDictionary *diagnostics = processDiagnostics[process];
+    NSNumber *terminationStatus = diagnostics[FBSimulatorHistoryDiagnosticNameTerminationStatus];
+    if (![terminationStatus isKindOfClass:NSNumber.class]) {
+      continue;
+    }
+    statuses[process] = terminationStatus;
+  }
+  return [statuses copy];
+}
+
 - (instancetype)firstSessionState
 {
   if (self.previousState == nil) {

--- a/FBSimulatorControl/Model/FBSimulatorHistory.h
+++ b/FBSimulatorControl/Model/FBSimulatorHistory.h
@@ -17,6 +17,11 @@
 @class FBSimulatorSession;
 
 /**
+ A Diagnostic key for the Termination Status.
+ */
+extern NSString *const FBSimulatorHistoryDiagnosticNameTerminationStatus;
+
+/**
  A value representing a history of events that have occurred for a Simulator.
  Can be serialized for reading across host processes.
  */

--- a/FBSimulatorControl/Model/FBSimulatorHistory.m
+++ b/FBSimulatorControl/Model/FBSimulatorHistory.m
@@ -16,6 +16,8 @@
 #import "FBSimulatorApplication.h"
 #import "FBSimulatorSession.h"
 
+NSString *const FBSimulatorHistoryDiagnosticNameTerminationStatus = @"termination_status";
+
 @implementation FBSimulatorHistory
 
 - (instancetype)init


### PR DESCRIPTION
Being able to interrogate the history of process termination without the need for notification callbacks can be pretty handy, so `FBSimulatorHistoryGenerator` now records this in the diagnostics dictionary.