### PR TITLE
Use FBSimulatorLaunchConfiguration to configure simulator before boot

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		AA3230CB1BDA387700C5BA01 /* FBSimulatorControlAssertions.m in Sources */ = {isa = PBXBuildFile; fileRef = AA3230CA1BDA387700C5BA01 /* FBSimulatorControlAssertions.m */; };
 		AA5639551C060005009BAFAA /* FBSimulatorControl.h in Headers */ = {isa = PBXBuildFile; fileRef = AA5639541C05FFF5009BAFAA /* FBSimulatorControl.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA6424FE1C44E99B00AA9BFB /* FBSimulatorLaunchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA6424FD1C44E99B00AA9BFB /* FBSimulatorLaunchTests.m */; };
+		AA7490051C4E6CBA00F3BDBA /* FBSimulatorLaunchConfiguration+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7490041C4E6C7700F3BDBA /* FBSimulatorLaunchConfiguration+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA819DB71B9FB40D002F58CA /* FBSimulatorControl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E291A4B50E500000001 /* FBSimulatorControl.framework */; };
 		AA9517471C15F54600A89CAD /* FBProcessLaunchConfiguration+Helpers.h in Headers */ = {isa = PBXBuildFile; fileRef = AA9516C21C15F54600A89CAD /* FBProcessLaunchConfiguration+Helpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA9517481C15F54600A89CAD /* FBProcessLaunchConfiguration+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = AA9516C31C15F54600A89CAD /* FBProcessLaunchConfiguration+Helpers.m */; };
@@ -807,6 +808,7 @@
 		AA4879951BAC74DD007F7D23 /* SimRuntime-DVTAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SimRuntime-DVTAdditions.h"; sourceTree = "<group>"; };
 		AA5639541C05FFF5009BAFAA /* FBSimulatorControl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBSimulatorControl.h; sourceTree = "<group>"; };
 		AA6424FD1C44E99B00AA9BFB /* FBSimulatorLaunchTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorLaunchTests.m; sourceTree = "<group>"; };
+		AA7490041C4E6C7700F3BDBA /* FBSimulatorLaunchConfiguration+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FBSimulatorLaunchConfiguration+Private.h"; sourceTree = "<group>"; };
 		AA819DB21B9FB40D002F58CA /* FBSimulatorControlTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FBSimulatorControlTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA819E0B1B9FB427002F58CA /* FBSimulatorControlTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "FBSimulatorControlTests-Info.plist"; sourceTree = "<group>"; };
 		AA9516C21C15F54600A89CAD /* FBProcessLaunchConfiguration+Helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FBProcessLaunchConfiguration+Helpers.h"; sourceTree = "<group>"; };
@@ -1708,6 +1710,7 @@
 				AAD51E9E1C3ADECA00A763D0 /* FBSimulatorLaunchConfiguration.m */,
 				AAD51EA11C3AEFEA00A763D0 /* FBSimulatorLaunchConfiguration+Helpers.h */,
 				AAD51EA21C3AEFEA00A763D0 /* FBSimulatorLaunchConfiguration+Helpers.m */,
+				AA7490041C4E6C7700F3BDBA /* FBSimulatorLaunchConfiguration+Private.h */,
 			);
 			path = Configuration;
 			sourceTree = "<group>";
@@ -2034,6 +2037,7 @@
 				AA9517A51C15F54600A89CAD /* FBTask.h in Headers */,
 				AA1D65461C21CD2A0069F90D /* FBASLParser.h in Headers */,
 				AAF2D3561C33EA3100434516 /* FBSimulatorInteraction+Lifecycle.h in Headers */,
+				AA7490051C4E6CBA00F3BDBA /* FBSimulatorLaunchConfiguration+Private.h in Headers */,
 				AA95179D1C15F54600A89CAD /* FBProcessQuery.h in Headers */,
 				AA9517A11C15F54600A89CAD /* FBSimulatorSession+Private.h in Headers */,
 				AA2219951C3E752800371B01 /* FBCoreSimulatorTerminationStrategy.h in Headers */,

--- a/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration+Private.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration+Private.h
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <FBSimulatorControl/FBSimulatorLaunchConfiguration.h>
+#import <FBSimulatorControl/FBSimulatorConfiguration+Private.h>
+
+@protocol FBSimulatorLaunchConfiguration_Scale <NSObject>
+
+- (NSString *)scaleString;
+
+@end
+
+@interface FBSimulatorLaunchConfiguration_Scale_25 : FBSimulatorConfigurationVariant_Base <FBSimulatorLaunchConfiguration_Scale>
+@end
+
+@interface FBSimulatorLaunchConfiguration_Scale_50 : FBSimulatorConfigurationVariant_Base <FBSimulatorLaunchConfiguration_Scale>
+@end
+
+@interface FBSimulatorLaunchConfiguration_Scale_75 : FBSimulatorConfigurationVariant_Base <FBSimulatorLaunchConfiguration_Scale>
+@end
+
+@interface FBSimulatorLaunchConfiguration_Scale_100 : FBSimulatorConfigurationVariant_Base <FBSimulatorLaunchConfiguration_Scale>
+@end
+
+@interface FBSimulatorLaunchConfiguration ()
+
+@property (nonatomic, strong, readonly) id<FBSimulatorLaunchConfiguration_Scale> scale;
+
+- (instancetype)withScale:(id<FBSimulatorLaunchConfiguration_Scale>)scale;
+
+@end

--- a/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration.m
@@ -8,26 +8,7 @@
  */
 
 #import "FBSimulatorLaunchConfiguration.h"
-
-#import "FBSimulatorConfiguration+Private.h"
-
-@protocol FBSimulatorLaunchConfiguration_Scale <NSObject>
-
-- (NSString *)scaleString;
-
-@end
-
-@interface FBSimulatorLaunchConfiguration_Scale_25 : FBSimulatorConfigurationVariant_Base <FBSimulatorLaunchConfiguration_Scale>
-@end
-
-@interface FBSimulatorLaunchConfiguration_Scale_50 : FBSimulatorConfigurationVariant_Base <FBSimulatorLaunchConfiguration_Scale>
-@end
-
-@interface FBSimulatorLaunchConfiguration_Scale_75 : FBSimulatorConfigurationVariant_Base <FBSimulatorLaunchConfiguration_Scale>
-@end
-
-@interface FBSimulatorLaunchConfiguration_Scale_100 : FBSimulatorConfigurationVariant_Base <FBSimulatorLaunchConfiguration_Scale>
-@end
+#import "FBSimulatorLaunchConfiguration+Private.h"
 
 #pragma mark Scales
 
@@ -64,12 +45,6 @@
 {
   return @"1.00";
 }
-
-@end
-
-@interface FBSimulatorLaunchConfiguration ()
-
-@property (nonatomic, strong, readonly) id<FBSimulatorLaunchConfiguration_Scale> scale;
 
 @end
 
@@ -174,7 +149,7 @@
 
 - (instancetype)scale25Percent
 {
-  return [self updateScale:FBSimulatorLaunchConfiguration_Scale_25.new];
+  return [self withScale:FBSimulatorLaunchConfiguration_Scale_25.new];
 }
 
 + (instancetype)scale50Percent
@@ -184,7 +159,7 @@
 
 - (instancetype)scale50Percent
 {
-  return [self updateScale:FBSimulatorLaunchConfiguration_Scale_50.new];
+  return [self withScale:FBSimulatorLaunchConfiguration_Scale_50.new];
 }
 
 + (instancetype)scale75Percent
@@ -194,7 +169,7 @@
 
 - (instancetype)scale75Percent
 {
-  return [self updateScale:FBSimulatorLaunchConfiguration_Scale_75.new];
+  return [self withScale:FBSimulatorLaunchConfiguration_Scale_75.new];
 }
 
 + (instancetype)scale100Percent
@@ -204,7 +179,7 @@
 
 - (instancetype)scale100Percent
 {
-  return [self updateScale:FBSimulatorLaunchConfiguration_Scale_100.new];
+  return [self withScale:FBSimulatorLaunchConfiguration_Scale_100.new];
 }
 
 #pragma mark Locale
@@ -231,7 +206,7 @@
 
 #pragma mark Private
 
-- (instancetype)updateScale:(id<FBSimulatorLaunchConfiguration_Scale>)scale
+- (instancetype)withScale:(id<FBSimulatorLaunchConfiguration_Scale>)scale
 {
   if (!scale) {
     return nil;

--- a/FBSimulatorControl/FBSimulatorControl.h
+++ b/FBSimulatorControl/FBSimulatorControl.h
@@ -57,6 +57,7 @@
 #import <FBSimulatorControl/FBSimulatorInteraction+Video.h>
 #import <FBSimulatorControl/FBSimulatorInteraction.h>
 #import <FBSimulatorControl/FBSimulatorLaunchConfiguration+Helpers.h>
+#import <FBSimulatorControl/FBSimulatorLaunchConfiguration+Private.h>
 #import <FBSimulatorControl/FBSimulatorLaunchConfiguration.h>
 #import <FBSimulatorControl/FBSimulatorLogger.h>
 #import <FBSimulatorControl/FBSimulatorLoggingEventSink.h>

--- a/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
@@ -46,7 +46,7 @@ public indirect enum Format {
  */
 public enum Interaction {
   case List
-  case Boot
+  case Boot(FBSimulatorLaunchConfiguration?)
   case Shutdown
   case Diagnose
   case Delete
@@ -119,8 +119,8 @@ public func == (left: Interaction, right: Interaction) -> Bool {
   switch (left, right) {
   case (.List, .List):
     return true
-  case (.Boot, .Boot):
-    return true
+  case (.Boot(let leftConfiguration), .Boot(let rightConfiguration)):
+    return leftConfiguration == rightConfiguration
   case (.Shutdown, .Shutdown):
     return true
   case (.Diagnose, .Diagnose):

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -241,7 +241,7 @@ extension Interaction : Parsable {
     return Parser
       .alternative([
         Parser.ofString("list", Interaction.List),
-        Parser.ofString("boot", Interaction.Boot),
+        Parser.ofString("boot", Interaction.Boot(nil)),
         Parser.ofString("shutdown", Interaction.Shutdown),
         Parser.ofString("diagnose", Interaction.Diagnose),
         Parser.ofString("delete", Interaction.Delete),

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -182,9 +182,10 @@ private struct SimulatorRunner : Runner {
       switch self.interaction {
       case .List:
         writer.write(self.formattedSimulator)
-      case .Boot:
+      case .Boot(let maybeLaunchConfiguration):
+        let launchConfiguration = maybeLaunchConfiguration ?? FBSimulatorLaunchConfiguration.defaultConfiguration()!
         writer.write("Booting \(self.formattedSimulator)")
-        try simulator.interact().bootSimulator().performInteraction()
+        try simulator.interact().prepareForLaunch(launchConfiguration).bootSimulator(launchConfiguration).performInteraction()
         writer.write("Booted \(self.formattedSimulator)")
       case .Shutdown:
         writer.write("Shutting Down \(self.formattedSimulator)")

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
@@ -254,6 +254,9 @@ class InteractionParserTests : XCTestCase {
     self.assertParsesAll(Interaction.parser(), [
       (["list"], Interaction.List),
       (["boot"], Interaction.Boot(nil)),
+      (["boot", "--locale", "fr_FR"], Interaction.Boot(FBSimulatorLaunchConfiguration.defaultConfiguration().withLocale(NSLocale(localeIdentifier: "fr_FR")))),
+      (["boot", "--scale=50"], Interaction.Boot(FBSimulatorLaunchConfiguration.defaultConfiguration().scale50Percent())),
+      (["boot", "--locale", "en_US", "--scale=75"], Interaction.Boot(FBSimulatorLaunchConfiguration.defaultConfiguration().withLocale(NSLocale(localeIdentifier: "en_US")).scale75Percent())),
       (["shutdown"], Interaction.Shutdown),
       (["diagnose"], Interaction.Diagnose),
       (["delete"], Interaction.Delete),

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
@@ -253,7 +253,7 @@ class InteractionParserTests : XCTestCase {
   func testParsesAllCases() {
     self.assertParsesAll(Interaction.parser(), [
       (["list"], Interaction.List),
-      (["boot"], Interaction.Boot),
+      (["boot"], Interaction.Boot(nil)),
       (["shutdown"], Interaction.Shutdown),
       (["diagnose"], Interaction.Diagnose),
       (["delete"], Interaction.Delete),
@@ -280,7 +280,7 @@ class ActionParserTests : XCTestCase {
   }
 
   func testParsesBoot() {
-    self.assertWithDefaultActions(Interaction.Boot, suffix: ["boot"])
+    self.assertWithDefaultActions(Interaction.Boot(nil), suffix: ["boot"])
   }
 
   func testParsesShutdown() {
@@ -363,7 +363,7 @@ class CommandParserTests : XCTestCase {
       Command.Perform(
         Configuration.defaultValue,
         Action.Interact(
-          [.Boot],
+          [.Boot(nil)],
           .UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]),
           nil
         )
@@ -378,7 +378,7 @@ class CommandParserTests : XCTestCase {
       Command.Perform(
         Configuration.defaultValue,
         Action.Interact(
-          [ .List, .Boot ],
+          [ .List, .Boot(nil) ],
           Query.And([.State([.Booted]), .UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"])]),
           nil
         )


### PR DESCRIPTION
This allows for the locale to be set before booting as well as the scale for the boot itself. This will also be able to account for options in the future when I finally get round to finishing #150 