### PR TITLE
Add Bundle Name to FBApplicationLaunchConfiguration

### DIFF
--- a/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration+Private.h
+++ b/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration+Private.h
@@ -21,6 +21,7 @@
 @interface FBApplicationLaunchConfiguration ()
 
 @property (nonatomic, copy, readwrite) NSString *bundleID;
+@property (nonatomic, copy, readwrite) NSString *bundleName;
 
 @end
 

--- a/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration.h
@@ -19,22 +19,22 @@
 @interface FBProcessLaunchConfiguration : NSObject <NSCopying, NSCoding>
 
 /**
- An NSArray<NSString *> of arguments to the process.
+ An NSArray<NSString *> of arguments to the process. Will not be nil.
  */
 @property (nonatomic, copy, readonly) NSArray *arguments;
 
 /**
- A NSDictionary<NSString *, NSString *> of the Environment of the launched Application process.
+ A NSDictionary<NSString *, NSString *> of the Environment of the launched Application process. Will not be nil.
  */
 @property (nonatomic, copy, readonly) NSDictionary *environment;
 
 /**
- The file path where the stdout of the launched process should be written.
+ The file path where the stdout of the launched process should be written. May be nil.
  */
 @property (nonatomic, copy, readonly) NSString *stdOutPath;
 
 /**
- The file path where the stderr of the launched process should be written.
+ The file path where the stderr of the launched process should be written. May be nil.
  */
 @property (nonatomic, copy, readonly) NSString *stdErrPath;
 
@@ -58,9 +58,9 @@
 /**
  Creates and returns a new Configuration with the provided parameters.
 
- @param application the Application to Launch.
- @param arguments an NSArray<NSString *> of arguments to the process.
- @param environment a NSDictionary<NSString *, NSString *> of the Environment of the launched Application process.
+ @param application the Application to Launch. Must not be nil.
+ @param arguments an NSArray<NSString *> of arguments to the process. Must not be nil.
+ @param environment a NSDictionary<NSString *, NSString *> of the Environment of the launched Application process. Must not be nil.
  @returns a new Configuration Object with the arguments applied.
  */
 + (instancetype)configurationWithApplication:(FBSimulatorApplication *)application arguments:(NSArray *)arguments environment:(NSDictionary *)environment;
@@ -69,8 +69,8 @@
  Creates and returns a new Configuration with the provided parameters.
 
  @param application the Application to Launch.
- @param arguments an NSArray<NSString *> of arguments to the process.
- @param environment a NSDictionary<NSString *, NSString *> of the Environment of the launched Application process.
+ @param arguments an NSArray<NSString *> of arguments to the process. Must not be nil.
+ @param environment a NSDictionary<NSString *, NSString *> of the Environment of the launched Application process. Must not be nil.
  @param stdOutPath the file path where the stderr of the launched process should be written. May be nil.
  @param stdErrPath The file path where the stderr of the launched process should be written. May be nil.
  @returns a new Configuration Object with the arguments applied.
@@ -80,29 +80,36 @@
 /**
  Creates and returns a new Configuration with the provided parameters.
 
- @param bundleID the Bundle ID of the App to Launch.
- @param arguments an NSArray<NSString *> of arguments to the process.
- @param environment a NSDictionary<NSString *, NSString *> of the Environment of the launched Application process.
+ @param bundleID the Bundle ID of the App to Launch. Must not be nil.
+ @param bundleName the BundleName (CFBundleName) of the App to Launch. Must not be nil.
+ @param arguments an NSArray<NSString *> of arguments to the process. Must not be nil.
+ @param environment a NSDictionary<NSString *, NSString *> of the Environment of the launched Application process. Must not be nil.
  @returns a new Configuration Object with the arguments applied.
  */
-+ (instancetype)configurationWithBundleID:(NSString *)bundleID arguments:(NSArray *)arguments environment:(NSDictionary *)environment;
++ (instancetype)configurationWithBundleID:(NSString *)bundleID bundleName:(NSString *)bundleName arguments:(NSArray *)arguments environment:(NSDictionary *)environment;
 
 /**
  Creates and returns a new Configuration with the provided parameters.
 
- @param bundleID the Bundle ID of the App to Launch.
- @param arguments an NSArray<NSString *> of arguments to the process.
- @param environment a NSDictionary<NSString *, NSString *> of the Environment of the launched Application process.
+ @param bundleID the Bundle ID (CFBundleIdentifier) of the App to Launch. Must not be nil.
+ @param bundleName the BundleName (CFBundleName) of the App to Launch. May be nil.
+ @param arguments an NSArray<NSString *> of arguments to the process. Must not be nil.
+ @param environment a NSDictionary<NSString *, NSString *> of the Environment of the launched Application process. Must not be nil.
  @param stdOutPath the file path where the stderr of the launched process should be written. May be nil.
  @param stdErrPath The file path where the stderr of the launched process should be written. May be nil.
  @returns a new Configuration Object with the arguments applied.
  */
-+ (instancetype)configurationWithBundleID:(NSString *)bundleID arguments:(NSArray *)arguments environment:(NSDictionary *)environment stdOutPath:(NSString *)stdOutPath stdErrPath:(NSString *)stdErrPath;
++ (instancetype)configurationWithBundleID:(NSString *)bundleID bundleName:(NSString *)bundleName arguments:(NSArray *)arguments environment:(NSDictionary *)environment stdOutPath:(NSString *)stdOutPath stdErrPath:(NSString *)stdErrPath;
 
 /**
- The Bundle ID of the the Application to Launch.
+ The Bundle ID (CFBundleIdentifier) of the the Application to Launch. Will not be nil.
  */
 @property (nonatomic, copy, readonly) NSString *bundleID;
+
+/**
+ The Name (CFBundleName) of the the Application to Launch. May be nil.
+ */
+@property (nonatomic, copy, readonly) NSString *bundleName;
 
 @end
 
@@ -114,9 +121,9 @@
 /**
  Creates and returns a new Configuration with the provided parameters
 
- @param agentBinary the Binary Path of the agent to Launch
- @param arguments an array-of-strings of arguments to the process
- @param environment a Dictionary, mapping Strings to Strings of the Environment to set in the launched Application process
+ @param agentBinary the Binary Path of the agent to Launch. Must not be nil.
+ @param arguments an array-of-strings of arguments to the process. Must not be nil.
+ @param environment a Dictionary, mapping Strings to Strings of the Environment to set in the launched Application process. Must not be nil.
  @returns a new Configuration Object with the arguments applied.
  */
 + (instancetype)configurationWithBinary:(FBSimulatorBinary *)agentBinary arguments:(NSArray *)arguments environment:(NSDictionary *)environment;
@@ -124,9 +131,9 @@
 /**
  Creates and returns a new Configuration with the provided parameters
 
- @param agentBinary the Binary Path of the agent to Launch
- @param arguments an array-of-strings of arguments to the process
- @param environment a Dictionary, mapping Strings to Strings of the Environment to set in the launched Application process
+ @param agentBinary the Binary Path of the agent to Launch. Must not be nil.
+ @param arguments an array-of-strings of arguments to the process. Must not be nil.
+ @param environment a Dictionary, mapping Strings to Strings of the Environment to set in the launched Application process. Must not be nil.
  @param stdOutPath the file path where the stderr of the launched process should be written. May be nil.
  @param stdErrPath The file path where the stderr of the launched process should be written. May be nil.
  @returns a new Configuration Object with the arguments applied.

--- a/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBProcessLaunchConfiguration.m
@@ -117,24 +117,24 @@
 
 + (instancetype)configurationWithApplication:(FBSimulatorApplication *)application arguments:(NSArray *)arguments environment:(NSDictionary *)environment stdOutPath:(NSString *)stdOutPath stdErrPath:(NSString *)stdErrPath
 {
-  return [self configurationWithBundleID:application.bundleID arguments:arguments environment:environment stdOutPath:stdOutPath stdErrPath:stdErrPath];
+  return [self configurationWithBundleID:application.bundleID bundleName:application.name arguments:arguments environment:environment stdOutPath:stdOutPath stdErrPath:stdErrPath];
 }
 
-+ (instancetype)configurationWithBundleID:(NSString *)bundleID arguments:(NSArray *)arguments environment:(NSDictionary *)environment
++ (instancetype)configurationWithBundleID:(NSString *)bundleID bundleName:(NSString *)bundleName arguments:(NSArray *)arguments environment:(NSDictionary *)environment
 {
-  return [self configurationWithBundleID:bundleID arguments:arguments environment:environment stdOutPath:nil stdErrPath:nil];
+  return [self configurationWithBundleID:bundleID bundleName:bundleName arguments:arguments environment:environment stdOutPath:nil stdErrPath:nil];
 }
 
-+ (instancetype)configurationWithBundleID:(NSString *)bundleID arguments:(NSArray *)arguments environment:(NSDictionary *)environment stdOutPath:(NSString *)stdOutPath stdErrPath:(NSString *)stdErrPath
++ (instancetype)configurationWithBundleID:(NSString *)bundleID bundleName:(NSString *)bundleName arguments:(NSArray *)arguments environment:(NSDictionary *)environment stdOutPath:(NSString *)stdOutPath stdErrPath:(NSString *)stdErrPath
 {
   if (!bundleID || !arguments || !environment) {
     return nil;
   }
 
-  return [[self alloc] initWithBundleID:bundleID arguments:arguments environment:environment stdOutPath:stdOutPath stdErrPath:stdErrPath];
+  return [[self alloc] initWithBundleID:bundleID bundleName:bundleName arguments:arguments environment:environment stdOutPath:stdOutPath stdErrPath:stdErrPath];
 }
 
-- (instancetype)initWithBundleID:(NSString *)bundleID arguments:(NSArray *)arguments environment:(NSDictionary *)environment stdOutPath:(NSString *)stdOutPath stdErrPath:(NSString *)stdErrPath
+- (instancetype)initWithBundleID:(NSString *)bundleID bundleName:(NSString *)bundleName arguments:(NSArray *)arguments environment:(NSDictionary *)environment stdOutPath:(NSString *)stdOutPath stdErrPath:(NSString *)stdErrPath
 {
   self = [super initWithArguments:arguments environment:environment stdOutPath:stdOutPath stdErrPath:stdErrPath];
   if (!self) {
@@ -142,6 +142,7 @@
   }
 
   _bundleID = bundleID;
+  _bundleName = bundleName;
 
   return self;
 }
@@ -151,8 +152,8 @@
 - (NSString *)debugDescription
 {
   return [NSString stringWithFormat:
-    @"App Launch %@ | Arguments %@ | Environment %@ | StdOut %@ | StdErr %@",
-    self.bundleID,
+    @"%@ | Arguments %@ | Environment %@ | StdOut %@ | StdErr %@",
+    self.shortDescription,
     self.arguments,
     self.environment,
     self.stdOutPath,
@@ -162,7 +163,7 @@
 
 - (NSString *)shortDescription
 {
-  return [NSString stringWithFormat:@"App Launch %@", self.bundleID];
+  return [NSString stringWithFormat:@"App Launch %@ (%@)", self.bundleID, self.bundleName];
 }
 
 #pragma mark NSCopying
@@ -171,6 +172,7 @@
 {
   return [[self.class alloc]
     initWithBundleID:self.bundleID
+    bundleName:self.bundleName
     arguments:self.arguments
     environment:self.environment
     stdOutPath:self.stdOutPath
@@ -187,6 +189,7 @@
   }
 
   _bundleID = [coder decodeObjectForKey:NSStringFromSelector(@selector(bundleID))];
+  _bundleName = [coder decodeObjectForKey:NSStringFromSelector(@selector(bundleName))];
 
   return self;
 }
@@ -196,19 +199,21 @@
   [super encodeWithCoder:coder];
 
   [coder encodeObject:self.bundleID forKey:NSStringFromSelector(@selector(bundleID))];
+  [coder encodeObject:self.bundleName forKey:NSStringFromSelector(@selector(bundleName))];
 }
 
 #pragma mark NSObject
 
 - (NSUInteger)hash
 {
-  return [super hash] ^ self.bundleID.hash;
+  return [super hash] ^ self.bundleID.hash ^ self.bundleName.hash;
 }
 
 - (BOOL)isEqual:(FBApplicationLaunchConfiguration *)object
 {
   return [super isEqual:object] &&
-         [self.bundleID isEqualToString:object.bundleID];
+         [self.bundleID isEqualToString:object.bundleID] &&
+         (self.bundleName == object.bundleName || [self.bundleName isEqual:object.bundleName]);
 }
 
 @end

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -322,7 +322,7 @@ extension Interaction : Parsable {
         self.argumentParser()
       )
       .fmap { (bundleID, arguments) in
-        return FBApplicationLaunchConfiguration(bundleID: bundleID, arguments: arguments, environment : [:])
+        return FBApplicationLaunchConfiguration(bundleID: bundleID, bundleName: nil, arguments: arguments, environment : [:])
       }
   }
 

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
@@ -263,7 +263,7 @@ class InteractionParserTests : XCTestCase {
       (["diagnose"], Interaction.Diagnose),
       (["delete"], Interaction.Delete),
       (["install", Fixtures.application().path], Interaction.Install(Fixtures.application())),
-      (["launch", Fixtures.application().path], Interaction.Launch(FBApplicationLaunchConfiguration(application: Fixtures.application(), arguments: [], environment: [:]))),
+      (["launch", Fixtures.application().path], Interaction.Launch(FBApplicationLaunchConfiguration(bundleID: Fixtures.application().bundleID, bundleName: nil, arguments: [], environment: [:]))),
       (["launch", Fixtures.binary().path], Interaction.Launch(FBAgentLaunchConfiguration(binary: Fixtures.binary(), arguments: [], environment: [:])))
     ])
   }
@@ -325,25 +325,25 @@ class ActionParserTests : XCTestCase {
   }
 
   func testParsesAppLaunchByPath() {
-    let interaction = Interaction.Launch(FBApplicationLaunchConfiguration(application: Fixtures.application(), arguments: [], environment: [:]))
+    let interaction = Interaction.Launch(FBApplicationLaunchConfiguration(bundleID: Fixtures.application().bundleID, bundleName: nil, arguments: [], environment: [:]))
     let suffix: [String] = ["launch", Fixtures.application().path]
     self.assertWithDefaultActions(interaction, suffix: suffix)
   }
 
   func testParsesAppLaunchByPathWithArguments() {
-    let interaction = Interaction.Launch(FBApplicationLaunchConfiguration(application: Fixtures.application(), arguments: ["--foo", "-b", "-a", "-r"], environment: [:]))
+    let interaction = Interaction.Launch(FBApplicationLaunchConfiguration(bundleID: Fixtures.application().bundleID, bundleName: nil, arguments: ["--foo", "-b", "-a", "-r"], environment: [:]))
     let suffix: [String] = ["launch", Fixtures.application().path, "--foo", "-b", "-a", "-r"]
     self.assertWithDefaultActions(interaction, suffix: suffix)
   }
 
   func testParsesAppLaunchByBundleID() {
-    let interaction = Interaction.Launch(FBApplicationLaunchConfiguration(bundleID: "com.foo.bar", arguments: [], environment: [:]))
+    let interaction = Interaction.Launch(FBApplicationLaunchConfiguration(bundleID: "com.foo.bar", bundleName: nil, arguments: [], environment: [:]))
     let suffix: [String] = ["launch", "com.foo.bar"]
     self.assertWithDefaultActions(interaction, suffix: suffix)
   }
 
   func testParsesAppLaunchByBundleIDArguments() {
-    let interaction = Interaction.Launch(FBApplicationLaunchConfiguration(bundleID: "com.foo.bar", arguments: ["--foo", "-b", "-a", "-r"], environment: [:]))
+    let interaction = Interaction.Launch(FBApplicationLaunchConfiguration(bundleID: "com.foo.bar", bundleName: nil, arguments: ["--foo", "-b", "-a", "-r"], environment: [:]))
     let suffix: [String] = ["launch", "com.foo.bar", "--foo", "-b", "-a", "-r"]
     self.assertWithDefaultActions(interaction, suffix: suffix)
   }


### PR DESCRIPTION
This is an (optional) but nonetheless useful piece of information. Also clarifies the nullability semantics.