### PR TITLE
Add Configuration to FBProcessTerminationStrategy

### DIFF
--- a/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.h
@@ -20,8 +20,7 @@ typedef NS_OPTIONS(NSUInteger, FBSimulatorManagementOptions){
   FBSimulatorManagementOptionsKillSpuriousSimulatorsOnFirstStart = 1 << 2, /** Kills all Simulators not managed by FBSimulatorControl when creating a Pool */
   FBSimulatorManagementOptionsIgnoreSpuriousKillFail = 1 << 3, /** Don't fail Pool creation when failing to kill spurious Simulators */
   FBSimulatorManagementOptionsKillSpuriousCoreSimulatorServices = 1 << 4, /** Kills CoreSimulatorService daemons from the non-current Xcode version when creating a Pool */
-  FBSimulatorManagementOptionsUseProcessKilling = 1 << 5, /** Kills Simulators using kill(2) instead of -[NSRunningApplication terminate] */
-  FBSimulatorManagementOptionsUseSimDeviceTimeoutResiliance = 1 << 6, /** Uses an alternative strategy for communicating with the Simulator that may be more robust with Xcode 7.1 */
+  FBSimulatorManagementOptionsUseSimDeviceTimeoutResiliance = 1 << 5, /** Uses an alternative strategy for communicating with the Simulator that may be more robust with Xcode 7.1 */
 };
 
 /**

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.m
@@ -111,8 +111,13 @@
         failBool:error];
     }
 
-    // Kill the Application if it exists. Failure can be ignored since the App may have already been terminated.
-    [[[simulator.interact killProcess:process] ignoreFailure] performInteractionWithError:nil];
+    // Kill the Application if it exists. Don't bother killing the process if it doesn't exist
+    if ([simulator.processQuery processExists:process error:nil]) {
+      NSError *innerError = nil;
+      if (![[simulator.interact killProcess:process] performInteractionWithError:&innerError]) {
+        return [FBSimulatorError failBoolWithError:innerError errorOut:error];
+      }
+    }
 
     // Relaunch the Application
     NSError *innerError = nil;

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.m
@@ -120,7 +120,7 @@
     // Use FBProcessTerminationStrategy to do the actual process killing
     // as it has more intelligent backoff strategies and error messaging.
     NSError *innerError = nil;
-    if (![[FBProcessTerminationStrategy withProcessKilling:simulator.processQuery signo:signo logger:simulator.logger] killProcess:process error:&innerError]) {
+    if (![[FBProcessTerminationStrategy withProcessQuery:simulator.processQuery logger:simulator.logger] killProcess:process error:&innerError]) {
       return [FBSimulatorError failBoolWithError:innerError errorOut:error];
     }
 

--- a/FBSimulatorControl/Management/FBCoreSimulatorTerminationStrategy.m
+++ b/FBSimulatorControl/Management/FBCoreSimulatorTerminationStrategy.m
@@ -40,7 +40,7 @@
 
   _processQuery = processQuery;
   _logger = logger;
-  _processTerminationStrategy = [FBProcessTerminationStrategy withProcessKilling:processQuery signo:SIGKILL logger:logger];
+  _processTerminationStrategy = [FBProcessTerminationStrategy withProcessQuery:processQuery logger:logger];
 
   return self;
 }

--- a/FBSimulatorControl/Management/FBProcessTerminationStrategy.h
+++ b/FBSimulatorControl/Management/FBProcessTerminationStrategy.h
@@ -14,30 +14,46 @@
 @class FBProcessQuery;
 
 /**
+ An Option Set for Process Termination.
+ */
+typedef NS_ENUM(NSUInteger, FBProcessTerminationStrategyOptions) {
+  FBProcessTerminationStrategyOptionsUseNSRunningApplication = 1 << 1, /** Use -[NSRunningApplication terminate] where relevant **/
+  FBProcessTerminationStrategyOptionsCheckProcessExistsBeforeSignal = 1 << 2, /** Checks for the process to exist before signalling **/
+  FBProcessTerminationStrategyOptionsCheckDeathAfterSignal = 1 << 3, /** Waits for the process to die before returning **/
+  FBProcessTerminationStrategyOptionsBackoffToSIGKILL = 1 << 4, /** Whether to backoff to SIGKILL if a less severe signal fails **/
+};
+
+/**
+ A Configuration for the Strategy.
+ */
+typedef struct {
+  int signo;
+  FBProcessTerminationStrategyOptions options;
+} FBProcessTerminationStrategyConfiguration;
+
+/**
  A Strategy that defines how to terminate Processes.
  */
 @interface FBProcessTerminationStrategy : NSObject
 
 /**
- Uses kill(2) to terminate Applications.
+ Creates and returns a strategy for the given configuration.
 
+ @param configuration the configuration to use in the strategy.
  @param processQuery the Process Query object to use.
- @param signo the signal number to use when killing. See signal(3) for more info
  @param logger the logger to use.
  @return a new Process Termination Strategy instance.
  */
-+ (instancetype)withProcessKilling:(FBProcessQuery *)processQuery signo:(int)signo logger:(id<FBSimulatorLogger>)logger;
++ (instancetype)withConfiguration:(FBProcessTerminationStrategyConfiguration)configuration processQuery:(FBProcessQuery *)processQuery logger:(id<FBSimulatorLogger>)logger;
 
 /**
- Uses methods on NSRunningApplication to terminate Applications.
- Uses kill(2) otherwise
+ Creates and returns a strategy with the default configuration.
 
  @param processQuery the Process Query object to use.
- @param signo the signal number to use when killing. See signal(3) for more info
  @param logger the logger to use.
  @return a new Process Termination Strategy instance.
  */
-+ (instancetype)withRunningApplicationTermination:(FBProcessQuery *)processQuery signo:(int)signo logger:(id<FBSimulatorLogger>)logger;;
++ (instancetype)withProcessQuery:(FBProcessQuery *)processQuery logger:(id<FBSimulatorLogger>)logger;
 
 /**
  Terminates a Process of the provided Process Info.

--- a/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.m
+++ b/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.m
@@ -52,13 +52,8 @@
 
 + (instancetype)withConfiguration:(FBSimulatorControlConfiguration *)configuration processQuery:(FBProcessQuery *)processQuery logger:(id<FBSimulatorLogger>)logger
 {
-  BOOL useKill = (configuration.options & FBSimulatorManagementOptionsUseProcessKilling) == FBSimulatorManagementOptionsUseProcessKilling;
-  FBProcessTerminationStrategy *processTerminationStrategy = useKill
-    ? [FBProcessTerminationStrategy withProcessKilling:processQuery signo:SIGKILL logger:logger]
-    : [FBProcessTerminationStrategy withRunningApplicationTermination:processQuery signo:SIGKILL logger:logger];
-
+  FBProcessTerminationStrategy *processTerminationStrategy = [FBProcessTerminationStrategy withProcessQuery:processQuery logger:logger];
   return [[self alloc] initWithConfiguration:configuration processQuery:processQuery processTerminationStrategy:processTerminationStrategy logger:logger];
-
 }
 
 - (instancetype)initWithConfiguration:(FBSimulatorControlConfiguration *)configuration processQuery:(FBProcessQuery *)processQuery processTerminationStrategy:(FBProcessTerminationStrategy *)processTerminationStrategy logger:(id<FBSimulatorLogger>)logger

--- a/FBSimulatorControl/Processes/FBProcessQuery+Helpers.h
+++ b/FBSimulatorControl/Processes/FBProcessQuery+Helpers.h
@@ -27,6 +27,15 @@
 - (FBProcessInfo *)processInfoFor:(pid_t)processIdentifier timeout:(NSTimeInterval)timeout;
 
 /**
+ A that determines if the provided process is currently running.
+
+ @param process the Process to look for
+ @param error an error out for any error that occurs
+ @return YES if a matching process is found, NO otherwise.
+ */
+- (BOOL)processExists:(FBProcessInfo *)process error:(NSError **)error;
+
+/**
  Uses the reciever to poll for the termination of a process.
 
  @param process the process that is expected to terminate.

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -214,7 +214,6 @@ extension FBSimulatorManagementOptions : Parsable {
         self.killSpuriousSimulatorsOnFirstStartParser(),
         self.ignoreSpuriousKillFailParser(),
         self.killSpuriousCoreSimulatorServicesParser(),
-        self.useProcessKillingParser(),
         self.useSimDeviceTimeoutResilianceParser()
       ])
   }
@@ -237,10 +236,6 @@ extension FBSimulatorManagementOptions : Parsable {
 
   static func killSpuriousCoreSimulatorServicesParser() -> Parser<FBSimulatorManagementOptions> {
     return Parser.ofString("--kill-spurious-services", .KillSpuriousCoreSimulatorServices)
-  }
-
-  static func useProcessKillingParser() -> Parser<FBSimulatorManagementOptions> {
-    return Parser.ofString("--process-killing", .UseProcessKilling)
   }
 
   static func useSimDeviceTimeoutResilianceParser() -> Parser<FBSimulatorManagementOptions> {

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
@@ -82,7 +82,6 @@ class FBSimulatorManagementOptionsParserTests : XCTestCase {
       (["--kill-spurious"], FBSimulatorManagementOptions.KillSpuriousSimulatorsOnFirstStart),
       (["--ignore-spurious-kill-fail"], FBSimulatorManagementOptions.IgnoreSpuriousKillFail),
       (["--kill-spurious-services"], FBSimulatorManagementOptions.KillSpuriousCoreSimulatorServices),
-      (["--process-killing"], FBSimulatorManagementOptions.UseProcessKilling),
       (["--timeout-resiliance"], FBSimulatorManagementOptions.UseSimDeviceTimeoutResiliance)
     ])
   }
@@ -90,7 +89,7 @@ class FBSimulatorManagementOptionsParserTests : XCTestCase {
   func testParsesCompound() {
     self.assertParsesAll(FBSimulatorManagementOptions.parser(), [
       (["--delete-all", "--kill-all"], FBSimulatorManagementOptions.DeleteAllOnFirstStart.union(.KillAllOnFirstStart)),
-      (["--kill-spurious-services", "--process-killing"], FBSimulatorManagementOptions.KillSpuriousCoreSimulatorServices.union(.UseProcessKilling)),
+      (["--kill-spurious-services"], FBSimulatorManagementOptions.KillSpuriousCoreSimulatorServices),
       (["--ignore-spurious-kill-fail", "--timeout-resiliance"], FBSimulatorManagementOptions.IgnoreSpuriousKillFail.union(.UseSimDeviceTimeoutResiliance)),
       (["--kill-spurious", "--ignore-spurious-kill-fail"], FBSimulatorManagementOptions.KillSpuriousSimulatorsOnFirstStart.union(.IgnoreSpuriousKillFail))
     ])
@@ -224,11 +223,11 @@ class ConfigurationParserTests : XCTestCase {
   func testParsesWithOptions() {
     self.assertParses(
       Configuration.parser(),
-      ["--kill-all", "--process-killing"],
+      ["--kill-all", "--kill-spurious"],
       Configuration(
         options: Configuration.Options(),
         deviceSetPath: nil,
-        managementOptions: FBSimulatorManagementOptions.KillAllOnFirstStart.union(.UseProcessKilling)
+        managementOptions: FBSimulatorManagementOptions.KillAllOnFirstStart.union(.KillSpuriousSimulatorsOnFirstStart)
       )
     )
   }


### PR DESCRIPTION
`FBProcessTerminationStrategy` has a bunch of behaviours on top of `kill` making these explicit with an option set means that behaviour is more understandable. `FBSimulatorManagementOptionsUseProcessKilling` no longer makes sense as it is always the fallback.

Additionally, the relaunch interaction could result in strange behaviour when the failure to kill an existing application was suppressed. As a result, the app wouldn't be re-launched at all.