### PR TITLE
Framebuffer Completion Wait

### DIFF
--- a/FBSimulatorControl/Framebuffer/FBFramebufferCompositeDelegate.m
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferCompositeDelegate.m
@@ -43,10 +43,10 @@
   }
 }
 
-- (void)framebufferDidBecomeInvalid:(FBSimulatorFramebuffer *)framebuffer error:(NSError *)error
+- (void)framebufferDidBecomeInvalid:(FBSimulatorFramebuffer *)framebuffer error:(NSError *)error teardownGroup:(dispatch_group_t)teardownGroup
 {
   for (id<FBFramebufferDelegate> delegate in self.delegates) {
-    [delegate framebufferDidBecomeInvalid:framebuffer error:error];
+    [delegate framebufferDidBecomeInvalid:framebuffer error:error teardownGroup:teardownGroup];
   }
 }
 

--- a/FBSimulatorControl/Framebuffer/FBFramebufferDebugWindow.m
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferDebugWindow.m
@@ -60,7 +60,7 @@
   });
 }
 
-- (void)framebufferDidBecomeInvalid:(FBSimulatorFramebuffer *)framebuffer error:(NSError *)error
+- (void)framebufferDidBecomeInvalid:(FBSimulatorFramebuffer *)framebuffer error:(NSError *)error teardownGroup:(dispatch_group_t)teardownGroup
 {
   [self teardownWindow];
 }

--- a/FBSimulatorControl/Framebuffer/FBFramebufferDelegate.h
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferDelegate.h
@@ -30,7 +30,9 @@
  Called when the framebuffer is no longer valid, typically when the Simulator shuts down.
 
  @param framebuffer the framebuffer that was updated.
+ @param error an error, if any occured in the teardown of the simulator.
+ @param teardownGroup a dispatch_group to add asynchronous tasks to that should be performed in the teardown of the Framebuffer.
  */
-- (void)framebufferDidBecomeInvalid:(FBSimulatorFramebuffer *)framebuffer error:(NSError *)error;
+- (void)framebufferDidBecomeInvalid:(FBSimulatorFramebuffer *)framebuffer error:(NSError *)error teardownGroup:(dispatch_group_t)teardownGroup;
 
 @end

--- a/FBSimulatorControl/Framebuffer/FBFramebufferImage.h
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferImage.h
@@ -17,7 +17,7 @@
 /**
  A Simulator Framebuffer Delegate that stores an image of the most recent image.
 
- When a Framebuffer is teared down, all it's delegates will be too.
+ When a Framebuffer is torn down, all it's delegates will be too.
  Just as this occurs, this class will report the image to the Event Sink.
  This means that the final frame will be captured.
  */

--- a/FBSimulatorControl/Framebuffer/FBFramebufferImage.m
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferImage.m
@@ -80,7 +80,7 @@
   CGImageRelease(oldImage);
 }
 
-- (void)framebufferDidBecomeInvalid:(FBSimulatorFramebuffer *)framebuffer error:(NSError *)error
+- (void)framebufferDidBecomeInvalid:(FBSimulatorFramebuffer *)framebuffer error:(NSError *)error teardownGroup:(dispatch_group_t)teardownGroup
 {
   FBDiagnostic *diagnostic = [FBFramebufferImage appendImage:self.image toDiagnostic:self.diagnostic];
   id<FBSimulatorEventSink> eventSink = self.eventSink;

--- a/FBSimulatorControl/Framebuffer/FBFramebufferVideo.h
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferVideo.h
@@ -34,12 +34,4 @@
  */
 + (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic scale:(CGFloat)scale logger:(id<FBSimulatorLogger>)logger eventSink:(id<FBSimulatorEventSink>)eventSink;
 
-/**
- Stops the recording recording of the video framebuffer.
-
- @param error an error out for any error that occurs.
- @return YES if successful, NO otherwise.
- */
-- (BOOL)stopRecordingWithError:(NSError **)error;
-
 @end

--- a/FBSimulatorControl/Framebuffer/FBSimulatorFramebuffer.h
+++ b/FBSimulatorControl/Framebuffer/FBSimulatorFramebuffer.h
@@ -45,7 +45,11 @@
 /**
  Stops listening for Framebuffer Events from SimDeviceFramebufferService.
  Must only be called from the main queue.
+ A dispatch_group is provided to allow for delegates to append any asychronous operations that may need cleanup.
+ For example in the case of the Video Recorder, this means completing the writing to file.
+
+ @param teardownGroup the dispatch_group to append asynchronous operations to.
  */
-- (void)stopListening;
+- (void)stopListeningWithTeardownGroup:(dispatch_group_t)teardownGroup;
 
 @end

--- a/FBSimulatorControl/Management/FBSimulatorBridge.h
+++ b/FBSimulatorControl/Management/FBSimulatorBridge.h
@@ -34,9 +34,13 @@
 + (instancetype)bootSimulator:(FBSimulator *)simulator withConfiguration:(FBSimulatorLaunchConfiguration *)configuration andAttachBridgeWithError:(NSError **)error;
 
 /**
- Tears down the bridge and it's resources.
+ Tears down the bridge and it's resources, waiting for any asynchronous teardown to occur before returning.
+ Must only ever be called from the main thread.
+
+ @param timeout the number of seconds to wait for termination to occur in. If 0 or fewer, the reciever won't wait.
+ @return YES if the termination occurred within timeout seconds, NO otherwise.
  */
-- (void)terminate;
+- (BOOL)terminateWithTimeout:(NSTimeInterval)timeout;
 
 #pragma mark Interacting with the Simulator
 

--- a/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.m
+++ b/FBSimulatorControl/Management/FBSimulatorTerminationStrategy.m
@@ -29,6 +29,7 @@
 #import "FBSimulatorConfiguration.h"
 #import "FBSimulatorControl.h"
 #import "FBSimulatorControlConfiguration.h"
+#import "FBSimulatorControlGlobalConfiguration.h"
 #import "FBSimulatorError.h"
 #import "FBSimulatorInteraction.h"
 #import "FBSimulatorLogger.h"
@@ -122,7 +123,15 @@
     if (bridge) {
       [self.logger.debug logFormat:@"Simulator %@ has a bridge %@, terminating it now", simulator.shortDescription, bridge];
       // Stopping listening will notify the event sink.
-      [bridge terminate];
+      NSTimeInterval timeout = FBSimulatorControlGlobalConfiguration.regularTimeout;
+      [self.logger.debug logFormat:@"Simulator %@ has a bridge %@, stopping & wait with timeout %f", simulator.shortDescription, bridge, timeout];
+      NSDate *date = NSDate.date;
+      BOOL success = [bridge terminateWithTimeout:FBSimulatorControlGlobalConfiguration.regularTimeout];
+      if (success) {
+        [self.logger.debug logFormat:@"Simulator Bridge %@ torn down in %f seconds", bridge, [NSDate.date timeIntervalSinceDate:date]];
+      } else {
+        [self.logger.debug logFormat:@"Simulator Bridge %@ did not teardown in less than %f seconds", bridge, timeout];
+      }
     } else {
       [self.logger.debug logFormat:@"Simulator %@ does not have a running bridge", simulator.shortDescription];
     }


### PR DESCRIPTION
It can be frustrating when the teardown of the `FBSimualtorControl` process races with the the final writing of a video to disk, as this can lead to incomplete videos.

By using `dispatch_group`s for the semaphore-like semantics and `dispatch_wait` we can pass down a group to `FBSimulatorFramebufferDelegate`'s so that they perform some teardown work, asynchronous with the main thread.