### PR TITLE
Fix Retain Cycle in FBInteraction

### DIFF
--- a/FBSimulatorControl/Interactions/FBInteraction.m
+++ b/FBSimulatorControl/Interactions/FBInteraction.m
@@ -302,8 +302,10 @@
 
 - (instancetype)interact:(BOOL (^)(NSError **error, id interaction))block
 {
+  __weak id weakInteraction = self;
   id<FBInteraction> next = [FBInteraction interact:^ BOOL (NSError **error) {
-    return block(error, self);
+    __strong id strongInteraction = weakInteraction;
+    return block(error, strongInteraction);
   }];
 
   FBInteraction *interaction = [self copy];


### PR DESCRIPTION
#205 was the first master run [to exhibit duping of logs](https://travis-ci.org/facebook/FBSimulatorControl/jobs/108248085). This was verified in Instruments.