### PR TITLE
Remove logBuilder property

### DIFF
--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Diagnostics.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Diagnostics.m
@@ -93,7 +93,7 @@ typedef id<FBTask>(^FBDiagnosticTaskFactory)(FBTaskExecutor *executor, pid_t pro
 
 + (void)writeDiagnosticForSimulator:(FBSimulator *)simulator process:(FBProcessInfo *)process name:(NSString *)name value:(NSString *)value
 {
-  FBWritableLog *log = [[[[simulator.logs.logBuilder
+  FBWritableLog *log = [[[[[FBWritableLogBuilder builderWithWritableLog:simulator.logs.base]
     updateString:value]
     updateShortName:[NSString stringWithFormat:@"%@_%@_%d", name, process.processName, process.processIdentifier]]
     updateFileType:@"txt"]

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Video.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Video.m
@@ -44,10 +44,7 @@
 - (instancetype)recordVideo
 {
   return [self interactWithBootedSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
-    FBWritableLogBuilder *logBuilder = [[self.simulator.logs.logBuilder
-      updateShortName:FBSimulatorLogNameVideo]
-      updateFileType:@"mp4"];
-
+    FBWritableLogBuilder *logBuilder = [FBWritableLogBuilder builderWithWritableLog:simulator.logs.video];
     NSString *path = [logBuilder createPath];
 
     FBSimulatorVideoRecorder *recorder = [FBSimulatorVideoRecorder forSimulator:simulator logger:nil];

--- a/FBSimulatorControl/Logs/FBSimulatorLogs.h
+++ b/FBSimulatorControl/Logs/FBSimulatorLogs.h
@@ -49,25 +49,14 @@ extern NSString *const FBSimulatorLogNameVideo;
  Creates and returns a `FBSimulatorLogs` instance.
 
  @param simulator the Simulator to Fetch logs for.
- @return A new `FBSimulatorLogFetcher` instance.
+ @return A new `FBSimulatorLogs` instance for the provided Simulator.
  */
 + (instancetype)withSimulator:(FBSimulator *)simulator;
 
 /**
- Returns an FBWritableLogBuilder suitable for writing diagnostic log information to.
- This builder is configured to serialize to the appropriate directories.
-
- @return A new `FBSimulatorLogFetcher` instance.
+ The FBWritableLog Instance from which all other logs are derived.
  */
-- (FBWritableLogBuilder *)logBuilder;
-
-/**
- All of the FBWritableLog instances for the Simulator.
- Prunes empty logs.
-
- @return an NSArray<FBWritableLog> of all the Writable Logs associated with the Simulator.
- */
-- (NSArray *)allLogs;
+- (FBWritableLog *)base;
 
 /**
  The syslog of the Simulator.
@@ -83,6 +72,11 @@ extern NSString *const FBSimulatorLogNameVideo;
  The Bootstrap of the Simulator's launchd_sim.
  */
 - (FBWritableLog *)simulatorBootstrap;
+
+/**
+ A Video of the Simulator
+ */
+- (FBWritableLog *)video;
 
 /**
  Crash logs of all the subprocesses that have crashed in the Simulator after the specified date.
@@ -105,5 +99,13 @@ extern NSString *const FBSimulatorLogNameVideo;
  @return an NSDictionary<FBProcessInfo *, FBWritableLog> of the logs, filtered by launched process.
  */
 - (NSDictionary *)launchedProcessLogs;
+
+/**
+ All of the FBWritableLog instances for the Simulator.
+ Prunes empty logs.
+
+ @return an NSArray<FBWritableLog> of all the Writable Logs associated with the Simulator.
+ */
+- (NSArray *)allLogs;
 
 @end

--- a/FBSimulatorControl/Logs/FBWritableLog.h
+++ b/FBSimulatorControl/Logs/FBWritableLog.h
@@ -87,12 +87,20 @@
 + (instancetype)builder;
 
 /**
- Creates a new `FBWritableLogBuilder` taking the values from the passed throught `writableLog`.
+ Creates a new `FBWritableLogBuilder` copying all of the values from `writableLog`.
 
  @param writableLog the original Writable Log to copy values from.
  @return the reciever, for chaining.
  */
 + (instancetype)builderWithWritableLog:(FBWritableLog *)writableLog;
+
+/**
+ Updates the Writable Log in the builder.
+
+ @param writableLog the original Writable Log to copy values from.
+ @return the reciever, for chaining.
+ */
+- (instancetype)updateWritableLog:(FBWritableLog *)writableLog;
 
 /**
  Updates the `shortName` of the underlying `FBWritableLog`.

--- a/FBSimulatorControl/Logs/FBWritableLog.m
+++ b/FBSimulatorControl/Logs/FBWritableLog.m
@@ -125,13 +125,18 @@
 
 + (NSString *)defaultStorageDirectory
 {
-  NSString *uniqueDirectory = [NSString stringWithFormat:@"%@_%@", NSProcessInfo.processInfo.globallyUniqueString, NSUUID.UUID.UUIDString];
-  return [NSTemporaryDirectory() stringByAppendingPathComponent:uniqueDirectory];
+  return [NSTemporaryDirectory() stringByAppendingPathComponent:NSUUID.UUID.UUIDString];
 }
 
 - (NSString *)temporaryFilePath
 {
-  return [self.storageDirectory stringByAppendingPathExtension:self.fileType ?: @"unknown_log"];
+  NSString *filename = self.shortName ?: NSUUID.UUID.UUIDString;
+  filename = [filename stringByAppendingPathExtension:self.fileType ?: @"unknown_log"];
+
+  NSString *storageDirectory = self.storageDirectory;
+  [NSFileManager.defaultManager createDirectoryAtPath:storageDirectory withIntermediateDirectories:YES attributes:nil error:nil];
+
+  return [storageDirectory stringByAppendingPathComponent:filename];
 }
 
 #pragma mark FBJSONSerializationDescribeable
@@ -534,7 +539,9 @@
 - (instancetype)updateStorageDirectory:(NSString *)storageDirectory
 {
   if (![NSFileManager.defaultManager fileExistsAtPath:storageDirectory]) {
-    return self;
+    if (![NSFileManager.defaultManager createDirectoryAtPath:storageDirectory withIntermediateDirectories:YES attributes:nil error:nil]) {
+      return self;
+    }
   }
   self.writableLog.storageDirectory = storageDirectory;
   return self;

--- a/FBSimulatorControl/Logs/FBWritableLog.m
+++ b/FBSimulatorControl/Logs/FBWritableLog.m
@@ -496,14 +496,21 @@
 
 + (instancetype)builder
 {
-  return [self builderWithWritableLog:[FBWritableLog_Empty new]];
+  return [self builderWithWritableLog:nil];
 }
 
 + (instancetype)builderWithWritableLog:(FBWritableLog *)writableLog
 {
-  FBWritableLogBuilder *builder = [FBWritableLogBuilder new];
-  builder.writableLog = [writableLog copy];
-  return builder;
+  return [[FBWritableLogBuilder new] updateWritableLog:[writableLog copy] ?: [FBWritableLog_Empty new]];
+}
+
+- (instancetype)updateWritableLog:(FBWritableLog *)writableLog
+{
+  if (!writableLog) {
+    return self;
+  }
+  self.writableLog = writableLog;
+  return self;
 }
 
 - (instancetype)updateShortName:(NSString *)shortName


### PR DESCRIPTION
It made little sense to have a `logBuilder` property, so that all logs could be configured with the Simulator's auxillary directory. Instead all logs are derived from a 'base' log that can be built on top of. This means that video recording can build on top of the video property of `FBSimulatorLogs`.