### PR TITLE
Don't fail to launch if Application was launched in the background

### DIFF
--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.m
@@ -73,8 +73,11 @@
         failBool:error];
     }
 
+    // This check confirms that if there's a currently running process for the given Bundle ID it doesn't match one that has been recently launched.
+    // Since the Background Modes of a Simulator can cause an Application to be launched independently of our usage of CoreSimulator,
+    // it's possible that application processes will come to life before `launchApplication` is called, if it has been previously killed.
     FBProcessInfo *process = [simulator runningApplicationWithBundleID:appLaunch.bundleID error:&innerError];
-    if (process) {
+    if (process && [simulator.history.launchedApplicationProcesses containsObject:process]) {
       return [[[[FBSimulatorError
         describeFormat:@"App %@ can't be launched as is running (%@)", appLaunch.bundleID, process.shortDescription]
         causedBy:innerError]


### PR DESCRIPTION
This could be optional in future, or we should have an API for disabling background modes for applications.