### PR TITLE
Terminate Application

### DIFF
--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.h
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.h
@@ -41,6 +41,24 @@
 - (instancetype)launchOrRelaunchApplication:(FBApplicationLaunchConfiguration *)appLaunch;
 
 /**
+ Terminates an Application based on the Application.
+ Will fail if a running Application could not be found, or the kill fails.
+
+ @param application the Application to terminate.
+ @return the reciever, for chaining.
+ */
+- (instancetype)terminateApplication:(FBSimulatorApplication *)application;
+
+/**
+ Terminates an Application based on the Bundle ID.
+ Will fail if a running Application for the Bundle ID could not be found, or the kill fails.
+
+ @param bundleID the bundle ID of the Application to Terminate.
+ @return the reciever, for chaining.
+ */
+- (instancetype)terminateApplicationWithBundleID:(NSString *)bundleID;
+
+/**
  Relaunches the last-launched Application:
  - If the Application is running, it will be killed first then launched.
  - If the Application has terminated, it will be launched.

--- a/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
@@ -56,6 +56,7 @@ public enum Interaction {
   case Install(FBSimulatorApplication)
   case Launch(FBProcessLaunchConfiguration)
   case Relaunch(FBApplicationLaunchConfiguration)
+  case Terminate(String)
 }
 
 /**
@@ -151,6 +152,8 @@ public func == (left: Interaction, right: Interaction) -> Bool {
     return leftLaunch == rightLaunch
   case (.Relaunch(let leftLaunch), .Relaunch(let rightLaunch)):
     return leftLaunch == rightLaunch
+  case (.Terminate(let leftBundleID), .Terminate(let rightBundleID)):
+    return leftBundleID == rightBundleID
   default:
     return false
   }

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -255,7 +255,8 @@ extension Interaction : Parsable {
         Parser.ofString("delete", Interaction.Delete),
         self.installParser(),
         self.launchParser(),
-        self.relaunchParser()
+        self.relaunchParser(),
+        self.terminateParser()
       ])
   }
 
@@ -287,6 +288,12 @@ extension Interaction : Parsable {
     return Parser
       .succeeded(EventName.Relaunch.rawValue, self.appLaunchParser())
       .fmap { Interaction.Relaunch($0 as! FBApplicationLaunchConfiguration) }
+  }
+
+  private static func terminateParser() -> Parser<Interaction> {
+    return Parser
+      .succeeded(EventName.Terminate.rawValue, Parser<String>.ofBundleID())
+      .fmap { Interaction.Terminate($0) }
   }
 
   private static func processLaunchParser() -> Parser<FBProcessLaunchConfiguration> {

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -198,18 +198,18 @@ private struct SimulatorRunner : Runner {
       case .List:
         translator.reportSimulator(EventName.List, simulator)
       case .Approve(let bundleIDs):
-        translator.reportSimulator(EventName.Approve, EventType.Started, bundleIDs as NSArray)
-        try simulator.interact().authorizeLocationSettings(bundleIDs).performInteraction()
-        translator.reportSimulator(EventName.Approve, EventType.Ended, bundleIDs as NSArray)
+        try interactWithSimulator(translator, EventName.Approve, bundleIDs as NSArray) { interaction in
+          interaction.authorizeLocationSettings(bundleIDs)
+        }
       case .Boot(let maybeLaunchConfiguration):
         let launchConfiguration = maybeLaunchConfiguration ?? FBSimulatorLaunchConfiguration.defaultConfiguration()!
-        translator.reportSimulator(EventName.Boot, EventType.Started, launchConfiguration)
-        try simulator.interact().prepareForLaunch(launchConfiguration).bootSimulator(launchConfiguration).performInteraction()
-        translator.reportSimulator(EventName.Boot, EventType.Ended, launchConfiguration)
+        try interactWithSimulator(translator, EventName.Boot, launchConfiguration) { interaction in
+          interaction.prepareForLaunch(launchConfiguration).bootSimulator(launchConfiguration)
+        }
       case .Shutdown:
-        translator.reportSimulator(EventName.Shutdown, EventType.Started, self.simulator)
-        try simulator.interact().shutdownSimulator().performInteraction()
-        translator.reportSimulator(EventName.Shutdown, EventType.Ended, self.simulator)
+        try interactWithSimulator(translator, EventName.Shutdown, self.simulator) { interaction in
+          interaction.shutdownSimulator()
+        }
       case .Diagnose:
         let logs = simulator.diagnostics.allDiagnostics() as! [FBSimulatorDiagnostics]
         translator.reportSimulator(EventName.Diagnose, EventType.Discrete, logs as NSArray)
@@ -218,26 +218,26 @@ private struct SimulatorRunner : Runner {
         try simulator.pool!.deleteSimulator(simulator)
         translator.reportSimulator(EventName.Delete, EventType.Ended, self.simulator)
       case .Install(let application):
-        translator.reportSimulator(EventName.Install, EventType.Started, application)
-        try simulator.interact().installApplication(application).performInteraction()
-        translator.reportSimulator(EventName.Install, EventType.Ended, application)
+        try interactWithSimulator(translator, EventName.Install, application) { interaction in
+          interaction.installApplication(application)
+        }
       case .Launch(let launch):
-        translator.reportSimulator(EventName.Launch, EventType.Started, launch)
-        if let appLaunch = launch as? FBApplicationLaunchConfiguration {
-          try simulator.interact().launchApplication(appLaunch).performInteraction()
+        try interactWithSimulator(translator, EventName.Launch, launch) { interaction in
+          if let appLaunch = launch as? FBApplicationLaunchConfiguration {
+            interaction.launchApplication(appLaunch)
+          }
+          else if let agentLaunch = launch as? FBAgentLaunchConfiguration {
+            interaction.launchAgent(agentLaunch)
+          }
         }
-        else if let agentLaunch = launch as? FBAgentLaunchConfiguration {
-          try simulator.interact().launchAgent(agentLaunch).performInteraction()
-        }
-        translator.reportSimulator(EventName.Launch, EventType.Ended, launch)
       case .Relaunch(let appLaunch):
-        translator.reportSimulator(EventName.Relaunch, EventType.Started, appLaunch)
-        try simulator.interact().launchOrRelaunchApplication(appLaunch).performInteraction()
-        translator.reportSimulator(EventName.Relaunch, EventType.Ended, appLaunch)
+        try interactWithSimulator(translator, EventName.Relaunch, appLaunch) { interaction in
+          interaction.launchOrRelaunchApplication(appLaunch)
+        }
       case .Terminate(let bundleID):
-        translator.reportSimulator(EventName.Terminate, EventType.Started, bundleID as NSString)
-        try simulator.interact().terminateApplicationWithBundleID(bundleID).performInteraction()
-        translator.reportSimulator(EventName.Terminate, EventType.Ended, bundleID as NSString)
+        try interactWithSimulator(translator, EventName.Relaunch, bundleID as NSString) { interaction in
+          interaction.terminateApplicationWithBundleID(bundleID)
+        }
       }
     } catch let error as NSError {
       return .Failure(error.description)
@@ -245,5 +245,13 @@ private struct SimulatorRunner : Runner {
       return .Failure(error.description)
     }
     return .Success
+  }
+
+  func interactWithSimulator(translator: EventSinkTranslator, _ eventName: EventName, _ subject: SimulatorControlSubject, interact: FBSimulatorInteraction -> Void) throws {
+    translator.reportSimulator(eventName, EventType.Started, subject)
+    let interaction = translator.simulator.interact()
+    interact(interaction)
+    try interaction.performInteraction()
+    translator.reportSimulator(eventName, EventType.Ended, subject)
   }
 }

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -198,9 +198,9 @@ private struct SimulatorRunner : Runner {
       case .List:
         translator.reportSimulator(EventName.List, simulator)
       case .Approve(let bundleIDs):
-        translator.reportSimulator(EventName.Approve, EventType.Started, [bundleIDs] as NSArray)
+        translator.reportSimulator(EventName.Approve, EventType.Started, bundleIDs as NSArray)
         try simulator.interact().authorizeLocationSettings(bundleIDs).performInteraction()
-        translator.reportSimulator(EventName.Approve, EventType.Ended, [bundleIDs] as NSArray)
+        translator.reportSimulator(EventName.Approve, EventType.Ended, bundleIDs as NSArray)
       case .Boot(let maybeLaunchConfiguration):
         let launchConfiguration = maybeLaunchConfiguration ?? FBSimulatorLaunchConfiguration.defaultConfiguration()!
         translator.reportSimulator(EventName.Boot, EventType.Started, launchConfiguration)

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -234,6 +234,10 @@ private struct SimulatorRunner : Runner {
         translator.reportSimulator(EventName.Relaunch, EventType.Started, appLaunch)
         try simulator.interact().launchOrRelaunchApplication(appLaunch).performInteraction()
         translator.reportSimulator(EventName.Relaunch, EventType.Ended, appLaunch)
+      case .Terminate(let bundleID):
+        translator.reportSimulator(EventName.Terminate, EventType.Started, bundleID as NSString)
+        try simulator.interact().terminateApplicationWithBundleID(bundleID).performInteraction()
+        translator.reportSimulator(EventName.Terminate, EventType.Ended, bundleID as NSString)
       }
     } catch let error as NSError {
       return .Failure(error.description)

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
@@ -368,6 +368,10 @@ class ActionParserTests : XCTestCase {
     self.assertWithDefaultActions(interaction, suffix: suffix)
   }
 
+  func testParsesTerminateByBundleID() {
+    self.assertWithDefaultActions(Interaction.Terminate("com.foo.bar"), suffix: ["terminate", "com.foo.bar"])
+  }
+
   func testFailsToParseCreate() {
     self.assertParseFails(Action.parser(), ["create"])
   }


### PR DESCRIPTION
Adds an API to terminate an application by a specific bundle ID. I want to revisit this later to ensure that that we specify 'interacting' with a process via bundle ids, app paths and pids as this will make the API far more flexible.