### PR TITLE
Improve Listen Lifecycle

### DIFF
--- a/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
@@ -84,7 +84,7 @@ public enum Server {
 public enum Command {
   case Perform(Configuration, Action)
   case Listen(Configuration, Server)
-  case Help(Interaction?)
+  case Help(Bool, Interaction?)
 }
 
 extension Configuration : Equatable {}
@@ -99,8 +99,8 @@ public func == (left: Command, right: Command) -> Bool {
     return leftConfiguration == rightConfiguration && lefts == rights
   case (.Listen(let leftConfiguration, let leftServer), .Listen(let rightConfiguration, let rightServer)):
     return leftConfiguration == rightConfiguration && leftServer == rightServer
-  case (.Help(let left), .Help(let right)):
-    return left == right
+  case (.Help(let leftSuccess, let leftCommand), .Help(let rightSuccess, let rightCommand)):
+    return leftSuccess == rightSuccess && leftCommand == rightCommand
   default:
     return false
   }

--- a/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
@@ -181,3 +181,36 @@ public func == (left: Interaction, right: Interaction) -> Bool {
     return false
   }
 }
+
+extension Server : JSONDescribeable, CustomStringConvertible {
+  public var jsonDescription: JSON {
+    get {
+      switch self {
+      case .StdIO:
+        return JSON.JDictionary([
+          "type" : JSON.JString("stdio")
+        ])
+      case .Socket(let port):
+        return JSON.JDictionary([
+          "type" : JSON.JString("socket"),
+          "port" : JSON.JNumber(NSNumber(int: Int32(port)))
+        ])
+      case .Http(_, let port):
+        return JSON.JDictionary([
+          "type" : JSON.JString("http"),
+          "port" : JSON.JNumber(NSNumber(int: Int32(port)))
+        ])
+      }
+    }
+  }
+
+  public var description: String {
+    get {
+      switch self {
+      case .StdIO: return "stdio"
+      case .Socket(let port): return "Socket: Port \(port)"
+      case .Http(_, let port): return "HTTP: Port \(port)"
+      }
+    }
+  }
+}

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -162,7 +162,7 @@ extension Command : Parsable {
 
   static func helpParser() -> Parser<Command> {
     return Parser
-      .ofString("help", .Help(nil))
+      .ofString("help", .Help(true, nil))
   }
 }
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/EventReporter.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/EventReporter.swift
@@ -15,8 +15,12 @@ public protocol EventReporter {
 }
 
 extension EventReporter {
-  func reportSimple(eventName: EventName, _ eventType: EventType, _ subject: SimulatorControlSubject) {
-    self.report(SimpleEvent(eventName, eventType, SimulatorControlSubjectBridge(subject)))
+  func reportSimpleBridge(eventName: EventName, _ eventType: EventType, _ subject: SimulatorControlSubject) {
+    self.reportSimple(eventName, eventType, SimulatorControlSubjectBridge(subject))
+  }
+
+  func reportSimple(eventName: EventName, _ eventType: EventType, _ subject: EventReporterSubject) {
+    self.report(SimpleEvent(eventName, eventType, subject))
   }
 }
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/Events.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Events.swift
@@ -28,6 +28,7 @@ public enum EventName : String {
   case Listen = "listen"
   case Relaunch = "relaunch"
   case Shutdown = "shutdown"
+  case Signalled = "signalled"
   case StateChange = "state"
   case Terminate = "terminate"
 }

--- a/fbsimctl/FBSimulatorControlKit/Sources/Events.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Events.swift
@@ -103,6 +103,12 @@ class SimpleEvent : NSObject, JSONDescribeable {
       return "\(self.eventName) \(self.eventType): \(self.subject)"
     }
   }
+
+  override var description: String {
+    get {
+      return self.shortDescription
+    }
+  }
 }
 
 @objc class LogEvent : NSObject, JSONDescribeable {

--- a/fbsimctl/FBSimulatorControlKit/Sources/HttpRelay.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/HttpRelay.swift
@@ -31,7 +31,7 @@ class HttpRelay : Relay {
     do {
       try self.httpServer.start(self.portNumber)
       self.reporter.started()
-      SignalHandler.runUntilSignalled()
+      SignalHandler.runUntilSignalled(self.reporter.reporter)
       self.reporter.ended(nil)
     } catch let error as NSError {
       self.reporter.ended(error.description)

--- a/fbsimctl/FBSimulatorControlKit/Sources/HttpRelay.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/HttpRelay.swift
@@ -33,8 +33,8 @@ class HttpRelay : Relay {
       self.reporter.started()
       SignalHandler.runUntilSignalled(self.reporter.reporter)
       self.reporter.ended(nil)
-    } catch let error as NSError {
-      self.reporter.ended(error.description)
+    } catch {
+      self.reporter.ended("An Error occurred starting the HTTP Server on Port \(self.portNumber)")
     }
   }
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/HttpRelay.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/HttpRelay.swift
@@ -16,21 +16,25 @@ class HttpRelay : Relay {
   let portNumber: in_port_t
   let httpServer: Swifter.HttpServer
   let performer: ActionPerformer
+  let reporter: RelayReporter
 
-  init(query: Query, portNumber: in_port_t, performer: ActionPerformer) {
+  init(query: Query, portNumber: in_port_t, performer: ActionPerformer, reporter: RelayReporter) {
     self.query = query
     self.portNumber = portNumber
     self.performer = performer
     self.httpServer = Swifter.HttpServer()
+    self.reporter = reporter
     self.registerRoutes()
   }
 
   func start() {
     do {
       try self.httpServer.start(self.portNumber)
-       SignalHandler.runUntilSignalled()
-    } catch _ as NSError {
-      print("Error Starting Server")
+      self.reporter.started()
+      SignalHandler.runUntilSignalled()
+      self.reporter.ended(nil)
+    } catch let error as NSError {
+      self.reporter.ended(error.description)
     }
   }
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/JSON.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/JSON.swift
@@ -10,6 +10,9 @@
 import Foundation
 import FBSimulatorControl
 
+/**
+ Errors for the JSON Type
+*/
 public enum JSONError : ErrorType {
   case NonEncodable(AnyObject)
   case Serialization(NSError)
@@ -32,6 +35,9 @@ public enum JSONError : ErrorType {
   }
 }
 
+/**
+ The JSON Type.
+ */
 public indirect enum JSON {
   case JDictionary([String : JSON])
   case JArray([JSON])
@@ -110,10 +116,16 @@ public indirect enum JSON {
   }
 }
 
+/**
+  Protocol for opting-in objects for being describeable in terms of the JSON Type.
+*/
 public protocol JSONDescribeable {
   var jsonDescription: JSON { get }
 }
 
+/**
+ Simple, Chainable Parsers for the JSON Type
+*/
 extension JSON {
   func getValue(key: String) throws -> JSON {
     switch self {

--- a/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
@@ -17,10 +17,10 @@ public extension Command {
       return command.appendEnvironment(environment)
     } catch let error as ParseError {
       print("Failed to Parse Command \(error)")
-      return Command.Help(nil)
+      return Command.Help(false, nil)
     } catch let error as NSError {
       print("Failed to Parse Command \(error)")
-      return Command.Help(nil)
+      return Command.Help(false, nil)
     }
   }
 }

--- a/fbsimctl/FBSimulatorControlKit/Sources/Relay.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Relay.swift
@@ -18,6 +18,25 @@ protocol Relay {
 }
 
 /**
+  A Class to report the Relay Lifecycle to.
+*/
+struct RelayReporter {
+  let reporter: EventReporter
+  let subject: EventReporterSubject
+
+  func started() {
+    self.reporter.reportSimple(EventName.Listen, EventType.Started, self.subject)
+  }
+
+  func ended(error: String?) {
+    if let error = error {
+      self.reporter.reportSimpleBridge(EventName.Failure, EventType.Discrete, error as NSString)
+    }
+    self.reporter.reportSimple(EventName.Listen, EventType.Ended, self.subject)
+  }
+}
+
+/**
  A Connection of Reporter-to-Transformer, linebuffering an input
  */
 class RelayConnection : LineBufferDelegate {

--- a/fbsimctl/FBSimulatorControlKit/Sources/Relay.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Relay.swift
@@ -34,7 +34,7 @@ class RelayConnection : LineBufferDelegate {
     let result = self.performer.perform(lineAvailable, reporter: self.reporter)
     switch result {
     case .Failure(let error):
-      self.reporter.reportSimple(EventName.Failure, EventType.Discrete, error as NSString)
+      self.reporter.reportSimpleBridge(EventName.Failure, EventType.Discrete, error as NSString)
     default:
       break
     }

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -110,20 +110,16 @@ class ServerRunner : Runner, ActionPerformer {
   }
 
   func run(reporter: EventReporter) -> ActionResult {
+    reporter.reportSimple(EventName.Listen, EventType.Started, self.serverConfiguration)
     switch serverConfiguration {
     case .StdIO:
-      reporter.report(LogEvent("Starting local interactive mode, listening on stdin", level: Constants.asl_level_info()))
       StdIORelay(configuration: self.configuration, performer: self).start()
-      reporter.report(LogEvent("Ending local interactive mode", level: Constants.asl_level_info()))
     case .Socket(let portNumber):
-      reporter.report(LogEvent("Starting Socket server on \(portNumber)", level: Constants.asl_level_info()))
       SocketRelay(configuration: self.configuration, portNumber: portNumber, performer: self).start()
-      reporter.report(LogEvent("Ending Socket Server", level: Constants.asl_level_info()))
     case .Http(let query, let portNumber):
-      reporter.report(LogEvent("Starting HTTP server on \(portNumber)", level: Constants.asl_level_info()))
       HttpRelay(query: query, portNumber: portNumber, performer: self).start()
-      reporter.report(LogEvent("Ending HTTP Server", level: Constants.asl_level_info()))
     }
+    reporter.reportSimple(EventName.Listen, EventType.Ended, self.serverConfiguration)
     return .Success
   }
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -110,16 +110,15 @@ class ServerRunner : Runner, ActionPerformer {
   }
 
   func run(reporter: EventReporter) -> ActionResult {
-    reporter.reportSimple(EventName.Listen, EventType.Started, self.serverConfiguration)
+    let relayReporter = RelayReporter(reporter: reporter, subject: self.serverConfiguration)
     switch serverConfiguration {
     case .StdIO:
-      StdIORelay(configuration: self.configuration, performer: self).start()
+      StdIORelay(configuration: self.configuration, performer: self, reporter: relayReporter).start()
     case .Socket(let portNumber):
-      SocketRelay(configuration: self.configuration, portNumber: portNumber, performer: self).start()
+      SocketRelay(configuration: self.configuration, portNumber: portNumber, performer: self, reporter: relayReporter).start()
     case .Http(let query, let portNumber):
-      HttpRelay(query: query, portNumber: portNumber, performer: self).start()
+      HttpRelay(query: query, portNumber: portNumber, performer: self, reporter: relayReporter).start()
     }
-    reporter.reportSimple(EventName.Listen, EventType.Ended, self.serverConfiguration)
     return .Success
   }
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -167,9 +167,9 @@ struct CreationRunner : Runner {
   func run(reporter: EventReporter) -> ActionResult {
     do {
       let options = FBSimulatorAllocationOptions.Create
-      reporter.reportSimple(EventName.Create, EventType.Started, self.simulatorConfiguration)
+      reporter.reportSimpleBridge(EventName.Create, EventType.Started, self.simulatorConfiguration)
       let simulator = try self.control.simulatorPool.allocateSimulatorWithConfiguration(simulatorConfiguration, options: options)
-      reporter.reportSimple(EventName.Create, EventType.Ended, simulator)
+      reporter.reportSimpleBridge(EventName.Create, EventType.Ended, simulator)
       return ActionResult.Success
     } catch let error as NSError {
       return ActionResult.Failure("Failed to Create Simulator \(error.description)")

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -42,9 +42,13 @@ private struct CommandBootstrap {
   func bootstrap() -> ActionResult {
     do {
       switch (self.command) {
-      case .Help:
+      case .Help(let userSpecified, _):
         self.writer.write(Command.getHelp())
-        return .Success
+        if userSpecified {
+          return .Success
+        } else {
+          return .Failure("")
+        }
       case .Listen(let configuration, let serverConfiguration):
         let reporter = configuration.options.createReporter(self.writer)
         let defaults = try Defaults.create(configuration, logWriter: FileHandleWriter.stdOutWriter)

--- a/fbsimctl/FBSimulatorControlKit/Sources/SignalHandler.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/SignalHandler.swift
@@ -35,6 +35,8 @@ let signalPairs: [SignalInfo] = [
   SignalInfo(signo: SIGINT, name: "SIGINT")
 ]
 
+func ignoreSignal(_: Int32) {}
+
 class SignalHandler {
   let callback: SignalInfo -> Void
   var sources: [dispatch_source_t] = []
@@ -45,6 +47,7 @@ class SignalHandler {
 
   private func register() {
     self.sources = signalPairs.map { info in
+      signal(info.signo, ignoreSignal)
       let source = dispatch_source_create(
         DISPATCH_SOURCE_TYPE_SIGNAL,
         UInt(info.signo),

--- a/fbsimctl/FBSimulatorControlKit/Sources/SignalHandler.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/SignalHandler.swift
@@ -9,29 +9,50 @@
 
 import Foundation
 
+struct SignalInfo : JSONDescribeable, CustomStringConvertible {
+  let signo: Int32
+  let name: String
+
+  var jsonDescription: JSON {
+    get {
+      return JSON.JDictionary([
+        "signo" : JSON.JNumber(NSNumber(int: self.signo)),
+        "name" : JSON.JString(self.name),
+      ])
+    }
+  }
+
+  var description: String {
+    get {
+      return "\(self.name) \(self.signo)"
+    }
+  }
+}
+
+let signalPairs: [SignalInfo] = [
+  SignalInfo(signo: SIGTERM, name: "SIGTERM"),
+  SignalInfo(signo: SIGHUP, name: "SIGHUP"),
+  SignalInfo(signo: SIGINT, name: "SIGINT")
+]
+
 class SignalHandler {
-  let callback: String -> Void
+  let callback: SignalInfo -> Void
   var sources: [dispatch_source_t] = []
 
-  init(callback: String -> Void) {
+  init(callback: SignalInfo -> Void) {
     self.callback = callback
   }
 
   private func register() {
-    let signalPairs: [(Int32, String)] = [
-      (SIGTERM, "SIGTERM"),
-      (SIGHUP, "SIGHUP"),
-      (SIGINT, "SIGINT")
-    ]
-    self.sources = signalPairs.map { (signal, name) in
+    self.sources = signalPairs.map { info in
       let source = dispatch_source_create(
         DISPATCH_SOURCE_TYPE_SIGNAL,
-        UInt(signal),
+        UInt(info.signo),
         0,
         dispatch_get_main_queue()
       )
       dispatch_source_set_event_handler(source) {
-        self.callback(name)
+        self.callback(info)
       }
       dispatch_resume(source)
       return source
@@ -46,10 +67,10 @@ class SignalHandler {
 }
 
 extension SignalHandler {
-  static func runUntilSignalled() {
+  static func runUntilSignalled(reporter: EventReporter) {
     var signalled = false
-    let handler = SignalHandler { signalName in
-      print("Signalled by \(signalName)")
+    let handler = SignalHandler { info in
+      reporter.reportSimple(EventName.Signalled, EventType.Discrete, info)
       signalled = true
     }
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/SocketRelay.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/SocketRelay.swift
@@ -226,7 +226,7 @@ class SocketRelay : Relay, SocketConnectionDelegate {
   func start() {
     self.reporter.started()
     createSocketsAndRunInRunLoop()
-    SignalHandler.runUntilSignalled()
+    SignalHandler.runUntilSignalled(self.reporter.reporter)
     self.reporter.ended(nil)
   }
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/SocketRelay.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/SocketRelay.swift
@@ -213,17 +213,21 @@ class SocketRelay : Relay, SocketConnectionDelegate {
   let configuration: Configuration
   let options: SocketRelay.Options
   let performer: ActionPerformer
+  let reporter: RelayReporter
   var registeredConnections: [SocketConnection] = []
 
-  init(configuration: Configuration, portNumber: in_port_t, performer: ActionPerformer) {
+  init(configuration: Configuration, portNumber: in_port_t, performer: ActionPerformer, reporter: RelayReporter) {
     self.configuration = configuration
     self.performer = performer
     self.options = SocketRelay.Options(portNumber: portNumber, bindIPv4: false, bindIPv6: true)
+    self.reporter = reporter
   }
 
   func start() {
+    self.reporter.started()
     createSocketsAndRunInRunLoop()
     SignalHandler.runUntilSignalled()
+    self.reporter.ended(nil)
   }
 
   func stop() {

--- a/fbsimctl/FBSimulatorControlKit/Sources/StdIORelay.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/StdIORelay.swift
@@ -39,22 +39,25 @@ public class FileHandleWriter : Writer {
 
 
 class StdIORelay : Relay {
-  private let relayConnection: RelayConnection
-  private let stdIn: NSFileHandle
+  let relayConnection: RelayConnection
+  let stdIn: NSFileHandle
+  let reporter: RelayReporter
 
-  init(configuration: Configuration, performer: ActionPerformer) {
+  init(configuration: Configuration, performer: ActionPerformer, reporter: RelayReporter) {
     self.relayConnection = RelayConnection(performer: performer, reporter: configuration.options.createReporter(FileHandleWriter.stdOutWriter))
     self.stdIn = NSFileHandle.fileHandleWithStandardInput()
+    self.reporter = reporter
   }
 
   func start() {
     let lineBuffer = self.relayConnection.lineBuffer
-
     self.stdIn.readabilityHandler = { handle in
       let data = handle.availableData
       lineBuffer.appendData(data)
     }
+    self.reporter.started()
     SignalHandler.runUntilSignalled()
+    self.reporter.ended(nil)
   }
 
   func stop() {

--- a/fbsimctl/FBSimulatorControlKit/Sources/StdIORelay.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/StdIORelay.swift
@@ -56,7 +56,7 @@ class StdIORelay : Relay {
       lineBuffer.appendData(data)
     }
     self.reporter.started()
-    SignalHandler.runUntilSignalled()
+    SignalHandler.runUntilSignalled(self.reporter.reporter)
     self.reporter.ended(nil)
   }
 

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
@@ -444,7 +444,7 @@ class CommandParserTests : XCTestCase {
 
   func testParsesHelp() {
     self.assertParsesAll(Command.parser(), [
-      (["help"], Command.Help(nil))
+      (["help"], Command.Help(true, nil))
     ])
   }
 }


### PR DESCRIPTION
The Listen Commands need a little polish:
- [x] Use the Event Reporting mechanism so events can be reported via JSON
- [x] Improve the Human Readable Output of some events
- [x] Log Signal Handling with Info about the Signal
- [x] Blackhole to ignored function with `signal`
- [x] Improve error handling for 'listens'
- [x] Don't log that a listen has started until ports are bound.
- [x] User Initiated help to distinguish status codes