### PR TITLE
Add Wrapper to Simulator's launchctl

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		AA5639551C060005009BAFAA /* FBSimulatorControl.h in Headers */ = {isa = PBXBuildFile; fileRef = AA5639541C05FFF5009BAFAA /* FBSimulatorControl.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA6424FE1C44E99B00AA9BFB /* FBSimulatorLaunchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA6424FD1C44E99B00AA9BFB /* FBSimulatorLaunchTests.m */; };
 		AA7490051C4E6CBA00F3BDBA /* FBSimulatorLaunchConfiguration+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7490041C4E6C7700F3BDBA /* FBSimulatorLaunchConfiguration+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA78DCDA1C5005D2006FAB41 /* FBSimulatorLaunchCtl.h in Headers */ = {isa = PBXBuildFile; fileRef = AA78DCD81C5005D2006FAB41 /* FBSimulatorLaunchCtl.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA78DCDB1C5005D2006FAB41 /* FBSimulatorLaunchCtl.m in Sources */ = {isa = PBXBuildFile; fileRef = AA78DCD91C5005D2006FAB41 /* FBSimulatorLaunchCtl.m */; };
 		AA819DB71B9FB40D002F58CA /* FBSimulatorControl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E291A4B50E500000001 /* FBSimulatorControl.framework */; };
 		AA9517471C15F54600A89CAD /* FBProcessLaunchConfiguration+Helpers.h in Headers */ = {isa = PBXBuildFile; fileRef = AA9516C21C15F54600A89CAD /* FBProcessLaunchConfiguration+Helpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA9517481C15F54600A89CAD /* FBProcessLaunchConfiguration+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = AA9516C31C15F54600A89CAD /* FBProcessLaunchConfiguration+Helpers.m */; };
@@ -809,6 +811,8 @@
 		AA5639541C05FFF5009BAFAA /* FBSimulatorControl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBSimulatorControl.h; sourceTree = "<group>"; };
 		AA6424FD1C44E99B00AA9BFB /* FBSimulatorLaunchTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorLaunchTests.m; sourceTree = "<group>"; };
 		AA7490041C4E6C7700F3BDBA /* FBSimulatorLaunchConfiguration+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FBSimulatorLaunchConfiguration+Private.h"; sourceTree = "<group>"; };
+		AA78DCD81C5005D2006FAB41 /* FBSimulatorLaunchCtl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorLaunchCtl.h; sourceTree = "<group>"; };
+		AA78DCD91C5005D2006FAB41 /* FBSimulatorLaunchCtl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorLaunchCtl.m; sourceTree = "<group>"; };
 		AA819DB21B9FB40D002F58CA /* FBSimulatorControlTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FBSimulatorControlTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA819E0B1B9FB427002F58CA /* FBSimulatorControlTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "FBSimulatorControlTests-Info.plist"; sourceTree = "<group>"; };
 		AA9516C21C15F54600A89CAD /* FBProcessLaunchConfiguration+Helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FBProcessLaunchConfiguration+Helpers.h"; sourceTree = "<group>"; };
@@ -1899,6 +1903,8 @@
 				AA95173D1C15F54600A89CAD /* FBSimDeviceWrapper.m */,
 				AA95173E1C15F54600A89CAD /* FBSimulatorError.h */,
 				AA95173F1C15F54600A89CAD /* FBSimulatorError.m */,
+				AA78DCD81C5005D2006FAB41 /* FBSimulatorLaunchCtl.h */,
+				AA78DCD91C5005D2006FAB41 /* FBSimulatorLaunchCtl.m */,
 				AA9517401C15F54600A89CAD /* FBSimulatorLogger.h */,
 				AA9517411C15F54600A89CAD /* FBSimulatorLogger.m */,
 				AA9517421C15F54600A89CAD /* NSRunLoop+SimulatorControlAdditions.h */,
@@ -2040,6 +2046,7 @@
 				AA7490051C4E6CBA00F3BDBA /* FBSimulatorLaunchConfiguration+Private.h in Headers */,
 				AA95179D1C15F54600A89CAD /* FBProcessQuery.h in Headers */,
 				AA9517A11C15F54600A89CAD /* FBSimulatorSession+Private.h in Headers */,
+				AA78DCDA1C5005D2006FAB41 /* FBSimulatorLaunchCtl.h in Headers */,
 				AA2219951C3E752800371B01 /* FBCoreSimulatorTerminationStrategy.h in Headers */,
 				AA9517871C15F54600A89CAD /* FBSimulatorPredicates.h in Headers */,
 				AA9517811C15F54600A89CAD /* FBSimulatorControl+PrincipalClass.h in Headers */,
@@ -2151,6 +2158,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				AA78DCDB1C5005D2006FAB41 /* FBSimulatorLaunchCtl.m in Sources */,
 				AA1D65431C21B38D0069F90D /* FBCrashLogInfo.m in Sources */,
 				AA9517521C15F54600A89CAD /* FBSimulatorConfiguration.m in Sources */,
 				AA9517541C15F54600A89CAD /* FBSimulatorControlConfiguration.m in Sources */,

--- a/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration+Helpers.h
+++ b/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration+Helpers.h
@@ -54,9 +54,8 @@
 
  @param stdOut the stdout to use, may be nil.
  @param stdErr the stderr to use, may be nil.
- @param error an out param for any error that occurred.
  @return a Dictionary if successful, nil otherwise.
  */
-- (NSDictionary *)agentLaunchOptionsWithStdOut:(NSFileHandle *)stdOut stdErr:(NSFileHandle *)stdErr error:(NSError **)error;
+- (NSDictionary *)simDeviceLaunchOptionsWithStdOut:(NSFileHandle *)stdOut stdErr:(NSFileHandle *)stdErr;
 
 @end

--- a/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration+Helpers.m
+++ b/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration+Helpers.m
@@ -94,7 +94,7 @@
   return YES;
 }
 
-- (NSDictionary *)agentLaunchOptionsWithStdOut:(NSFileHandle *)stdOut stdErr:(NSFileHandle *)stdErr error:(NSError **)error
+- (NSDictionary *)simDeviceLaunchOptionsWithStdOut:(NSFileHandle *)stdOut stdErr:(NSFileHandle *)stdErr
 {
   NSMutableDictionary *options = [@{
     @"arguments" : self.arguments,

--- a/FBSimulatorControl/FBSimulatorControl.h
+++ b/FBSimulatorControl/FBSimulatorControl.h
@@ -59,6 +59,7 @@
 #import <FBSimulatorControl/FBSimulatorLaunchConfiguration+Helpers.h>
 #import <FBSimulatorControl/FBSimulatorLaunchConfiguration+Private.h>
 #import <FBSimulatorControl/FBSimulatorLaunchConfiguration.h>
+#import <FBSimulatorControl/FBSimulatorLaunchCtl.h>
 #import <FBSimulatorControl/FBSimulatorLogger.h>
 #import <FBSimulatorControl/FBSimulatorLoggingEventSink.h>
 #import <FBSimulatorControl/FBSimulatorLogs.h>

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Agents.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Agents.m
@@ -46,7 +46,7 @@
     }
 
     FBProcessInfo *process = [simulator.simDeviceWrapper
-      spawnWithPath:agentLaunch.agentBinary.path
+      spawnLongRunningWithPath:agentLaunch.agentBinary.path
       options:options
       terminationHandler:NULL
       error:&innerError];

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Agents.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Agents.m
@@ -40,7 +40,7 @@
       return [FBSimulatorError failBoolWithError:innerError errorOut:error];
     }
 
-    NSDictionary *options = [agentLaunch agentLaunchOptionsWithStdOut:stdOut stdErr:stdErr error:error];
+    NSDictionary *options = [agentLaunch simDeviceLaunchOptionsWithStdOut:stdOut stdErr:stdErr];
     if (!options) {
       return [FBSimulatorError failBoolWithError:innerError errorOut:error];
     }

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.m
@@ -72,7 +72,7 @@
       return [FBSimulatorError failBoolWithError:innerError errorOut:error];
     }
 
-    NSDictionary *options = [appLaunch agentLaunchOptionsWithStdOut:stdOut stdErr:stdErr error:error];
+    NSDictionary *options = [appLaunch simDeviceLaunchOptionsWithStdOut:stdOut stdErr:stdErr];
     if (!options) {
       return [FBSimulatorError failBoolWithError:innerError errorOut:error];
     }

--- a/FBSimulatorControl/Management/FBSimulator+Helpers.h
+++ b/FBSimulatorControl/Management/FBSimulator+Helpers.h
@@ -12,6 +12,7 @@
 @class FBSimDeviceWrapper;
 @class FBSimulatorApplication;
 @class FBSimulatorInteraction;
+@class FBSimulatorLaunchCtl;
 
 @interface FBSimulator (Helpers)
 
@@ -95,8 +96,14 @@
  */
 - (FBSimDeviceWrapper *)simDeviceWrapper;
 
+/**
+ Creates a FBSimulatorLaunchCtl for the Simulator.
+ */
+- (FBSimulatorLaunchCtl *)launchctl;
+
 /*
  The Subprocesses of the launchd_sim process.
+ Constructs this information from the kernel's Process Table.
  */
 - (NSArray *)launchdSimSubprocesses;
 

--- a/FBSimulatorControl/Management/FBSimulator+Helpers.m
+++ b/FBSimulatorControl/Management/FBSimulator+Helpers.m
@@ -20,6 +20,7 @@
 #import "FBSimulatorControlGlobalConfiguration.h"
 #import "FBSimulatorError.h"
 #import "FBSimulatorInteraction.h"
+#import "FBSimulatorLaunchCtl.h"
 #import "FBSimulatorPool.h"
 #import "NSRunLoop+SimulatorControlAdditions.h"
 
@@ -156,6 +157,11 @@
 - (FBSimDeviceWrapper *)simDeviceWrapper
 {
   return [FBSimDeviceWrapper withSimulator:self configuration:self.pool.configuration processQuery:self.processQuery];
+}
+
+- (FBSimulatorLaunchCtl *)launchctl
+{
+  return [FBSimulatorLaunchCtl withSimulator:self];
 }
 
 - (NSArray *)launchdSimSubprocesses

--- a/FBSimulatorControl/Model/FBSimulatorApplication.h
+++ b/FBSimulatorControl/Model/FBSimulatorApplication.h
@@ -113,7 +113,8 @@
 + (instancetype)applicationWithPath:(NSString *)path error:(NSError **)error;
 
 /**
- Returns the FBSimulatorApplication for the current version of Xcode's Simulator.app
+ Returns the FBSimulatorApplication for the current version of Xcode's Simulator.app.
+ Will assert if the FBSimulatorApplication instance could not be constructed.
 
  @return A FBSimulatorApplication instance for the Simulator.app.
  */
@@ -139,5 +140,13 @@
  Returns the FBSimulatorBinary for the given binary path
  */
 + (instancetype)binaryWithPath:(NSString *)path error:(NSError **)error;
+
+/**
+ Returns the launchctl for the current version of Xcode's of the Simulator Platform.
+ Will assert if the FBSimulatorBinary instance could not be constructed.
+
+ @return a FBSimulatorBinary instance launchctl.
+ */
++ (instancetype)launchCtl;
 
 @end

--- a/FBSimulatorControl/Model/FBSimulatorApplication.m
+++ b/FBSimulatorControl/Model/FBSimulatorApplication.m
@@ -371,6 +371,22 @@
     architectures:archs];
 }
 
++ (instancetype)launchCtl
+{
+  NSError *error = nil;
+  FBSimulatorBinary *binary = [FBSimulatorBinary binaryWithPath:self.pathForiPhoneLaunchCtl error:&error];
+  NSAssert(binary, @"Failed to construct launchctl binary with error %@", error);
+  return binary;
+}
+
+#pragma mark Private
+
++ (NSString *)pathForiPhoneLaunchCtl
+{
+  return [FBSimulatorControlGlobalConfiguration.developerDirectory
+    stringByAppendingPathComponent:@"/Platforms/WatchSimulator.platform/Developer/SDKs/WatchSimulator.sdk/bin/launchctl"];
+}
+
 + (NSString *)binaryNameForBinaryPath:(NSString *)binaryPath
 {
   return binaryPath.lastPathComponent;

--- a/FBSimulatorControl/Utility/FBSimDeviceWrapper.h
+++ b/FBSimulatorControl/Utility/FBSimDeviceWrapper.h
@@ -16,7 +16,12 @@
 @class SimDevice;
 
 /**
- Mirrors the Method Signatures in SimDevice. Augmenting with:
+ A Typedef for a SimDevice Callback.
+ */
+typedef void (^FBSimDeviceWrapperCallback)(void);
+
+/**
+ Augments methods in CoreSimulator with:
  - More informative return values.
  - Implementations that are more resiliant to failure in CoreSimulator.
  */
@@ -75,16 +80,29 @@
 - (BOOL)installApplication:(NSURL *)appURL withOptions:(NSDictionary *)options error:(NSError **)error;
 
 /**
- Spawns a binary on the Simulator.
- Will time out with an error if CoreSimulator gets stuck in a semaphore and timeout resiliance is enabled.
+ Spawns an long-lived executable on the Simulator.
+ The Task should not terminate in less than a few seconds, as Process Info will be obtained.
 
  @param launchPath the path to the binary.
  @param options the Options to use in the launch.
- @param terminationHandler ?????
+ @param terminationHandler a Termination Handler for when the process dies.
  @param error an error out for any error that occured.
  @return the Process Identifier of the launched process, -1 otherwise.
  */
-- (FBProcessInfo *)spawnWithPath:(NSString *)launchPath options:(NSDictionary *)options terminationHandler:(id)terminationHandler error:(NSError **)error;
+- (FBProcessInfo *)spawnLongRunningWithPath:(NSString *)launchPath options:(NSDictionary *)options terminationHandler:(FBSimDeviceWrapperCallback)terminationHandler error:(NSError **)error;
+
+/**
+ Spawns an short-lived executable on the Simulator.
+ The Process Identifier of the task will be returned, but will be invalid by the time it is returned if the process is short-lived.
+ Will block for timeout seconds to confirm that the process terminates
+
+ @param launchPath the path to the binary.
+ @param options the Options to use in the launch.
+ @param timeout the number of seconds to wait for the process to terminate.
+ @param error an error out for any error that occured.
+ @return the Process Identifier of the launched process, -1 otherwise.
+ */
+- (pid_t)spawnShortRunningWithPath:(NSString *)launchPath options:(NSDictionary *)options timeout:(NSTimeInterval)timeout error:(NSError **)error;
 
 /**
  Adds a Video to the Camera Roll.

--- a/FBSimulatorControl/Utility/FBSimulatorLaunchCtl.h
+++ b/FBSimulatorControl/Utility/FBSimulatorLaunchCtl.h
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class FBSimulator;
+@class FBProcessInfo;
+
+/**
+ An Interface to a Simulator's launchctl.
+ */
+@interface FBSimulatorLaunchCtl : NSObject
+
+/**
+ Creates a FBSimulatorLaunchCtl instance for the provided Simulator
+ 
+ @param simulator the Simulator to create a launchctl wrapper for.
+ @return a new FBSimulatorLaunchCtl instance.
+ */
++ (instancetype)withSimulator:(FBSimulator *)simulator;
+
+/**
+ Consults the Simulator's launchctl to determine if the given process
+
+ @param process the Simulator to create a launchctl wrapper for.
+ @param error an error for any error that occurs.
+ @return a new FBSimulatorLaunchCtl instance.
+ */
+- (BOOL)processIsRunningOnSimulator:(FBProcessInfo *)process error:(NSError **)error;
+
+@end

--- a/FBSimulatorControl/Utility/FBSimulatorLaunchCtl.m
+++ b/FBSimulatorControl/Utility/FBSimulatorLaunchCtl.m
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBSimulatorLaunchCtl.h"
+
+#import "FBProcessInfo.h"
+#import "FBSimulatorControlGlobalConfiguration.h"
+#import "FBProcessLaunchConfiguration+Helpers.h"
+#import "FBProcessLaunchConfiguration.h"
+#import "FBSimDeviceWrapper.h"
+#import "FBSimulator.h"
+#import "FBSimulator+Helpers.h"
+#import "FBSimulatorApplication.h"
+#import "FBSimulatorError.h"
+#import "NSRunLoop+SimulatorControlAdditions.h"
+
+@interface FBSimulatorLaunchCtl ()
+
+@property (nonatomic, strong, readonly) FBSimulator *simulator;
+
+@end
+
+@implementation FBSimulatorLaunchCtl
+
+#pragma mark Initializers
+
++ (instancetype)withSimulator:(FBSimulator *)simulator
+{
+  return [[self alloc] initWithSimulator:simulator];
+}
+
+- (instancetype)initWithSimulator:(FBSimulator *)simulator
+{
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  _simulator = simulator;
+
+  return self;
+}
+
+#pragma mark Public
+
+- (BOOL)processIsRunningOnSimulator:(FBProcessInfo *)process error:(NSError **)error
+{
+  // Construct a Launch Configuration for launchctl.
+  // launchctl requires that it's 1st argument is the name 'launchctl'.
+  FBAgentLaunchConfiguration *launchConfiguration = [FBAgentLaunchConfiguration
+    configurationWithBinary:FBSimulatorBinary.launchCtl
+    arguments:@[@"launchctl", @"list"]
+    environment:@{}];
+
+  // Construct a pipe to stdout and read asynchronously from it.
+  // Synchronize on the mutable string.
+  NSPipe *stdOutPipe = [NSPipe pipe];
+  NSDictionary *options = [launchConfiguration simDeviceLaunchOptionsWithStdOut:stdOutPipe.fileHandleForWriting stdErr:nil];
+  NSMutableString *haystack = [NSMutableString string];
+  stdOutPipe.fileHandleForReading.readabilityHandler = ^(NSFileHandle *handle) {
+    NSString *string = [[NSString alloc] initWithData:handle.availableData encoding:NSUTF8StringEncoding];
+    @synchronized(haystack)
+    {
+      [haystack appendString:string];
+    }
+  };
+
+  // Spawn the Process.
+  NSError *innerError = nil;
+  pid_t processIdentifier = [self.simulator.simDeviceWrapper
+    spawnShortRunningWithPath:launchConfiguration.agentBinary.path
+    options:options
+    timeout:FBSimulatorControlGlobalConfiguration.fastTimeout
+    error:&innerError];
+  if (processIdentifier <= 0) {
+    return [[[FBSimulatorError
+      describeFormat:@"Could not get launchctl info for process %@ as the spawn of launchctl failed", process.shortDescription]
+      causedBy:innerError]
+      failBool:error];
+  }
+
+  // Wait for the data to exist.
+  NSString *needle = [NSString stringWithFormat:@"%d", process.processIdentifier];
+  return [NSRunLoop.currentRunLoop spinRunLoopWithTimeout:FBSimulatorControlGlobalConfiguration.fastTimeout untilTrue:^BOOL{
+    @synchronized(haystack)
+    {
+      return [haystack containsString:needle];
+    }
+  }];
+}
+
+@end

--- a/FBSimulatorControlTests/Tests/FBSimulatorLaunchTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorLaunchTests.m
@@ -65,6 +65,11 @@
 
   [self.assert consumeAllNotifications];
   [self assertInteractionSuccessful:[[[session.interact bootSimulator:self.simulatorLaunchConfiguration] installApplication:appLaunch.application] launchApplication:appLaunch]];
+  [self assertLastLaunchedApplicationIsRunning:session.simulator];
+
+  FBProcessInfo *process = session.simulator.history.lastLaunchedApplicationProcess;
+  XCTAssertTrue(process.processIdentifier);
+  XCTAssertTrue([session.simulator.launchctl processIsRunningOnSimulator:process error:nil]);
 
   [self.assert bootingNotificationsFired];
   [self.assert consumeNotification:FBSimulatorApplicationProcessDidLaunchNotification];

--- a/FBSimulatorControlTests/Utilities/FBSimulatorControlAssertions.h
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorControlAssertions.h
@@ -58,6 +58,13 @@
  */
 - (void)assertSimulatorShutdown:(FBSimulator *)simulator;
 
+#pragma mark Processes
+
+/**
+ Assertion failure if there isn't a last launched application or launchctl isn't aware of the process.
+ */
+- (void)assertLastLaunchedApplicationIsRunning:(FBSimulator *)simulator;
+
 @end
 
 /**

--- a/FBSimulatorControlTests/Utilities/FBSimulatorControlAssertions.m
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorControlAssertions.m
@@ -73,6 +73,18 @@
   XCTAssertNil(simulator.containerApplication);
 }
 
+#pragma mark Processes
+
+- (void)assertLastLaunchedApplicationIsRunning:(FBSimulator *)simulator
+{
+  FBProcessInfo *process = simulator.history.lastLaunchedApplicationProcess;
+  XCTAssertTrue(process.processIdentifier);
+  NSError *error = nil;
+  BOOL isRunning = [simulator.launchctl processIsRunningOnSimulator:process error:nil];
+  XCTAssertTrue(isRunning);
+  XCTAssertNil(error);
+}
+
 @end
 
 @interface FBSimulatorControlNotificationAssertions ()


### PR DESCRIPTION
In #175 I discovered a race that can occur between the killing of a process and the Simulator's knowledge of this process in `launchctl`.

By looking at `launchctl`s knowledge of the world by spawning a `launchctl` process from `FBSimulatorControl` (via `CoreSimulator`) we can know whether `launchctl` is aware of the process or not. I am looking to add features to this class over time as there's plenty of useful information in `launchctl` that we currently don't have access to in `FBSimulatorControl`.