### PR TITLE
Add method to return home directory for last app launched

### DIFF
--- a/FBSimulatorControl/Management/FBSimulator+Helpers.h
+++ b/FBSimulatorControl/Management/FBSimulator+Helpers.h
@@ -112,4 +112,8 @@
  */
 - (NSSet *)requiredProcessNamesToVerifyBooted;
 
+/**
+ Returns the home folder of the last application launched
+ */
+- (NSString *)homeDirectoryOfLastLaunchedApplication;
 @end

--- a/FBSimulatorControl/Management/FBSimulator+Helpers.m
+++ b/FBSimulatorControl/Management/FBSimulator+Helpers.m
@@ -19,6 +19,7 @@
 #import "FBSimulatorApplication.h"
 #import "FBSimulatorControlGlobalConfiguration.h"
 #import "FBSimulatorError.h"
+#import "FBSimulatorHistory+Queries.h"
 #import "FBSimulatorInteraction.h"
 #import "FBSimulatorPool.h"
 #import "NSRunLoop+SimulatorControlAdditions.h"
@@ -192,6 +193,13 @@
     ]];
   }
   return [NSSet set];
+}
+
+- (NSString *)homeDirectoryOfLastLaunchedApplication
+{
+  FBProcessInfo* processInfo = [self.history lastLaunchedApplicationProcess];
+  NSDictionary* environment = processInfo.environment;
+  return environment[@"HOME"];
 }
 
 @end


### PR DESCRIPTION
This pull request is to add a method for FBSimulatorControl to return the home directory for the last app launched.