### PR TITLE
Extract underlying error when executing FBSimDeviceWrapper methods

### DIFF
--- a/FBSimulatorControl/Utility/FBSimDeviceWrapper.m
+++ b/FBSimulatorControl/Utility/FBSimDeviceWrapper.m
@@ -87,22 +87,23 @@
 {
   NSAssert([NSThread isMainThread], @"Must be called from the main thread.");
 
-  NSError *__autoreleasing innerError = nil;
-  NSError *__autoreleasing *innerErrorPointer = &innerError;
+  NSError *innerError = nil;
   NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[self methodSignatureForSelector:@selector(installApplication:withOptions:error:)]];
   [invocation setTarget:self.simulator.device];
   [invocation setSelector:@selector(installApplication:withOptions:error:)];
   [invocation setArgument:&appURL atIndex:2];
   [invocation setArgument:&options atIndex:3];
-  [invocation setArgument:&innerErrorPointer atIndex:4];
-  error = innerErrorPointer;
+  [invocation setArgument:&innerError atIndex:4];
   if (![self runInvocationInBackgroundUntilTimeout:invocation]) {
     return [[FBSimulatorError describe:@"Timed out calling installApplication"] failBool:error];
   }
 
-  BOOL rv;
-  [invocation getReturnValue:&rv];
-  return rv;
+  BOOL returnValue;
+  [invocation getReturnValue:&returnValue];
+  if (!returnValue) {
+    return [FBSimulatorError failBoolWithError:innerError errorOut:error];
+  }
+  return YES;
 }
 
 @end

--- a/FBSimulatorControl/Utility/FBSimDeviceWrapper.m
+++ b/FBSimulatorControl/Utility/FBSimDeviceWrapper.m
@@ -65,21 +65,22 @@
 {
   NSAssert([NSThread isMainThread], @"Must be called from the main thread.");
 
-  NSError *__autoreleasing innerError = nil;
-  NSError *__autoreleasing *innerErrorPointer = &innerError;
+  NSError *innerError = nil;
   NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[self methodSignatureForSelector:@selector(launchApplicationWithID:options:error:)]];
   [invocation setTarget:self.simulator.device];
   [invocation setSelector:@selector(launchApplicationWithID:options:error:)];
   [invocation setArgument:&appID atIndex:2];
   [invocation setArgument:&options atIndex:3];
-  [invocation setArgument:&innerErrorPointer atIndex:4];
-  error = innerErrorPointer;
+  [invocation setArgument:&innerError atIndex:4];
   if (![self runInvocationInBackgroundUntilTimeout:invocation]) {
     return [[FBSimulatorError describe:@"Timed out calling launchApplicationWithID"] fail:error];
   }
 
   pid_t pid;
   [invocation getReturnValue:&pid];
+  if (pid <= 0) {
+    return [FBSimulatorError failWithError:innerError errorOut:error];
+  }
   return [self processInfoForProcessIdentifier:pid error:error];
 }
 


### PR DESCRIPTION
In the `TimeoutResiliance` case for `FBSimDeviceWrapper` we don't do anything with the error from `SimDevice` so the underlying error cause can get missed, this is problematic on Xcode 7.2 which still seems to have issues with `installApplication:`