### PR TITLE
Improve launchd_sim subprocess killing

### DIFF
--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.h
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.h
@@ -30,22 +30,6 @@
 - (instancetype)launchApplication:(FBApplicationLaunchConfiguration *)appLaunch;
 
 /**
- Unix Signals the Application.
-
- @param signal the unix signo to send.
- @return the reciever, for chaining.
- */
-- (instancetype)signal:(int)signal application:(FBSimulatorApplication *)application;
-
-/**
- Kills the provided Application.
-
- @param application the Application to kill.
- @return the reciever, for chaining.
- */
-- (instancetype)killApplication:(FBSimulatorApplication *)application;
-
-/**
  Relaunches the last-launched Application:
  - If the Application is running, it will be killed first then launched.
  - If the Application has terminated, it will be launched.

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.m
@@ -117,9 +117,10 @@
     // Relaunch the Application
     NSError *innerError = nil;
     if (![[simulator.interact launchApplication:launchConfig] performInteractionWithError:&innerError]) {
-      return [[[FBSimulatorError
+      return [[[[FBSimulatorError
         describeFormat:@"Failed to re-launch %@", launchConfig]
         inSimulator:simulator]
+        causedBy:innerError]
         failBool:error];
     }
     return YES;

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.m
@@ -21,12 +21,15 @@
 #import "FBSimulator+Private.h"
 #import "FBSimulator.h"
 #import "FBSimulatorApplication.h"
+#import "FBSimulatorControlGlobalConfiguration.h"
 #import "FBSimulatorError.h"
 #import "FBSimulatorEventSink.h"
 #import "FBSimulatorHistory+Queries.h"
 #import "FBSimulatorInteraction+Lifecycle.h"
 #import "FBSimulatorInteraction+Private.h"
+#import "FBSimulatorLaunchCtl.h"
 #import "FBSimulatorPool.h"
+#import "NSRunLoop+SimulatorControlAdditions.h"
 
 @implementation FBSimulatorInteraction (Applications)
 
@@ -139,7 +142,7 @@
     NSError *innerError = nil;
     if (![[simulator.interact killProcess:process] performInteractionWithError:&innerError]) {
       return [[[[FBSimulatorError
-        describeFormat:@"Failed to terminate app  %@", process.shortDescription]
+        describeFormat:@"Failed to terminate app %@", process.shortDescription]
         causedBy:innerError]
         inSimulator:simulator]
         failBool:error];

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.h
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.h
@@ -47,4 +47,21 @@
  */
 - (instancetype)openURL:(NSURL *)url;
 
+/**
+ Sends a signal(3) to the Process, verifying that is is a subprocess of the Simulator.
+
+ @param signo the unix signo to send.
+ @param process the process to send a Signal to.
+ @return the reciever, for chaining.
+ */
+- (instancetype)signal:(int)signo process:(FBProcessInfo *)process;
+
+/**
+ SIGKILL's the provided Process, verifying that is is a subprocess of the Simulator.
+
+ @param process the Process to kill.
+ @return the reciever, for chaining.
+ */
+- (instancetype)killProcess:(FBProcessInfo *)process;
+
 @end

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.m
@@ -190,7 +190,7 @@
 
     // Use FBProcessTerminationStrategy to do the actual process killing.
     NSError *innerError = nil;
-    if (![[FBProcessTerminationStrategy withProcessKilling:simulator.processQuery logger:simulator.logger] killProcess:process error:&innerError]) {
+    if (![[FBProcessTerminationStrategy withProcessKilling:simulator.processQuery signo:signo logger:simulator.logger] killProcess:process error:&innerError]) {
       return [FBSimulatorError failBoolWithError:innerError errorOut:error];
     }
 

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.m
@@ -13,6 +13,7 @@
 
 #import "FBCollectionDescriptions.h"
 #import "FBInteraction+Private.h"
+#import "FBProcessInfo.h"
 #import "FBProcessLaunchConfiguration.h"
 #import "FBProcessQuery+Simulators.h"
 #import "FBSimulator+Helpers.h"
@@ -159,6 +160,48 @@
     }
     return YES;
   }];
+}
+
+- (instancetype)signal:(int)signo process:(FBProcessInfo *)process
+{
+  NSParameterAssert(process);
+
+  return [self process:process interact:^ BOOL (NSError **error, FBSimulator *simulator) {
+    // Confirm that the process has the launchd_sim as a parent process.
+    // The interaction should restrict itself to simulator processes so this is a guard
+    // to ensure that this interaction can't go around killing random processes.
+    pid_t parentProcessIdentifier = [simulator.processQuery parentOf:process.processIdentifier];
+    if (parentProcessIdentifier != simulator.launchdSimProcess.processIdentifier) {
+      return [[FBSimulatorError
+        describeFormat:@"Parent of %@ is not the launchd_sim (%@) it has a pid %d", process.shortDescription, simulator.launchdSimProcess.shortDescription, parentProcessIdentifier]
+        failBool:error];
+    }
+
+    // Notify the eventSink of the process getting killed, before it is killed.
+    // This is done to prevent being marked as an unexpected termination when the
+    // detecting of the process getting killed kicks in.
+    FBProcessLaunchConfiguration *configuration = simulator.history.processLaunchConfigurations[process];
+    if ([configuration isKindOfClass:FBApplicationLaunchConfiguration.class]) {
+      [simulator.eventSink applicationDidTerminate:process expected:YES];
+    } else if ([configuration isKindOfClass:FBAgentLaunchConfiguration.class]) {
+      [simulator.eventSink agentDidTerminate:process expected:YES];
+    }
+
+    int returnCode = kill(process.processIdentifier, signo);
+    if (returnCode != 0) {
+      return [[[FBSimulatorError describeFormat:@"SIGKILL of %@ failed", process] inSimulator:simulator] failBool:error];
+    }
+    if (![simulator.processQuery waitForProcessToDie:process timeout:20]) {
+      return [[[FBSimulatorError describeFormat:@"Termination of process %@ failed in waiting for process to dissappear", process] inSimulator:simulator] failBool:error];
+    }
+
+    return YES;
+  }];
+}
+
+- (instancetype)killProcess:(FBProcessInfo *)process
+{
+  return [self signal:SIGKILL process:process];
 }
 
 @end

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Private.h
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Private.h
@@ -19,6 +19,15 @@
 /**
  Chains an interaction on an process, for the given application.
 
+ @param process the process to interact with.
+ @param block the block to execute with the process.
+ @return the reciever, for chaining.
+ */
+- (instancetype)process:(FBProcessInfo *)process interact:(BOOL (^)(NSError **error, FBSimulator *simulator))block;
+
+/**
+ Chains an interaction on an process, for the given binary.
+
  @param binary the binary to interact with.
  @param block the block to execute with the process.
  @return the reciever, for chaining.

--- a/FBSimulatorControl/Management/FBCoreSimulatorTerminationStrategy.m
+++ b/FBSimulatorControl/Management/FBCoreSimulatorTerminationStrategy.m
@@ -40,7 +40,7 @@
 
   _processQuery = processQuery;
   _logger = logger;
-  _processTerminationStrategy = [FBProcessTerminationStrategy withProcessKilling:processQuery logger:logger];
+  _processTerminationStrategy = [FBProcessTerminationStrategy withProcessKilling:processQuery signo:SIGKILL logger:logger];
 
   return self;
 }

--- a/FBSimulatorControl/Management/FBProcessTerminationStrategy.h
+++ b/FBSimulatorControl/Management/FBProcessTerminationStrategy.h
@@ -22,20 +22,22 @@
  Uses kill(2) to terminate Applications.
 
  @param processQuery the Process Query object to use.
+ @param signo the signal number to use when killing. See signal(3) for more info
  @param logger the logger to use.
  @return a new Process Termination Strategy instance.
  */
-+ (instancetype)withProcessKilling:(FBProcessQuery *)processQuery logger:(id<FBSimulatorLogger>)logger;
++ (instancetype)withProcessKilling:(FBProcessQuery *)processQuery signo:(int)signo logger:(id<FBSimulatorLogger>)logger;
 
 /**
  Uses methods on NSRunningApplication to terminate Applications.
  Uses kill(2) otherwise
 
  @param processQuery the Process Query object to use.
+ @param signo the signal number to use when killing. See signal(3) for more info
  @param logger the logger to use.
  @return a new Process Termination Strategy instance.
  */
-+ (instancetype)withRunningApplicationTermination:(FBProcessQuery *)processQuery logger:(id<FBSimulatorLogger>)logger;;
++ (instancetype)withRunningApplicationTermination:(FBProcessQuery *)processQuery signo:(int)signo logger:(id<FBSimulatorLogger>)logger;;
 
 /**
  Terminates a Process of the provided Process Info.

--- a/FBSimulatorControl/Management/FBProcessTerminationStrategy.m
+++ b/FBSimulatorControl/Management/FBProcessTerminationStrategy.m
@@ -97,7 +97,15 @@
 
 - (BOOL)killProcess:(FBProcessInfo *)process error:(NSError **)error
 {
-  // The kill was successful, all is well.
+  FBProcessInfo *actualProcess = [self.processQuery processInfoFor:process.processIdentifier];
+  if (![actualProcess isEqual:process]) {
+    return [[[FBSimulatorError
+      describeFormat:@"Avoiding killing %@ as it differs from the actual process %@", process.debugDescription, actualProcess.debugDescription]
+      logger:self.logger]
+      failBool:error];
+  }
+
+  // Kill the process with kill(2).
   [self.logger.debug logFormat:@"Killing %@", process.shortDescription];
   if (kill(process.processIdentifier, SIGTERM) == 0) {
     return YES;

--- a/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.m
+++ b/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.m
@@ -53,8 +53,8 @@
 {
   BOOL useKill = (configuration.options & FBSimulatorManagementOptionsUseProcessKilling) == FBSimulatorManagementOptionsUseProcessKilling;
   FBProcessTerminationStrategy *processTerminationStrategy = useKill
-    ? [FBProcessTerminationStrategy withProcessKilling:processQuery logger:logger]
-    : [FBProcessTerminationStrategy withRunningApplicationTermination:processQuery logger:logger];
+    ? [FBProcessTerminationStrategy withProcessKilling:processQuery signo:SIGKILL logger:logger]
+    : [FBProcessTerminationStrategy withRunningApplicationTermination:processQuery signo:SIGKILL logger:logger];
 
   return [[self alloc] initWithConfiguration:configuration processQuery:processQuery processTerminationStrategy:processTerminationStrategy logger:logger];
 

--- a/FBSimulatorControl/Utility/FBAddVideoPolyfill.m
+++ b/FBSimulatorControl/Utility/FBAddVideoPolyfill.m
@@ -15,7 +15,9 @@
 #import "FBSimulatorApplication.h"
 #import "FBSimulatorControlGlobalConfiguration.h"
 #import "FBSimulatorError.h"
+#import "FBSimulatorHistory+Queries.h"
 #import "FBSimulatorInteraction+Applications.h"
+#import "FBSimulatorInteraction+Lifecycle.h"
 #import "NSRunLoop+SimulatorControlAdditions.h"
 
 @interface FBAddVideoPolyfill ()
@@ -104,8 +106,19 @@
     previousCount:dcimPaths.count
     error:error];
 
-  if (![[simulator.interact killApplication:photosApp] performInteractionWithError:nil]) {
-    return [[[FBSimulatorError describe:@"Couldn't kill MobileSlideShow after uploading videos"] causedBy:innerError] failBool:error];
+  FBProcessInfo *photosAppProcess = simulator.history.lastLaunchedApplicationProcess;
+  if (![photosAppProcess.processName isEqualToString:@"MobileSlideshow"]) {
+    return [[[FBSimulatorError
+      describe:@"Couldn't find MobileSlideShow process after uploading video"]
+      causedBy:innerError]
+      failBool:error];
+  }
+
+  if (![[simulator.interact killProcess:photosAppProcess] performInteractionWithError:nil]) {
+    return [[[FBSimulatorError
+      describe:@"Couldn't kill MobileSlideShow after uploading videos"]
+      causedBy:innerError]
+      failBool:error];
   }
 
   return success;

--- a/FBSimulatorControlTests/Tests/FBSimulatorAutomaticUpdatingTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorAutomaticUpdatingTests.m
@@ -108,7 +108,7 @@
   }
 
   [self.assert consumeAllNotifications];
-  [self assertInteractionSuccessful:[session.interact killApplication:appLaunch.application]];
+  [self assertInteractionSuccessful:[session.interact killProcess:process]];
 
   NSNotification *actual = [self.assert consumeNotification:FBSimulatorApplicationProcessDidTerminateNotification timeout:20];
   XCTAssertTrue([actual.userInfo[FBSimulatorExpectedTerminationKey] boolValue]);

--- a/FBSimulatorControlTests/Tests/FBSimulatorLaunchTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorLaunchTests.m
@@ -49,10 +49,8 @@
   [self.assert noNotificationsToConsume];
   [self assertSimulatorBooted:session.simulator];
 
-  [self assertInteractionSuccessful:session.interact.terminateLastLaunchedApplication];
-  [self.assert consumeNotification:FBSimulatorApplicationProcessDidTerminateNotification];
-
   [self assertInteractionSuccessful:session.interact.relaunchLastLaunchedApplication];
+  [self.assert consumeNotification:FBSimulatorApplicationProcessDidTerminateNotification];
   [self.assert consumeNotification:FBSimulatorApplicationProcessDidLaunchNotification];
 
   [self.assert noNotificationsToConsume];


### PR DESCRIPTION
Instead of just having `killApplication:` to kill applications, we should expose an API to do this for any subprocess of the simulator. We can add additional checks so that we don't kill random processes on a host and also use the existing `FBSimulatorTerminationStrategy`

Additionally, it looks like there is a race condition in the relaunch case:
1) An app is launched and has a pid
2) The app is terminated
3) Wait for the pid to disappear
4) Relaunch the app with the same launch configuration
5) The relaunched app will have the same pid as 1)
6) We try and fetch the process info for the pid, but it has died.

I can only assume that `CoreSimulator` will talk to the `launchd_sim` inside the Simulator and as the process was killed externally, it has to update it's knowledge of the world to determine that the process has died.