### PR TITLE
FBApplicationLaunchConfiguration defined in terms of Bundle ID

### DIFF
--- a/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration+Private.h
+++ b/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration+Private.h
@@ -17,15 +17,3 @@
 @property (nonatomic, copy, readwrite) NSString *stdErrPath;
 
 @end
-
-@interface FBApplicationLaunchConfiguration ()
-
-@property (nonatomic, copy, readwrite) FBSimulatorApplication *application;
-
-@end
-
-@interface FBAgentLaunchConfiguration ()
-
-@property (nonatomic, copy, readwrite) FBSimulatorBinary *agentBinary;
-
-@end

--- a/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration.h
@@ -56,7 +56,7 @@
 @interface FBApplicationLaunchConfiguration : FBProcessLaunchConfiguration
 
 /**
- Creates and returns a new Configuration with the provided parameters
+ Creates and returns a new Configuration with the provided parameters.
 
  @param application the Application to Launch.
  @param arguments an NSArray<NSString *> of arguments to the process.
@@ -66,7 +66,7 @@
 + (instancetype)configurationWithApplication:(FBSimulatorApplication *)application arguments:(NSArray *)arguments environment:(NSDictionary *)environment;
 
 /**
- Creates and returns a new Configuration with the provided parameters
+ Creates and returns a new Configuration with the provided parameters.
 
  @param application the Application to Launch.
  @param arguments an NSArray<NSString *> of arguments to the process.
@@ -76,6 +76,28 @@
  @returns a new Configuration Object with the arguments applied.
  */
 + (instancetype)configurationWithApplication:(FBSimulatorApplication *)application arguments:(NSArray *)arguments environment:(NSDictionary *)environment stdOutPath:(NSString *)stdOutPath stdErrPath:(NSString *)stdErrPath;
+
+/**
+ Creates and returns a new Configuration with the provided parameters.
+
+ @param bundleID the Bundle ID of the App to Launch.
+ @param arguments an NSArray<NSString *> of arguments to the process.
+ @param environment a NSDictionary<NSString *, NSString *> of the Environment of the launched Application process.
+ @returns a new Configuration Object with the arguments applied.
+ */
++ (instancetype)configurationWithBundleID:(NSString *)bundleID arguments:(NSArray *)arguments environment:(NSDictionary *)environment;
+
+/**
+ Creates and returns a new Configuration with the provided parameters.
+
+ @param bundleID the Bundle ID of the App to Launch.
+ @param arguments an NSArray<NSString *> of arguments to the process.
+ @param environment a NSDictionary<NSString *, NSString *> of the Environment of the launched Application process.
+ @param stdOutPath the file path where the stderr of the launched process should be written. May be nil.
+ @param stdErrPath The file path where the stderr of the launched process should be written. May be nil.
+ @returns a new Configuration Object with the arguments applied.
+ */
++ (instancetype)configurationWithBundleID:(NSString *)bundleID arguments:(NSArray *)arguments environment:(NSDictionary *)environment stdOutPath:(NSString *)stdOutPath stdErrPath:(NSString *)stdErrPath;
 
 /**
  The Bundle ID of the the Application to Launch.

--- a/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration.h
@@ -29,11 +29,6 @@
 @property (nonatomic, copy, readonly) NSDictionary *environment;
 
 /**
- An NSString * representing the path to the launched binary.
- */
-@property (nonatomic, copy, readonly) NSString *launchPath;
-
-/**
  The file path where the stdout of the launched process should be written.
  */
 @property (nonatomic, copy, readonly) NSString *stdOutPath;
@@ -83,9 +78,9 @@
 + (instancetype)configurationWithApplication:(FBSimulatorApplication *)application arguments:(NSArray *)arguments environment:(NSDictionary *)environment stdOutPath:(NSString *)stdOutPath stdErrPath:(NSString *)stdErrPath;
 
 /**
- The Application to Launch.
+ The Bundle ID of the the Application to Launch.
  */
-@property (nonatomic, copy, readonly) FBSimulatorApplication *application;
+@property (nonatomic, copy, readonly) NSString *bundleID;
 
 @end
 

--- a/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration.m
@@ -120,11 +120,21 @@
 
 + (instancetype)configurationWithApplication:(FBSimulatorApplication *)application arguments:(NSArray *)arguments environment:(NSDictionary *)environment stdOutPath:(NSString *)stdOutPath stdErrPath:(NSString *)stdErrPath
 {
-  if (!application || !arguments || !environment) {
+  return [self configurationWithBundleID:application.bundleID arguments:arguments environment:environment stdOutPath:stdOutPath stdErrPath:stdErrPath];
+}
+
++ (instancetype)configurationWithBundleID:(NSString *)bundleID arguments:(NSArray *)arguments environment:(NSDictionary *)environment
+{
+  return [self configurationWithBundleID:bundleID arguments:arguments environment:environment stdOutPath:nil stdErrPath:nil];
+}
+
++ (instancetype)configurationWithBundleID:(NSString *)bundleID arguments:(NSArray *)arguments environment:(NSDictionary *)environment stdOutPath:(NSString *)stdOutPath stdErrPath:(NSString *)stdErrPath
+{
+  if (!bundleID || !arguments || !environment) {
     return nil;
   }
 
-  return [[self alloc] initWithBundleID:application.bundleID arguments:arguments environment:environment stdOutPath:stdOutPath stdErrPath:stdErrPath];
+  return [[self alloc] initWithBundleID:bundleID arguments:arguments environment:environment stdOutPath:stdOutPath stdErrPath:stdErrPath];
 }
 
 - (instancetype)initWithBundleID:(NSString *)bundleID arguments:(NSArray *)arguments environment:(NSDictionary *)environment stdOutPath:(NSString *)stdOutPath stdErrPath:(NSString *)stdErrPath

--- a/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration.m
@@ -207,7 +207,7 @@
 
 - (NSUInteger)hash
 {
-  return [super hash] | self.bundleID.hash;
+  return [super hash] ^ self.bundleID.hash;
 }
 
 - (BOOL)isEqual:(FBApplicationLaunchConfiguration *)object

--- a/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration.m
@@ -124,35 +124,30 @@
     return nil;
   }
 
-  return [[self alloc] initWithApplication:application arguments:arguments environment:environment stdOutPath:stdOutPath stdErrPath:stdErrPath];
+  return [[self alloc] initWithBundleID:application.bundleID arguments:arguments environment:environment stdOutPath:stdOutPath stdErrPath:stdErrPath];
 }
 
-- (instancetype)initWithApplication:(FBSimulatorApplication *)application arguments:(NSArray *)arguments environment:(NSDictionary *)environment stdOutPath:(NSString *)stdOutPath stdErrPath:(NSString *)stdErrPath
+- (instancetype)initWithBundleID:(NSString *)bundleID arguments:(NSArray *)arguments environment:(NSDictionary *)environment stdOutPath:(NSString *)stdOutPath stdErrPath:(NSString *)stdErrPath
 {
-  NSParameterAssert(application);
+  NSParameterAssert(bundleID);
 
   self = [super initWithArguments:arguments environment:environment stdOutPath:stdOutPath stdErrPath:stdErrPath];
   if (!self) {
     return nil;
   }
 
-  _application = application;
+  _bundleID = bundleID;
 
   return self;
 }
 
 #pragma mark Abstract Methods
 
-- (NSString *)launchPath
-{
-  return self.application.binary.path;
-}
-
 - (NSString *)debugDescription
 {
   return [NSString stringWithFormat:
-    @"App Launch | Application %@ | Arguments %@ | Environment %@ | StdOut %@ | StdErr %@",
-    self.application,
+    @"App Launch %@ | Arguments %@ | Environment %@ | StdOut %@ | StdErr %@",
+    self.bundleID,
     self.arguments,
     self.environment,
     self.stdOutPath,
@@ -162,7 +157,7 @@
 
 - (NSString *)shortDescription
 {
-  return [NSString stringWithFormat:@"App Launch %@", self.application.name];
+  return [NSString stringWithFormat:@"App Launch %@", self.bundleID];
 }
 
 #pragma mark NSCopying
@@ -170,7 +165,7 @@
 - (instancetype)copyWithZone:(NSZone *)zone
 {
   return [[self.class alloc]
-    initWithApplication:self.application
+    initWithBundleID:self.bundleID
     arguments:self.arguments
     environment:self.environment
     stdOutPath:self.stdOutPath
@@ -186,7 +181,7 @@
     return nil;
   }
 
-  _application = [coder decodeObjectForKey:NSStringFromSelector(@selector(application))];
+  _bundleID = [coder decodeObjectForKey:NSStringFromSelector(@selector(bundleID))];
 
   return self;
 }
@@ -195,19 +190,20 @@
 {
   [super encodeWithCoder:coder];
 
-  [coder encodeObject:self.application forKey:NSStringFromSelector(@selector(application))];
+  [coder encodeObject:self.bundleID forKey:NSStringFromSelector(@selector(bundleID))];
 }
 
 #pragma mark NSObject
 
 - (NSUInteger)hash
 {
-  return [super hash] | self.application.hash;
+  return [super hash] | self.bundleID.hash;
 }
 
 - (BOOL)isEqual:(FBApplicationLaunchConfiguration *)object
 {
-  return [super isEqual:object] && [self.application isEqual:object.application];
+  return [super isEqual:object] &&
+         [self.bundleID isEqualToString:object.bundleID];
 }
 
 @end

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.h
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.h
@@ -30,22 +30,6 @@
 - (instancetype)launchApplication:(FBApplicationLaunchConfiguration *)appLaunch;
 
 /**
- Unix Signals the Application.
-
- @param signal the unix signo to send.
- @return the reciever, for chaining.
- */
-- (instancetype)signal:(int)signal application:(FBSimulatorApplication *)application;
-
-/**
- Kills the provided Application.
-
- @param application the Application to kill.
- @return the reciever, for chaining.
- */
-- (instancetype)killApplication:(FBSimulatorApplication *)application;
-
-/**
  Relaunches the last-launched Application:
  - If the Application is running, it will be killed first then launched.
  - If the Application has terminated, it will be launched.

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.m
@@ -61,10 +61,10 @@
 
   return [self interactWithBootedSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
     NSError *innerError = nil;
-    FBSimulatorApplication *application = [simulator installedApplicationWithBundleID:appLaunch.application.bundleID error:&innerError];
+    FBSimulatorApplication *application = [simulator installedApplicationWithBundleID:appLaunch.bundleID error:&innerError];
     if (!application) {
       return [[[[FBSimulatorError
-        describeFormat:@"App %@ can't be launched as it isn't installed", appLaunch.application.bundleID]
+        describeFormat:@"App %@ can't be launched as it isn't installed", appLaunch.bundleID]
         causedBy:innerError]
         inSimulator:simulator]
         failBool:error];
@@ -81,7 +81,7 @@
       return [FBSimulatorError failBoolWithError:innerError errorOut:error];
     }
 
-    FBProcessInfo *process = [simulator.simDeviceWrapper launchApplicationWithID:appLaunch.application.bundleID options:options error:&innerError];
+    FBProcessInfo *process = [simulator.simDeviceWrapper launchApplicationWithID:appLaunch.bundleID options:options error:&innerError];
     if (!process) {
       return [[[[FBSimulatorError describeFormat:@"Failed to launch application %@", appLaunch] causedBy:innerError] inSimulator:simulator] failBool:error];
     }

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.m
@@ -117,9 +117,10 @@
     // Relaunch the Application
     NSError *innerError = nil;
     if (![[simulator.interact launchApplication:launchConfig] performInteractionWithError:&innerError]) {
-      return [[[FBSimulatorError
+      return [[[[FBSimulatorError
         describeFormat:@"Failed to re-launch %@", launchConfig]
         inSimulator:simulator]
+        causedBy:innerError]
         failBool:error];
     }
     return YES;

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.m
@@ -21,12 +21,15 @@
 #import "FBSimulator+Private.h"
 #import "FBSimulator.h"
 #import "FBSimulatorApplication.h"
+#import "FBSimulatorControlGlobalConfiguration.h"
 #import "FBSimulatorError.h"
 #import "FBSimulatorEventSink.h"
 #import "FBSimulatorHistory+Queries.h"
 #import "FBSimulatorInteraction+Lifecycle.h"
 #import "FBSimulatorInteraction+Private.h"
+#import "FBSimulatorLaunchCtl.h"
 #import "FBSimulatorPool.h"
+#import "NSRunLoop+SimulatorControlAdditions.h"
 
 @implementation FBSimulatorInteraction (Applications)
 
@@ -139,7 +142,7 @@
     NSError *innerError = nil;
     if (![[simulator.interact killProcess:process] performInteractionWithError:&innerError]) {
       return [[[[FBSimulatorError
-        describeFormat:@"Failed to terminate app  %@", process.shortDescription]
+        describeFormat:@"Failed to terminate app %@", process.shortDescription]
         causedBy:innerError]
         inSimulator:simulator]
         failBool:error];

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.h
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.h
@@ -47,4 +47,21 @@
  */
 - (instancetype)openURL:(NSURL *)url;
 
+/**
+ Sends a signal(3) to the Process, verifying that is is a subprocess of the Simulator.
+
+ @param signo the unix signo to send.
+ @param process the process to send a Signal to.
+ @return the reciever, for chaining.
+ */
+- (instancetype)signal:(int)signo process:(FBProcessInfo *)process;
+
+/**
+ SIGKILL's the provided Process, verifying that is is a subprocess of the Simulator.
+
+ @param process the Process to kill.
+ @return the reciever, for chaining.
+ */
+- (instancetype)killProcess:(FBProcessInfo *)process;
+
 @end

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.m
@@ -190,7 +190,7 @@
 
     // Use FBProcessTerminationStrategy to do the actual process killing.
     NSError *innerError = nil;
-    if (![[FBProcessTerminationStrategy withProcessKilling:simulator.processQuery logger:simulator.logger] killProcess:process error:&innerError]) {
+    if (![[FBProcessTerminationStrategy withProcessKilling:simulator.processQuery signo:signo logger:simulator.logger] killProcess:process error:&innerError]) {
       return [FBSimulatorError failBoolWithError:innerError errorOut:error];
     }
 

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.m
@@ -13,6 +13,7 @@
 
 #import "FBCollectionDescriptions.h"
 #import "FBInteraction+Private.h"
+#import "FBProcessInfo.h"
 #import "FBProcessLaunchConfiguration.h"
 #import "FBProcessQuery+Simulators.h"
 #import "FBSimulator+Helpers.h"
@@ -159,6 +160,48 @@
     }
     return YES;
   }];
+}
+
+- (instancetype)signal:(int)signo process:(FBProcessInfo *)process
+{
+  NSParameterAssert(process);
+
+  return [self process:process interact:^ BOOL (NSError **error, FBSimulator *simulator) {
+    // Confirm that the process has the launchd_sim as a parent process.
+    // The interaction should restrict itself to simulator processes so this is a guard
+    // to ensure that this interaction can't go around killing random processes.
+    pid_t parentProcessIdentifier = [simulator.processQuery parentOf:process.processIdentifier];
+    if (parentProcessIdentifier != simulator.launchdSimProcess.processIdentifier) {
+      return [[FBSimulatorError
+        describeFormat:@"Parent of %@ is not the launchd_sim (%@) it has a pid %d", process.shortDescription, simulator.launchdSimProcess.shortDescription, parentProcessIdentifier]
+        failBool:error];
+    }
+
+    // Notify the eventSink of the process getting killed, before it is killed.
+    // This is done to prevent being marked as an unexpected termination when the
+    // detecting of the process getting killed kicks in.
+    FBProcessLaunchConfiguration *configuration = simulator.history.processLaunchConfigurations[process];
+    if ([configuration isKindOfClass:FBApplicationLaunchConfiguration.class]) {
+      [simulator.eventSink applicationDidTerminate:process expected:YES];
+    } else if ([configuration isKindOfClass:FBAgentLaunchConfiguration.class]) {
+      [simulator.eventSink agentDidTerminate:process expected:YES];
+    }
+
+    int returnCode = kill(process.processIdentifier, signo);
+    if (returnCode != 0) {
+      return [[[FBSimulatorError describeFormat:@"SIGKILL of %@ failed", process] inSimulator:simulator] failBool:error];
+    }
+    if (![simulator.processQuery waitForProcessToDie:process timeout:20]) {
+      return [[[FBSimulatorError describeFormat:@"Termination of process %@ failed in waiting for process to dissappear", process] inSimulator:simulator] failBool:error];
+    }
+
+    return YES;
+  }];
+}
+
+- (instancetype)killProcess:(FBProcessInfo *)process
+{
+  return [self signal:SIGKILL process:process];
 }
 
 @end

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Private.h
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Private.h
@@ -19,6 +19,15 @@
 /**
  Chains an interaction on an process, for the given application.
 
+ @param process the process to interact with.
+ @param block the block to execute with the process.
+ @return the reciever, for chaining.
+ */
+- (instancetype)process:(FBProcessInfo *)process interact:(BOOL (^)(NSError **error, FBSimulator *simulator))block;
+
+/**
+ Chains an interaction on an process, for the given binary.
+
  @param binary the binary to interact with.
  @param block the block to execute with the process.
  @return the reciever, for chaining.

--- a/FBSimulatorControl/Management/FBCoreSimulatorTerminationStrategy.m
+++ b/FBSimulatorControl/Management/FBCoreSimulatorTerminationStrategy.m
@@ -40,7 +40,7 @@
 
   _processQuery = processQuery;
   _logger = logger;
-  _processTerminationStrategy = [FBProcessTerminationStrategy withProcessKilling:processQuery logger:logger];
+  _processTerminationStrategy = [FBProcessTerminationStrategy withProcessKilling:processQuery signo:SIGKILL logger:logger];
 
   return self;
 }

--- a/FBSimulatorControl/Management/FBProcessTerminationStrategy.h
+++ b/FBSimulatorControl/Management/FBProcessTerminationStrategy.h
@@ -22,20 +22,22 @@
  Uses kill(2) to terminate Applications.
 
  @param processQuery the Process Query object to use.
+ @param signo the signal number to use when killing. See signal(3) for more info
  @param logger the logger to use.
  @return a new Process Termination Strategy instance.
  */
-+ (instancetype)withProcessKilling:(FBProcessQuery *)processQuery logger:(id<FBSimulatorLogger>)logger;
++ (instancetype)withProcessKilling:(FBProcessQuery *)processQuery signo:(int)signo logger:(id<FBSimulatorLogger>)logger;
 
 /**
  Uses methods on NSRunningApplication to terminate Applications.
  Uses kill(2) otherwise
 
  @param processQuery the Process Query object to use.
+ @param signo the signal number to use when killing. See signal(3) for more info
  @param logger the logger to use.
  @return a new Process Termination Strategy instance.
  */
-+ (instancetype)withRunningApplicationTermination:(FBProcessQuery *)processQuery logger:(id<FBSimulatorLogger>)logger;;
++ (instancetype)withRunningApplicationTermination:(FBProcessQuery *)processQuery signo:(int)signo logger:(id<FBSimulatorLogger>)logger;;
 
 /**
  Terminates a Process of the provided Process Info.

--- a/FBSimulatorControl/Management/FBProcessTerminationStrategy.m
+++ b/FBSimulatorControl/Management/FBProcessTerminationStrategy.m
@@ -97,7 +97,15 @@
 
 - (BOOL)killProcess:(FBProcessInfo *)process error:(NSError **)error
 {
-  // The kill was successful, all is well.
+  FBProcessInfo *actualProcess = [self.processQuery processInfoFor:process.processIdentifier];
+  if (![actualProcess isEqual:process]) {
+    return [[[FBSimulatorError
+      describeFormat:@"Avoiding killing %@ as it differs from the actual process %@", process.debugDescription, actualProcess.debugDescription]
+      logger:self.logger]
+      failBool:error];
+  }
+
+  // Kill the process with kill(2).
   [self.logger.debug logFormat:@"Killing %@", process.shortDescription];
   if (kill(process.processIdentifier, SIGTERM) == 0) {
     return YES;

--- a/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.m
+++ b/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.m
@@ -53,8 +53,8 @@
 {
   BOOL useKill = (configuration.options & FBSimulatorManagementOptionsUseProcessKilling) == FBSimulatorManagementOptionsUseProcessKilling;
   FBProcessTerminationStrategy *processTerminationStrategy = useKill
-    ? [FBProcessTerminationStrategy withProcessKilling:processQuery logger:logger]
-    : [FBProcessTerminationStrategy withRunningApplicationTermination:processQuery logger:logger];
+    ? [FBProcessTerminationStrategy withProcessKilling:processQuery signo:SIGKILL logger:logger]
+    : [FBProcessTerminationStrategy withRunningApplicationTermination:processQuery signo:SIGKILL logger:logger];
 
   return [[self alloc] initWithConfiguration:configuration processQuery:processQuery processTerminationStrategy:processTerminationStrategy logger:logger];
 

--- a/FBSimulatorControl/Model/FBSimulatorApplication.m
+++ b/FBSimulatorControl/Model/FBSimulatorApplication.m
@@ -360,6 +360,12 @@
 + (instancetype)binaryWithPath:(NSString *)binaryPath error:(NSError **)error;
 {
   NSError *innerError = nil;
+  if (![NSFileManager.defaultManager fileExistsAtPath:binaryPath]) {
+    return [[FBSimulatorError
+      describeFormat:@"Binary does not exist at path %@", binaryPath]
+      fail:error];
+  }
+
   NSSet *archs = [FBBinaryParser architecturesForBinaryAtPath:binaryPath error:&innerError];
   if (archs.count < 1) {
     return [FBSimulatorError failWithError:innerError errorOut:error];

--- a/FBSimulatorControl/Model/FBSimulatorHistory+Queries.m
+++ b/FBSimulatorControl/Model/FBSimulatorHistory+Queries.m
@@ -28,24 +28,6 @@
 
 @end
 
-@implementation FBApplicationLaunchConfiguration (SessionStateQueries)
-
-- (FBSimulatorBinary *)binary
-{
-  return self.application.binary;
-}
-
-@end
-
-@implementation FBAgentLaunchConfiguration (SessionStateQueries)
-
-- (FBSimulatorBinary *)binary
-{
-  return self.agentBinary;
-}
-
-@end
-
 @implementation FBSimulatorHistory (Queries)
 
 - (NSArray *)launchedApplicationProcesses

--- a/FBSimulatorControl/Utility/FBAddVideoPolyfill.m
+++ b/FBSimulatorControl/Utility/FBAddVideoPolyfill.m
@@ -15,7 +15,9 @@
 #import "FBSimulatorApplication.h"
 #import "FBSimulatorControlGlobalConfiguration.h"
 #import "FBSimulatorError.h"
+#import "FBSimulatorHistory+Queries.h"
 #import "FBSimulatorInteraction+Applications.h"
+#import "FBSimulatorInteraction+Lifecycle.h"
 #import "NSRunLoop+SimulatorControlAdditions.h"
 
 @interface FBAddVideoPolyfill ()
@@ -104,8 +106,19 @@
     previousCount:dcimPaths.count
     error:error];
 
-  if (![[simulator.interact killApplication:photosApp] performInteractionWithError:nil]) {
-    return [[[FBSimulatorError describe:@"Couldn't kill MobileSlideShow after uploading videos"] causedBy:innerError] failBool:error];
+  FBProcessInfo *photosAppProcess = simulator.history.lastLaunchedApplicationProcess;
+  if (![photosAppProcess.processName isEqualToString:@"MobileSlideshow"]) {
+    return [[[FBSimulatorError
+      describe:@"Couldn't find MobileSlideShow process after uploading video"]
+      causedBy:innerError]
+      failBool:error];
+  }
+
+  if (![[simulator.interact killProcess:photosAppProcess] performInteractionWithError:nil]) {
+    return [[[FBSimulatorError
+      describe:@"Couldn't kill MobileSlideShow after uploading videos"]
+      causedBy:innerError]
+      failBool:error];
   }
 
   return success;

--- a/FBSimulatorControl/Utility/FBBinaryParser.m
+++ b/FBSimulatorControl/Utility/FBBinaryParser.m
@@ -166,6 +166,9 @@ static inline NSArray *ReadArchs(FILE *file, uint32_t magic)
 + (NSSet *)architecturesForBinaryAtPath:(NSString *)binaryPath error:(NSError **)error
 {
   FILE *file = fopen(binaryPath.UTF8String, "rb");
+  if (file == NULL) {
+    return [[FBSimulatorError describeFormat:@"Could not fopen file at path %@", binaryPath] fail:error];
+  }
 
   // Seek to and read the magic.
   rewind(file);

--- a/FBSimulatorControlTests/Fixtures/FBSimulatorControlFixtures.m
+++ b/FBSimulatorControlTests/Fixtures/FBSimulatorControlFixtures.m
@@ -102,17 +102,16 @@
 {
   return [[FBProcessInfo alloc]
     initWithProcessIdentifier:42
-    launchPath:self.appLaunch1.application.binary.path
+    launchPath:self.tableSearchApplication.binary.path
     arguments:self.appLaunch1.arguments
     environment:self.appLaunch1.environment];
-
 }
 
 - (FBProcessInfo *)processInfo2
 {
   return [[FBProcessInfo alloc]
     initWithProcessIdentifier:20
-    launchPath:self.appLaunch2.application.binary.path
+    launchPath:self.safariApplication.binary.path
     arguments:self.appLaunch2.arguments
     environment:self.appLaunch2.environment];
 }
@@ -121,7 +120,7 @@
 {
   return [[FBProcessInfo alloc]
     initWithProcessIdentifier:30
-    launchPath:self.appLaunch2.application.binary.path
+    launchPath:self.safariApplication.binary.path
     arguments:self.appLaunch2.arguments
     environment:self.appLaunch2.environment];
 }

--- a/FBSimulatorControlTests/Tests/FBProcessLaunchConfigurationTests.m
+++ b/FBSimulatorControlTests/Tests/FBProcessLaunchConfigurationTests.m
@@ -24,7 +24,7 @@
   FBApplicationLaunchConfiguration *appLaunch = self.appLaunch1;
   FBApplicationLaunchConfiguration *appLaunchCopy = [appLaunch copy];
 
-  XCTAssertEqualObjects(appLaunch.application, appLaunchCopy.application);
+  XCTAssertEqualObjects(appLaunch.bundleID, appLaunchCopy.bundleID);
   XCTAssertEqualObjects(appLaunch.arguments, appLaunchCopy.arguments);
   XCTAssertEqualObjects(appLaunch.environment, appLaunchCopy.environment);
   XCTAssertEqualObjects(appLaunch, appLaunchCopy);
@@ -44,7 +44,7 @@
   NSData *appLaunchData = [NSKeyedArchiver archivedDataWithRootObject:appLaunch];
   FBApplicationLaunchConfiguration *appLaunchUnarchived = [NSKeyedUnarchiver unarchiveObjectWithData:appLaunchData];
 
-  XCTAssertEqualObjects(appLaunch.application, appLaunchUnarchived.application);
+  XCTAssertEqualObjects(appLaunch.bundleID, appLaunchUnarchived.bundleID);
   XCTAssertEqualObjects(appLaunch.arguments, appLaunchUnarchived.arguments);
   XCTAssertEqualObjects(appLaunch.environment, appLaunchUnarchived.environment);
   XCTAssertEqualObjects(appLaunch, appLaunchUnarchived);

--- a/FBSimulatorControlTests/Tests/FBSimulatorAutomaticUpdatingTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorAutomaticUpdatingTests.m
@@ -70,11 +70,10 @@
   }
 
   FBSimulatorSession *session = [self createSession];
-  FBApplicationLaunchConfiguration *appLaunch = self.safariAppLaunch;
 
-  [self assertInteractionSuccessful:[session.interact.bootSimulator launchApplication:appLaunch]];
+  [self assertInteractionSuccessful:[session.interact.bootSimulator launchApplication:self.safariAppLaunch]];
 
-  FBProcessInfo *process = [session.history runningProcessForApplication:appLaunch.application];
+  FBProcessInfo *process = [session.history runningProcessForApplication:self.safariApplication];
   XCTAssertNotNil(process);
   if (!process) {
     // Need to guard against continuing the test in case the PID is 0 or -1 to avoid nuking the machine.
@@ -86,7 +85,7 @@
 
   NSNotification *actual = [self.assert consumeNotification:FBSimulatorApplicationProcessDidTerminateNotification timeout:20];
   XCTAssertFalse([actual.userInfo[FBSimulatorExpectedTerminationKey] boolValue]);
-  XCTAssertNil([session.history runningProcessForApplication:appLaunch.application]);
+  XCTAssertNil([session.history runningProcessForApplication:self.safariApplication]);
 }
 
 - (void)testNotifiedByExpectedApplicationTermination
@@ -100,7 +99,7 @@
 
   [self assertInteractionSuccessful:[session.interact.bootSimulator launchApplication:appLaunch]];
 
-  FBProcessInfo *process = [session.history runningProcessForApplication:appLaunch.application];
+  FBProcessInfo *process = [session.history runningProcessForApplication:self.safariApplication];
   XCTAssertNotNil(process);
   if (!process) {
     // Need to guard against continuing the test in case the PID is 0 or -1 to avoid nuking the machine.
@@ -112,7 +111,7 @@
 
   NSNotification *actual = [self.assert consumeNotification:FBSimulatorApplicationProcessDidTerminateNotification timeout:20];
   XCTAssertTrue([actual.userInfo[FBSimulatorExpectedTerminationKey] boolValue]);
-  XCTAssertNil([session.history runningProcessForApplication:appLaunch.application]);
+  XCTAssertNil([session.history runningProcessForApplication:self.safariApplication]);
 }
 
 @end

--- a/FBSimulatorControlTests/Tests/FBSimulatorAutomaticUpdatingTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorAutomaticUpdatingTests.m
@@ -108,7 +108,7 @@
   }
 
   [self.assert consumeAllNotifications];
-  [self assertInteractionSuccessful:[session.interact killApplication:appLaunch.application]];
+  [self assertInteractionSuccessful:[session.interact killProcess:process]];
 
   NSNotification *actual = [self.assert consumeNotification:FBSimulatorApplicationProcessDidTerminateNotification timeout:20];
   XCTAssertTrue([actual.userInfo[FBSimulatorExpectedTerminationKey] boolValue]);

--- a/FBSimulatorControlTests/Tests/FBSimulatorControlHistoryTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorControlHistoryTests.m
@@ -48,7 +48,7 @@
   FBSimulatorHistory *history = [NSKeyedUnarchiver unarchiveObjectWithData:data];
 
   XCTAssertEqualObjects(history.lastLaunchedApplicationProcess, self.processInfo1);
-  XCTAssertEqualObjects([history diagnosticNamed:@"foo" forApplication:self.appLaunch1.application], @"bar");
+  XCTAssertEqualObjects([history diagnosticNamed:@"foo" forApplication:self.tableSearchApplication], @"bar");
 }
 
 @end

--- a/FBSimulatorControlTests/Tests/FBSimulatorHistoryGeneratorTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorHistoryGeneratorTests.m
@@ -83,7 +83,7 @@
   [self.generator diagnosticInformationAvailable:@"SECRIT" process:self.processInfo1 value:diagnostic];
   FBSimulatorHistory *history = self.generator.history;
 
-  XCTAssertEqualObjects(diagnostic, [history diagnosticNamed:@"SECRIT" forApplication:self.appLaunch1.application]);
+  XCTAssertEqualObjects(diagnostic, [history diagnosticNamed:@"SECRIT" forApplication:self.tableSearchApplication]);
 }
 
 - (void)testDiagnosticInformationForTerminatedProcessIsAvailable
@@ -95,7 +95,7 @@
   [self.generator applicationDidTerminate:self.processInfo1 expected:NO];
   FBSimulatorHistory *history = self.generator.history;
 
-  XCTAssertEqualObjects(diagnostic, [history diagnosticNamed:@"SECRIT" forApplication:self.appLaunch1.application]);
+  XCTAssertEqualObjects(diagnostic, [history diagnosticNamed:@"SECRIT" forApplication:self.tableSearchApplication]);
 }
 
 - (void)testChangesToSimulatorState

--- a/FBSimulatorControlTests/Tests/FBSimulatorLaunchTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorLaunchTests.m
@@ -59,10 +59,11 @@
 - (void)testLaunchesSampleApplication
 {
   FBSimulatorSession *session = [self createSession];
+  FBSimulatorApplication *application = self.tableSearchApplication;
   FBApplicationLaunchConfiguration *appLaunch = self.tableSearchAppLaunch;
 
   [self.assert consumeAllNotifications];
-  [self assertInteractionSuccessful:[[[session.interact bootSimulator:self.simulatorLaunchConfiguration] installApplication:appLaunch.application] launchApplication:appLaunch]];
+  [self assertInteractionSuccessful:[[[session.interact bootSimulator:self.simulatorLaunchConfiguration] installApplication:application] launchApplication:appLaunch]];
   [self assertLastLaunchedApplicationIsRunning:session.simulator];
 
   [self.assert bootingNotificationsFired];

--- a/FBSimulatorControlTests/Tests/FBSimulatorLaunchTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorLaunchTests.m
@@ -49,10 +49,8 @@
   [self.assert noNotificationsToConsume];
   [self assertSimulatorBooted:session.simulator];
 
-  [self assertInteractionSuccessful:session.interact.terminateLastLaunchedApplication];
-  [self.assert consumeNotification:FBSimulatorApplicationProcessDidTerminateNotification];
-
   [self assertInteractionSuccessful:session.interact.relaunchLastLaunchedApplication];
+  [self.assert consumeNotification:FBSimulatorApplicationProcessDidTerminateNotification];
   [self.assert consumeNotification:FBSimulatorApplicationProcessDidLaunchNotification];
 
   [self.assert noNotificationsToConsume];

--- a/FBSimulatorControlTests/Tests/FBSimulatorLogsTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorLogsTests.m
@@ -45,7 +45,7 @@
   FBSimulatorSession *session = [self createBootedSession];
   FBApplicationLaunchConfiguration *appLaunch = [self.tableSearchAppLaunch.injectingShimulator withEnvironmentAdditions:@{@"SHIMULATOR_CRASH_AFTER" : @"1"}];
 
-  [self assertInteractionSuccessful:[[session.interact installApplication:appLaunch.application] launchApplication:appLaunch]];
+  [self assertInteractionSuccessful:[[session.interact installApplication:self.tableSearchApplication] launchApplication:appLaunch]];
 
   // Shimulator sends an unrecognized selector to NSFileManager to cause a crash.
   // The CrashReporter service is a background service as it will symbolicate in a separate process.
@@ -75,7 +75,7 @@
 
   FBSimulatorSession *session = [self createBootedSession];
   FBApplicationLaunchConfiguration *appLaunch = self.tableSearchAppLaunch.injectingShimulator;
-  [self assertInteractionSuccessful:[[session.interact installApplication:appLaunch.application] launchApplication:appLaunch]];
+  [self assertInteractionSuccessful:[[session.interact installApplication:self.tableSearchApplication] launchApplication:appLaunch]];
 
   [self assertFindsNeedle:@"Shimulator" fromHaystackBlock:^ NSString * {
     return [[session.simulator.logs.launchedProcessLogs.allValues firstObject] asString];

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -300,7 +300,7 @@ extension Interaction : Parsable {
     return Parser<FBProcessLaunchConfiguration>
       .alternative([
         self.agentLaunchParser(),
-        self.appLaunchParser()
+        self.appLaunchParser(),
       ])
   }
 
@@ -318,13 +318,13 @@ extension Interaction : Parsable {
   private static func appLaunchParser() -> Parser<FBProcessLaunchConfiguration> {
     return Parser
       .ofTwoSequenced(
-        Parser<FBSimulatorApplication>.ofApplication(),
+        Parser<FBSimulatorApplication>.ofBundleID(),
         self.argumentParser()
       )
-      .fmap { (application, arguments) in
-        return FBApplicationLaunchConfiguration(application: application, arguments: arguments, environment : [:])
+      .fmap { (bundleID, arguments) in
+        return FBApplicationLaunchConfiguration(bundleID: bundleID, arguments: arguments, environment : [:])
       }
-    }
+  }
 
   private static func argumentParser() -> Parser<[String]> {
     return Parser.many(Parser<String>.ofAny())

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
@@ -312,18 +312,6 @@ class ActionParserTests : XCTestCase {
     self.assertWithDefaultActions(interaction, suffix: suffix)
   }
 
-  func testParsesAppLaunch() {
-    let interaction = Interaction.Launch(FBApplicationLaunchConfiguration(application: Fixtures.application(), arguments: [], environment: [:]))
-    let suffix: [String] = ["launch", Fixtures.application().path]
-    self.assertWithDefaultActions(interaction, suffix: suffix)
-  }
-
-  func testParsesAppLaunchWithArguments() {
-    let interaction = Interaction.Launch(FBApplicationLaunchConfiguration(application: Fixtures.application(), arguments: ["--foo", "-b", "-a", "-r"], environment: [:]))
-    let suffix: [String] = ["launch", Fixtures.application().path, "--foo", "-b", "-a", "-r"]
-    self.assertWithDefaultActions(interaction, suffix: suffix)
-  }
-
   func testParsesAgentLaunch() {
     let interaction = Interaction.Launch(FBAgentLaunchConfiguration(binary: Fixtures.binary(), arguments: [], environment: [:]))
     let suffix: [String] = ["launch", Fixtures.binary().path]
@@ -333,6 +321,30 @@ class ActionParserTests : XCTestCase {
   func testParsesAgentLaunchWithArguments() {
     let interaction = Interaction.Launch(FBAgentLaunchConfiguration(binary: Fixtures.binary(), arguments: ["--foo", "-b", "-a", "-r"], environment: [:]))
     let suffix: [String] = ["launch", Fixtures.binary().path, "--foo", "-b", "-a", "-r"]
+    self.assertWithDefaultActions(interaction, suffix: suffix)
+  }
+
+  func testParsesAppLaunchByPath() {
+    let interaction = Interaction.Launch(FBApplicationLaunchConfiguration(application: Fixtures.application(), arguments: [], environment: [:]))
+    let suffix: [String] = ["launch", Fixtures.application().path]
+    self.assertWithDefaultActions(interaction, suffix: suffix)
+  }
+
+  func testParsesAppLaunchByPathWithArguments() {
+    let interaction = Interaction.Launch(FBApplicationLaunchConfiguration(application: Fixtures.application(), arguments: ["--foo", "-b", "-a", "-r"], environment: [:]))
+    let suffix: [String] = ["launch", Fixtures.application().path, "--foo", "-b", "-a", "-r"]
+    self.assertWithDefaultActions(interaction, suffix: suffix)
+  }
+
+  func testParsesAppLaunchByBundleID() {
+    let interaction = Interaction.Launch(FBApplicationLaunchConfiguration(bundleID: "com.foo.bar", arguments: [], environment: [:]))
+    let suffix: [String] = ["launch", "com.foo.bar"]
+    self.assertWithDefaultActions(interaction, suffix: suffix)
+  }
+
+  func testParsesAppLaunchByBundleIDArguments() {
+    let interaction = Interaction.Launch(FBApplicationLaunchConfiguration(bundleID: "com.foo.bar", arguments: ["--foo", "-b", "-a", "-r"], environment: [:]))
+    let suffix: [String] = ["launch", "com.foo.bar", "--foo", "-b", "-a", "-r"]
     self.assertWithDefaultActions(interaction, suffix: suffix)
   }
 


### PR DESCRIPTION
It should be possible to launch an Application without the location of the source Application. The path to the original binary makes less sense considering the Application is installed relative to the `data` directory of Simulator, so the original location of the `Application` binary isn't used when the Application is a launched on the Simulator.