### PR TITLE
Move Interaction to the end of the Action

### DIFF
--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -290,11 +290,11 @@ extension Action : Parsable {
   public static func parser() -> Parser<Action> {
     return Parser
       .ofThreeSequenced(
-        Interaction.parser(),
         Query.parser().fallback(Query.defaultValue()),
-        Format.parser().fallback(Format.defaultValue())
+        Format.parser().fallback(Format.defaultValue()),
+        Interaction.parser()
       )
-      .fmap { (interaction, query, format) in
+      .fmap { (query, format, interaction) in
         return Action(interaction: interaction, query: query, format: format)
       }
   }

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
@@ -233,89 +233,67 @@ class InteractionParserTests : XCTestCase {
 
 class ActionParserTests : XCTestCase {
   func testParsesList() {
-    self.assertParsesAll(Action.parser(), [
-      (["list"], Action(interaction: .List, query: Query.defaultValue(), format: Format.defaultValue())),
-      (["list", "--state=booted"], Action(interaction: .List, query: Query.State([.Booted]), format: Format.defaultValue())),
-      (["list", "--name"], Action(interaction: .List, query: Query.defaultValue(), format: Format.Name)),
-      (["list", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139", "--os"], Action(interaction: .List, query: Query.UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]), format: Format.OSVersion)),
-      (["list", "--state=booted", "iPhone 5", "--device-name", "--os"], Action(interaction: .List, query: Query.And([.State([.Booted]), .Configured([FBSimulatorConfiguration.iPhone5()])]), format: Format.Compound([.DeviceName, .OSVersion])))
-    ])
+    self.assertWithDefaultActions(Interaction.List, suffix: ["list"])
   }
 
   func testParsesBoot() {
-    self.assertParsesAll(Action.parser(), [
-      (["boot"], Action(interaction: .Boot, query: Query.defaultValue(), format: Format.defaultValue())),
-      (["boot", "iPad 2"], Action(interaction: .Boot, query: .Configured([FBSimulatorConfiguration.iPad2()]), format: Format.defaultValue())),
-      (["boot", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Action(interaction: .Boot, query: .UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]), format: Format.defaultValue())),
-      (["boot", "iPhone 5", "--state=shutdown", "iPhone 6"], Action(interaction: .Boot, query: .And([.Configured([FBSimulatorConfiguration.iPhone5(), FBSimulatorConfiguration.iPhone6()]), .State([.Shutdown])]), format: Format.defaultValue()))
-    ])
+    self.assertWithDefaultActions(Interaction.Boot, suffix: ["boot"])
   }
 
   func testParsesInstall() {
     let interaction = Interaction.Install(Fixtures.application())
-    let prefix: [String] = ["install", Fixtures.application().path]
-
-    self.assertParsesAll(Action.parser(), [
-      (prefix, Action(interaction: interaction, query: Query.defaultValue(), format: Format.defaultValue())),
-      (prefix + ["iPad 2"], Action(interaction: interaction, query: .Configured([FBSimulatorConfiguration.iPad2()]), format: Format.defaultValue())),
-      (prefix + ["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Action(interaction: interaction, query: .UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]), format: Format.defaultValue())),
-      (prefix + ["iPhone 5", "--state=shutdown", "iPhone 6"], Action(interaction: interaction, query: .And([.Configured([FBSimulatorConfiguration.iPhone5(), FBSimulatorConfiguration.iPhone6()]), .State([.Shutdown])]), format: Format.defaultValue())),
-    ])
+    let suffix: [String] = ["install", Fixtures.application().path]
+    self.assertWithDefaultActions(interaction, suffix: suffix)
   }
 
   func testParsesAppLaunch() {
     let interaction = Interaction.Launch(FBApplicationLaunchConfiguration(application: Fixtures.application(), arguments: [], environment: [:]))
-    let prefix: [String] = ["launch", Fixtures.application().path]
-
-    self.assertParsesAll(Action.parser(), [
-      (prefix, Action(interaction: interaction, query: Query.defaultValue(), format: Format.defaultValue())),
-      (prefix + ["iPad 2"], Action(interaction: interaction, query: .Configured([FBSimulatorConfiguration.iPad2()]), format: Format.defaultValue())),
-      (prefix + ["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Action(interaction: interaction, query: .UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]), format: Format.defaultValue())),
-      (prefix + ["iPhone 5", "--state=shutdown", "iPhone 6"], Action(interaction: interaction, query: .And([.Configured([FBSimulatorConfiguration.iPhone5(), FBSimulatorConfiguration.iPhone6()]), .State([.Shutdown])]), format: Format.defaultValue())),
-    ])
+    let suffix: [String] = ["launch", Fixtures.application().path]
+    self.assertWithDefaultActions(interaction, suffix: suffix)
   }
 
   func testParsesAgentLaunch() {
     let interaction = Interaction.Launch(FBAgentLaunchConfiguration(binary: Fixtures.binary(), arguments: [], environment: [:]))
-    let prefix: [String] = ["launch", Fixtures.binary().path]
-
-    self.assertParsesAll(Action.parser(), [
-      (prefix, Action(interaction: interaction, query: Query.defaultValue(), format: Format.defaultValue())),
-      (prefix + ["iPad 2"], Action(interaction: interaction, query: .Configured([FBSimulatorConfiguration.iPad2()]), format: Format.defaultValue())),
-      (prefix + ["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Action(interaction: interaction, query: .UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]), format: Format.defaultValue())),
-      (prefix + ["iPhone 5", "--state=shutdown", "iPhone 6"], Action(interaction: interaction, query: .And([.Configured([FBSimulatorConfiguration.iPhone5(), FBSimulatorConfiguration.iPhone6()]), .State([.Shutdown])]), format: Format.defaultValue())),
-    ])
+    let suffix: [String] = ["launch", Fixtures.binary().path]
+    self.assertWithDefaultActions(interaction, suffix: suffix)
   }
 
   func testParsesShutdown() {
-    self.assertParsesAll(Action.parser(), [
-      (["shutdown"], Action(interaction: .Shutdown, query: Query.defaultValue(), format: Format.defaultValue())),
-      (["shutdown", "iPad 2"], Action(interaction: .Shutdown, query: .Configured([FBSimulatorConfiguration.iPad2()]), format: Format.defaultValue())),
-      (["shutdown", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Action(interaction: .Shutdown, query: .UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]), format: Format.defaultValue())),
-      (["shutdown", "iPhone 5", "--state=shutdown", "iPhone 6"], Action(interaction: .Shutdown, query: .And([.Configured([FBSimulatorConfiguration.iPhone5(), FBSimulatorConfiguration.iPhone6()]), .State([.Shutdown])]), format: Format.defaultValue())),
-    ])
+    self.assertWithDefaultActions(Interaction.Shutdown, suffix: ["shutdown"])
   }
 
   func testParsesDiagnose() {
-    self.assertParsesAll(Action.parser(), [
-      (["diagnose"], Action(interaction: .Diagnose, query: Query.defaultValue(), format: Format.defaultValue())),
-      (["diagnose", "iPad 2"], Action(interaction: .Diagnose, query: .Configured([FBSimulatorConfiguration.iPad2()]), format: Format.defaultValue())),
-      (["diagnose", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Action(interaction: .Diagnose, query: .UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]), format: Format.defaultValue())),
-      (["diagnose", "iPhone 5", "--state=shutdown", "iPhone 6"], Action(interaction: .Diagnose, query: .And([.Configured([FBSimulatorConfiguration.iPhone5(), FBSimulatorConfiguration.iPhone6()]), .State([.Shutdown])]), format: Format.defaultValue())),
+    self.assertWithDefaultActions(Interaction.Diagnose, suffix: ["diagnose"])
+  }
+
+  func assertWithDefaultActions(interaction: Interaction, suffix: [String]) {
+    return self.unzipAndAssert(interaction, suffix: suffix, extras: [
+      ([], Query.defaultValue(), Format.defaultValue()),
+      (["iPad 2"], Query.Configured([FBSimulatorConfiguration.iPad2()]), Format.defaultValue()),
+      (["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Query.UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]), Format.defaultValue()),
+      (["iPhone 5", "--state=shutdown", "iPhone 6"], Query.And([.Configured([FBSimulatorConfiguration.iPhone5(), FBSimulatorConfiguration.iPhone6()]), .State([.Shutdown])]), Format.defaultValue()),
+      (["iPad 2", "--device-name", "--os"], Query.Configured([FBSimulatorConfiguration.iPad2()]), Format.Compound([.DeviceName, .OSVersion]))
     ])
+  }
+
+  func unzipAndAssert(interaction: Interaction, suffix: [String], extras: [([String], Query, Format)]) {
+    let pairs = extras.map { (tokens, query, format) in
+      return (tokens + suffix, Action(interaction: interaction, query: query, format: format))
+    }
+    self.assertParsesAll(Action.parser(), pairs)
   }
 }
 
 class CommandParserTests : XCTestCase {
   func testParsesSingleAction() {
     self.assertParsesAll(Command.parser(), [
-      (["boot", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Command.Perform(Configuration.defaultValue(), [Action(interaction: .Boot, query: .UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]), format: Format.defaultValue())])),
+      (["B8EEA6C4-841B-47E5-92DE-014E0ECD8139", "boot"], Command.Perform(Configuration.defaultValue(), [Action(interaction: .Boot, query: .UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]), format: Format.defaultValue())])),
     ])
   }
 
   func testParsesMultipleActions() {
     self.assertParsesAll(Command.parser(), [
-      (["list", "--state=booted", "boot", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Command.Perform(Configuration.defaultValue(), [
+      (["--state=booted", "list", "B8EEA6C4-841B-47E5-92DE-014E0ECD8139", "boot"], Command.Perform(Configuration.defaultValue(), [
         Action(interaction: .List, query: Query.State([.Booted]), format: Format.defaultValue()),
         Action(interaction: .Boot, query: .UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]), format: Format.defaultValue())
       ])),


### PR DESCRIPTION
Changes the grammar from:
`[interaction] [query] [format]`
To:
`[query] [format] [interaction]`

There's a very good reason for doing this; the `Interaction` can have associated values, and these values may be variadic. This will be important for the `launch` interaction, which should in future be able to take arguments to the launched process after the `launch` command. 

If the `Interact` part was expected to be first in the `Action` then the arguments to the launched process would have to be escaped.