### PR TITLE
Add FBJSONSerializationDescribeable Protocol

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		AACA2C381C2976B100979C45 /* FBAddVideoPolyfill.m in Sources */ = {isa = PBXBuildFile; fileRef = AACA2C361C2976B100979C45 /* FBAddVideoPolyfill.m */; };
 		AAD3051F1BD4D5B10047376E /* photo0.png in Resources */ = {isa = PBXBuildFile; fileRef = AAD3051D1BD4D5B10047376E /* photo0.png */; };
 		AAD305201BD4D5B10047376E /* photo1.png in Resources */ = {isa = PBXBuildFile; fileRef = AAD3051E1BD4D5B10047376E /* photo1.png */; };
+		AAD497851C50F0BB00ABC1A7 /* FBJSONSerializationDescribeable.h in Headers */ = {isa = PBXBuildFile; fileRef = AAD497841C50F0BB00ABC1A7 /* FBJSONSerializationDescribeable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AAD51E9F1C3ADECA00A763D0 /* FBSimulatorLaunchConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = AAD51E9D1C3ADECA00A763D0 /* FBSimulatorLaunchConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AAD51EA01C3ADECA00A763D0 /* FBSimulatorLaunchConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD51E9E1C3ADECA00A763D0 /* FBSimulatorLaunchConfiguration.m */; };
 		AAD51EA31C3AEFEA00A763D0 /* FBSimulatorLaunchConfiguration+Helpers.h in Headers */ = {isa = PBXBuildFile; fileRef = AAD51EA11C3AEFEA00A763D0 /* FBSimulatorLaunchConfiguration+Helpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -937,6 +938,7 @@
 		AACA2C361C2976B100979C45 /* FBAddVideoPolyfill.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBAddVideoPolyfill.m; sourceTree = "<group>"; };
 		AAD3051D1BD4D5B10047376E /* photo0.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = photo0.png; sourceTree = "<group>"; };
 		AAD3051E1BD4D5B10047376E /* photo1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = photo1.png; sourceTree = "<group>"; };
+		AAD497841C50F0BB00ABC1A7 /* FBJSONSerializationDescribeable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBJSONSerializationDescribeable.h; sourceTree = "<group>"; };
 		AAD51E9D1C3ADECA00A763D0 /* FBSimulatorLaunchConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorLaunchConfiguration.h; sourceTree = "<group>"; };
 		AAD51E9E1C3ADECA00A763D0 /* FBSimulatorLaunchConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorLaunchConfiguration.m; sourceTree = "<group>"; };
 		AAD51EA11C3AEFEA00A763D0 /* FBSimulatorLaunchConfiguration+Helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FBSimulatorLaunchConfiguration+Helpers.h"; sourceTree = "<group>"; };
@@ -1809,6 +1811,7 @@
 		AA95170A1C15F54600A89CAD /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				AAD497841C50F0BB00ABC1A7 /* FBJSONSerializationDescribeable.h */,
 				AA95170E1C15F54600A89CAD /* FBSimulatorApplication.h */,
 				AA95170F1C15F54600A89CAD /* FBSimulatorApplication.m */,
 				AA9517131C15F54600A89CAD /* FBSimulatorHistory.h */,
@@ -2045,6 +2048,7 @@
 				AAF2D3561C33EA3100434516 /* FBSimulatorInteraction+Lifecycle.h in Headers */,
 				AA7490051C4E6CBA00F3BDBA /* FBSimulatorLaunchConfiguration+Private.h in Headers */,
 				AA95179D1C15F54600A89CAD /* FBProcessQuery.h in Headers */,
+				AAD497851C50F0BB00ABC1A7 /* FBJSONSerializationDescribeable.h in Headers */,
 				AA9517A11C15F54600A89CAD /* FBSimulatorSession+Private.h in Headers */,
 				AA78DCDA1C5005D2006FAB41 /* FBSimulatorLaunchCtl.h in Headers */,
 				AA2219951C3E752800371B01 /* FBCoreSimulatorTerminationStrategy.h in Headers */,

--- a/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration.h
@@ -9,6 +9,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import <FBSimulatorControl/FBJSONSerializationDescribeable.h>
+
 @class FBSimulator;
 @class FBSimulatorApplication;
 @class FBSimulatorBinary;
@@ -16,7 +18,7 @@
 /**
  An abstract value object for launching both agents and applications
  */
-@interface FBProcessLaunchConfiguration : NSObject <NSCopying, NSCoding>
+@interface FBProcessLaunchConfiguration : NSObject <NSCopying, NSCoding, FBJSONSerializationDescribeable>
 
 /**
  An NSArray<NSString *> of arguments to the process. Will not be nil.

--- a/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration.m
@@ -106,6 +106,18 @@
   return [self debugDescription];
 }
 
+#pragma mark FBJSONSerializationDescribeable
+
+- (NSDictionary *)jsonSerializableRepresentation
+{
+  return @{
+    @"arguments" : self.arguments,
+    @"environment" : self.environment,
+    @"stdout_path" : self.stdOutPath ?: NSNull.null,
+    @"stderr_path" : self.stdErrPath ?: NSNull.null,
+  };
+}
+
 @end
 
 @implementation FBApplicationLaunchConfiguration
@@ -216,6 +228,16 @@
          (self.bundleName == object.bundleName || [self.bundleName isEqual:object.bundleName]);
 }
 
+#pragma mark FBJSONSerializationDescribeable
+
+- (NSDictionary *)jsonSerializableRepresentation
+{
+  NSMutableDictionary *representation = [[super jsonSerializableRepresentation] mutableCopy];
+  representation[@"bundle_id"] = self.bundleID;
+  representation[@"bundle_name"] = self.bundleName;
+  return [representation mutableCopy];
+}
+
 @end
 
 @implementation FBAgentLaunchConfiguration
@@ -317,6 +339,15 @@
   return [self.agentBinary isEqual:object.agentBinary] &&
   [self.arguments isEqual:object.arguments] &&
   [self.environment isEqual:object.environment];
+}
+
+#pragma mark FBJSONSerializationDescribeable
+
+- (NSDictionary *)jsonSerializableRepresentation
+{
+  NSMutableDictionary *representation = [[super jsonSerializableRepresentation] mutableCopy];
+  representation[@"binary"] = [self.agentBinary jsonSerializableRepresentation];
+  return [representation mutableCopy];
 }
 
 @end

--- a/FBSimulatorControl/FBSimulatorControl.h
+++ b/FBSimulatorControl/FBSimulatorControl.h
@@ -19,6 +19,7 @@
 #import <FBSimulatorControl/FBDispatchSourceNotifier.h>
 #import <FBSimulatorControl/FBInteraction+Private.h>
 #import <FBSimulatorControl/FBInteraction.h>
+#import <FBSimulatorControl/FBJSONSerializationDescribeable.h>
 #import <FBSimulatorControl/FBProcessInfo+Helpers.h>
 #import <FBSimulatorControl/FBProcessInfo.h>
 #import <FBSimulatorControl/FBProcessLaunchConfiguration+Helpers.h>

--- a/FBSimulatorControl/Logs/FBWritableLog.h
+++ b/FBSimulatorControl/Logs/FBWritableLog.h
@@ -9,11 +9,13 @@
 
 #import <Foundation/Foundation.h>
 
+#import <FBSimulatorControl/FBJSONSerializationDescribeable.h>
+
 /**
  Defines the content & metadata of a log.
  Lazily converts between the backing store data formats.
  */
-@interface FBWritableLog : NSObject <NSCopying>
+@interface FBWritableLog : NSObject <NSCopying, FBJSONSerializationDescribeable>
 
 /**
  The name of the Log for uniquely identifying the log.
@@ -51,12 +53,6 @@
  The content of the log, as represented by a File Path.
  */
 @property (nonatomic, readonly, copy) NSString *asPath;
-
-/**
- The content and metadata of the log, as a NSDictionary.
- All keys and values are types allowable by NSJSONSerialization.
- */
-@property (nonatomic, readonly, copy) NSDictionary *asDictionary;
 
 /**
  Whether the log has content or is missing/empty.

--- a/FBSimulatorControl/Logs/FBWritableLog.m
+++ b/FBSimulatorControl/Logs/FBWritableLog.m
@@ -81,7 +81,7 @@
   return NO;
 }
 
-- (NSDictionary *)asDictionary
+- (NSDictionary *)jsonSerializableRepresentation
 {
   NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
   if (self.shortName) {
@@ -153,9 +153,9 @@
   return self.logPath;
 }
 
-- (NSDictionary *)asDictionary
+- (NSDictionary *)jsonSerializableRepresentation
 {
-  NSMutableDictionary *dictionary = [[super asDictionary] mutableCopy];
+  NSMutableDictionary *dictionary = [[super jsonSerializableRepresentation] mutableCopy];
   NSString *base64String = [self.logData base64EncodedStringWithOptions:0];
   if (base64String) {
     dictionary[@"data"] = base64String;
@@ -217,9 +217,9 @@
   return self.logPath;
 }
 
-- (NSDictionary *)asDictionary
+- (NSDictionary *)jsonSerializableRepresentation
 {
-  NSMutableDictionary *dictionary = [[super asDictionary] mutableCopy];
+  NSMutableDictionary *dictionary = [[super jsonSerializableRepresentation] mutableCopy];
   dictionary[@"contents"] = self.logString;
   return dictionary;
 }
@@ -276,9 +276,9 @@
   return self.logPath;
 }
 
-- (NSDictionary *)asDictionary
+- (NSDictionary *)jsonSerializableRepresentation
 {
-  NSMutableDictionary *dictionary = [[super asDictionary] mutableCopy];
+  NSMutableDictionary *dictionary = [[super jsonSerializableRepresentation] mutableCopy];
   dictionary[@"location"] = self.logPath;
   return dictionary;
 }

--- a/FBSimulatorControl/Management/FBSimulator.h
+++ b/FBSimulatorControl/Management/FBSimulator.h
@@ -9,6 +9,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import <FBSimulatorControl/FBJSONSerializationDescribeable.h>
+
 @protocol FBSimulatorEventSink;
 @protocol FBSimulatorLogger;
 @class FBProcessInfo;
@@ -49,7 +51,7 @@ typedef NS_ENUM(NSInteger, FBSimulatorProductFamily) {
 /**
  Defines the High-Level Properties and Methods that exist on any Simulator returned from `FBSimulatorPool`.
  */
-@interface FBSimulator : NSObject
+@interface FBSimulator : NSObject <FBJSONSerializationDescribeable>
 
 /**
  The Underlying SimDevice.

--- a/FBSimulatorControl/Management/FBSimulator.m
+++ b/FBSimulatorControl/Management/FBSimulator.m
@@ -196,4 +196,14 @@
   return [NSString stringWithFormat:@"Simulator %@", self.udid];
 }
 
+#pragma mark FBJSONSerializationDescribeable
+
+- (NSDictionary *)jsonSerializableRepresentation
+{
+  return @{
+    @"name" : self.device.name,
+    @"state" : self.device.stateString
+  };
+}
+
 @end

--- a/FBSimulatorControl/Model/FBJSONSerializationDescribeable.h
+++ b/FBSimulatorControl/Model/FBJSONSerializationDescribeable.h
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+/**
+ Protocol for denoting objects that are serializable with NSJSONSerialization.
+ */
+@protocol FBJSONSerializationDescribeable
+
+/**
+ Returns an NSJSONSerialization-compatible representation of the reciever.
+ For more information about permitted types, refer the the NSJSONSerialization Documentation.
+
+ @return an NSJSONSerialization-compatible representation of the reciever.
+ */
+- (id)jsonSerializableRepresentation;
+
+@end

--- a/FBSimulatorControl/Model/FBSimulatorApplication.h
+++ b/FBSimulatorControl/Model/FBSimulatorApplication.h
@@ -9,10 +9,12 @@
 
 #import <Foundation/Foundation.h>
 
+#import <FBSimulatorControl/FBJSONSerializationDescribeable.h>
+
 /**
  Concrete value wrapper around a binary artifact.
  */
-@interface FBSimulatorBinary : NSObject <NSCopying, NSCoding>
+@interface FBSimulatorBinary : NSObject <NSCopying, NSCoding, FBJSONSerializationDescribeable>
 
 /**
  The Designated Initializer.
@@ -54,7 +56,7 @@
 /**
  Concrete value wrapper around a Application artifact.
  */
-@interface FBSimulatorApplication : NSObject <NSCopying, NSCoding>
+@interface FBSimulatorApplication : NSObject <NSCopying, NSCoding, FBJSONSerializationDescribeable>
 
 /**
  The Designated Initializer.

--- a/FBSimulatorControl/Model/FBSimulatorApplication.m
+++ b/FBSimulatorControl/Model/FBSimulatorApplication.m
@@ -104,6 +104,17 @@
   ];
 }
 
+#pragma mark FBJSONSerializationDescribeable
+
+- (NSDictionary *)jsonSerializableRepresentation
+{
+  return [self dictionaryWithValuesForKeys:@[
+    NSStringFromSelector(@selector(name)),
+    NSStringFromSelector(@selector(path)),
+    NSStringFromSelector(@selector(architectures))
+  ]];
+}
+
 @end
 
 @implementation FBSimulatorApplication
@@ -198,6 +209,18 @@
     self.path,
     self.binary
   ];
+}
+
+#pragma mark FBJSONSerializationDescribeable
+
+- (NSDictionary *)jsonSerializableRepresentation
+{
+  return @{
+    @"name" : self.name,
+    @"bundle_id" : self.bundleID,
+    @"path" : self.path,
+    @"binary" : self.binary.jsonSerializableRepresentation
+  };
 }
 
 @end

--- a/FBSimulatorControl/Processes/FBProcessInfo.h
+++ b/FBSimulatorControl/Processes/FBProcessInfo.h
@@ -9,12 +9,14 @@
 
 #import <Foundation/Foundation.h>
 
+#import <FBSimulatorControl/FBJSONSerializationDescribeable.h>
+
 @class FBProcessLaunchConfiguration;
 
 /**
  Concrete Value of Process Information.
  */
-@interface FBProcessInfo : NSObject <NSCopying, NSCoding>
+@interface FBProcessInfo : NSObject <NSCopying, NSCoding, FBJSONSerializationDescribeable>
 
 /**
  The Designated Initializer.

--- a/FBSimulatorControl/Processes/FBProcessInfo.m
+++ b/FBSimulatorControl/Processes/FBProcessInfo.m
@@ -22,6 +22,10 @@
 
 - (instancetype)initWithProcessIdentifier:(pid_t)processIdentifier launchPath:(NSString *)launchPath arguments:(NSArray *)arguments environment:(NSDictionary *)environment
 {
+  NSParameterAssert(launchPath);
+  NSParameterAssert(arguments);
+  NSParameterAssert(environment);
+
   self = [super init];
   if (!self) {
     return nil;
@@ -45,9 +49,9 @@
     return NO;
   }
   return self.processIdentifier == object.processIdentifier &&
-        [self.launchPath isEqual:object.launchPath] &&
-        [self.arguments isEqual:object.arguments] &&
-        [self.environment isEqual:object.environment];
+         [self.launchPath isEqual:object.launchPath] &&
+         [self.arguments isEqual:object.arguments] &&
+         [self.environment isEqual:object.environment];
 }
 
 #pragma mark Accessors
@@ -115,6 +119,18 @@
   [coder encodeObject:self.launchPath forKey:NSStringFromSelector(@selector(launchPath))];
   [coder encodeObject:self.arguments forKey:NSStringFromSelector(@selector(arguments))];
   [coder encodeObject:self.environment forKey:NSStringFromSelector(@selector(environment))];
+}
+
+#pragma mark FBJSONSerializationDescribeable
+
+- (NSDictionary *)jsonSerializableRepresentation
+{
+  return @{
+    @"launch_path" : self.launchPath,
+    @"arguments" : self.arguments,
+    @"name" : self.processName,
+    @"pid" : @(self.processIdentifier)
+  };
 }
 
 @end

--- a/fbsimctl/FBSimulatorControlKit/Sources/JSON.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/JSON.swift
@@ -8,14 +8,22 @@
  */
 
 import Foundation
+import FBSimulatorControl
 
 public struct JSONError : ErrorType {
 
 }
 
 public struct JSON {
-  static func serializeToString(object: AnyObject) throws -> String {
-    let data = try NSJSONSerialization.dataWithJSONObject(object, options: NSJSONWritingOptions.PrettyPrinted)
+  static func serializeToString(objects: [AnyObject]) throws -> String {
+    let descriptions: [AnyObject] = objects.flatMap { candidate in
+      guard let describable = candidate as? FBJSONSerializationDescribeable else {
+        return nil
+      }
+      return describable.jsonSerializableRepresentation()
+    }
+
+    let data = try NSJSONSerialization.dataWithJSONObject(descriptions, options: NSJSONWritingOptions.PrettyPrinted)
     guard let string = NSString(data: data, encoding: NSUTF8StringEncoding) else {
       throw JSONError()
     }

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -196,14 +196,7 @@ private struct SimulatorRunner : Runner {
         try simulator.interact().shutdownSimulator().performInteraction()
         writer.write("Shutdown \(self.formattedSimulator)")
       case .Diagnose:
-        let logs: [NSDictionary] = simulator.logs.allLogs().flatMap { candidate in
-          guard let log = candidate as? FBWritableLog else {
-            return nil
-          }
-          return log.asDictionary
-        }
-        let string = try JSON.serializeToString(logs)
-        writer.write(string)
+        writer.write(try JSON.serializeToString(simulator.logs.allLogs()))
       case .Delete:
         writer.write("Deleteing \(self.formattedSimulator)")
         try simulator.pool!.deleteSimulator(simulator)


### PR DESCRIPTION
Adds a protocol for defining `NSObject`s that can be represented in a `NSDictionary` that is serializable with `NSJSONSerialization`