### PR TITLE
Use exit(3) for a return code on success or failure

### DIFF
--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -22,13 +22,14 @@ extension Configuration {
 }
 
 public extension Command {
-  func runFromCLI() -> Void {
+  func runFromCLI() -> Int32 {
     let writer = StdIOWriter()
     switch (BaseRunner(command: self).run(StdIOWriter())) {
+    case .Success:
+      return 0
     case .Failure(let string):
       writer.writeOut(string)
-    default:
-      break
+      return 1
     }
   }
 }

--- a/fbsimctl/fbsimctl/main.swift
+++ b/fbsimctl/fbsimctl/main.swift
@@ -10,14 +10,14 @@
 import Foundation
 import FBSimulatorControl
 
-let arguments = NSProcessInfo.processInfo().arguments.dropFirst(1)
+let arguments = Array(NSProcessInfo.processInfo().arguments.dropFirst(1))
 let argumentSet = Set(arguments)
 FBSimulatorControlGlobalConfiguration.setDebugLoggingEnabled(argumentSet.contains(Flags.DebugLogging))
 
 let environment = NSProcessInfo.processInfo().environment
 
 let returnCode = Command
-  .fromArguments(Array(NSProcessInfo.processInfo().arguments.dropFirst(1)), environment: environment)
+  .fromArguments(arguments, environment: environment)
   .runFromCLI()
 
 exit(returnCode)

--- a/fbsimctl/fbsimctl/main.swift
+++ b/fbsimctl/fbsimctl/main.swift
@@ -16,6 +16,8 @@ FBSimulatorControlGlobalConfiguration.setDebugLoggingEnabled(argumentSet.contain
 
 let environment = NSProcessInfo.processInfo().environment
 
-Command
+let returnCode = Command
   .fromArguments(Array(NSProcessInfo.processInfo().arguments.dropFirst(1)), environment: environment)
   .runFromCLI()
+
+exit(returnCode)


### PR DESCRIPTION
Failing commands should result in a return code.