### PR TITLE
Add 'all' as query for targeting all Simulators

### DIFF
--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -396,6 +396,18 @@ extension Action : Parsable {
 
 extension Query : Parsable {
   public static func parser() -> Parser<Query> {
+    return Parser.alternative([
+      self.allParser(),
+      self.specificParser()
+    ])
+  }
+
+  private static func allParser() -> Parser<Query> {
+    return Parser<Query>
+      .ofString("all", Query.And([]))
+  }
+
+  private static func specificParser() -> Parser<Query> {
     return Parser<Query>
       .alternativeMany(1, [
         self.simulatorStateParser(),

--- a/fbsimctl/FBSimulatorControlKit/Sources/Defaults.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Defaults.swift
@@ -73,11 +73,19 @@ public class Defaults {
     self.query = query
   }
 
-  func queryForInteraction(interaction: Interaction) -> Query? {
+  func queryForInteraction(interactions: [Interaction]) -> Query? {
+    // Always use the last query, if present
     if let query = self.query {
       return query
     }
-    switch interaction {
+    // Otherwise only allow [.List]
+    if interactions.count != 1 {
+      return nil
+    }
+    guard let first = interactions.first else {
+      return nil
+    }
+    switch first {
       case .List: return .And([])
       default: return nil
     }

--- a/fbsimctl/FBSimulatorControlKit/Sources/Defaults.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Defaults.swift
@@ -51,20 +51,36 @@ extension Configuration {
 
 let DefaultsRCFile = NSURL(fileURLWithPath: NSHomeDirectory()).URLByAppendingPathComponent(".fbsimctlrc", isDirectory: false)
 
+/**
+ Provides Default Values, with overrides from a .rc file
+ as well as updates to defaults to avoid repetitious commands.
+*/
 public class Defaults {
   let logWriter: Writer
   let format: Format
   let configuration: Configuration
-  var query: Query? = nil {
-    willSet(newQuery) {
-      let _ = Defaults.queryHistoryLocation(configuration)
-    }
-  }
+  private var query: Query?
 
   init(logWriter: Writer, format: Format, configuration: Configuration) {
     self.logWriter = logWriter
     self.format = format
     self.configuration = configuration
+  }
+
+  func updateLastQuery(query: Query) {
+    // TODO: Create the CLI equivalent of the configuration and save.
+    let _ = Defaults.queryHistoryLocation(configuration)
+    self.query = query
+  }
+
+  func queryForInteraction(interaction: Interaction) -> Query? {
+    if let query = self.query {
+      return query
+    }
+    switch interaction {
+      case .List: return .And([])
+      default: return nil
+    }
   }
 
   static func create(configuration: Configuration, logWriter: Writer) throws -> Defaults {
@@ -93,15 +109,13 @@ public class Defaults {
     }
   }
 
-  private static var rcFileParser: Parser<(Configuration?, Format?)> {
-    get {
-      return Parser
-        .ofTwoSequenced(
-          Configuration.parser().optional(),
-          Format.parser().optional()
-        )
-    }
-  }
+  private static var rcFileParser: Parser<(Configuration?, Format?)> { get {
+    return Parser
+      .ofTwoSequenced(
+        Configuration.parser().optional(),
+        Format.parser().optional()
+      )
+  }}
 
   private static func queryHistoryLocation(configuration: Configuration) -> NSURL {
     let setPath = configuration.deviceSetPath ?? FBSimulatorControlConfiguration.defaultDeviceSetPath()

--- a/fbsimctl/FBSimulatorControlKit/Sources/Query.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Query.swift
@@ -38,6 +38,9 @@ public indirect enum Query {
   case And(Set<Query>)
 }
 
+/**
+ Given a Query and a Pool, obtain a list of the Simulators
+*/
 extension Query {
   static func perform(pool: FBSimulatorPool, query: Query?, defaults: Defaults) throws -> [FBSimulator] {
     guard let query = query ?? defaults.query else {
@@ -75,6 +78,10 @@ extension Query {
   }
 }
 
+/**
+ Extracts values for each of the cases in the enumeration,
+ performing a union along each of these cases.
+*/
 public extension Query {
   static func flatten(queries: [Query]) -> Query {
     if (queries.count == 1) {

--- a/fbsimctl/FBSimulatorControlKit/Sources/Query.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Query.swift
@@ -42,8 +42,8 @@ public indirect enum Query {
  Given a Query and a Pool, obtain a list of the Simulators
 */
 extension Query {
-  static func perform(pool: FBSimulatorPool, query: Query?, defaults: Defaults) throws -> [FBSimulator] {
-    guard let query = query ?? defaults.query else {
+  static func perform(pool: FBSimulatorPool, query: Query?, defaults: Defaults, interaction: Interaction) throws -> [FBSimulator] {
+    guard let query = query ?? defaults.queryForInteraction(interaction)  else {
       throw QueryError.NoQueryProvided
     }
     if pool.allSimulators.count == 0 {
@@ -54,7 +54,7 @@ extension Query {
     if matching.count == 0 {
       throw QueryError.NoMatches
     }
-    defaults.query = query
+    defaults.updateLastQuery(query)
     return matching
   }
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/Query.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Query.swift
@@ -42,8 +42,8 @@ public indirect enum Query {
  Given a Query and a Pool, obtain a list of the Simulators
 */
 extension Query {
-  static func perform(pool: FBSimulatorPool, query: Query?, defaults: Defaults, interaction: Interaction) throws -> [FBSimulator] {
-    guard let query = query ?? defaults.queryForInteraction(interaction)  else {
+  static func perform(pool: FBSimulatorPool, query: Query?, defaults: Defaults, interactions: [Interaction]) throws -> [FBSimulator] {
+    guard let query = query ?? defaults.queryForInteraction(interactions) else {
       throw QueryError.NoQueryProvided
     }
     if pool.allSimulators.count == 0 {

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -141,7 +141,7 @@ struct InteractionRunner : Runner {
 
   func run(reporter: EventReporter) -> ActionResult {
     do {
-      let simulators = try Query.perform(self.control.simulatorPool, query: self.query, defaults: self.defaults, interaction: )
+      let simulators = try Query.perform(self.control.simulatorPool, query: self.query, defaults: self.defaults, interactions: self.interactions)
       let format = self.format ?? defaults.format
       let runners: [Runner] = self.interactions.flatMap { interaction in
         return simulators.map { simulator in

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -95,7 +95,7 @@ private struct ActionRunner : Runner {
     case .Interact(let interactions, let query, let format):
       return InteractionRunner(control: control, configuration: self.configuration, defaults: defaults, interactions: interactions, query: query, format: format).run(reporter)
     case .Create(let configuration, let format):
-      return CreationRunner(control: control, configuration: self.configuration, simulatorConfiguration: configuration, format: format ?? self.defaults.format).run(reporter)
+      return CreationRunner(control: control, configuration: self.configuration, defaults: defaults, simulatorConfiguration: configuration, format: format ?? self.defaults.format).run(reporter)
     }
   }
 }
@@ -160,6 +160,7 @@ struct InteractionRunner : Runner {
 struct CreationRunner : Runner {
   let control: FBSimulatorControl
   let configuration: Configuration
+  let defaults: Defaults
   let simulatorConfiguration: FBSimulatorConfiguration
   let format: Format
 
@@ -168,6 +169,7 @@ struct CreationRunner : Runner {
       let options = FBSimulatorAllocationOptions.Create
       reporter.reportSimpleBridge(EventName.Create, EventType.Started, self.simulatorConfiguration)
       let simulator = try self.control.simulatorPool.allocateSimulatorWithConfiguration(simulatorConfiguration, options: options)
+      self.defaults.updateLastQuery(Query.UDID([simulator.udid]))
       reporter.reportSimpleBridge(EventName.Create, EventType.Ended, simulator)
       return ActionResult.Success
     } catch let error as NSError {

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -141,7 +141,7 @@ struct InteractionRunner : Runner {
 
   func run(reporter: EventReporter) -> ActionResult {
     do {
-      let simulators = try Query.perform(self.control.simulatorPool, query: self.query, defaults: self.defaults)
+      let simulators = try Query.perform(self.control.simulatorPool, query: self.query, defaults: self.defaults, interaction: )
       let format = self.format ?? defaults.format
       let runners: [Runner] = self.interactions.flatMap { interaction in
         return simulators.map { simulator in

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
@@ -14,6 +14,7 @@ import FBSimulatorControl
 class QueryParserTests : XCTestCase {
   func testParsesSimpleQueries() {
     self.assertParsesAll(Query.parser(), [
+      (["all"], .And([])),
       (["iPhone 5"], .Configured([FBSimulatorConfiguration.iPhone5()])),
       (["iPad 2"], .Configured([FBSimulatorConfiguration.iPad2()])),
       (["--state=creating"], .State([.Creating])),
@@ -387,6 +388,7 @@ class ActionParserTests : XCTestCase {
   func assertWithDefaultActions(interaction: Interaction, suffix: [String]) {
     return self.unzipAndAssert([interaction], suffix: suffix, extras: [
       ([], nil, nil),
+      (["all"], Query.And([]), nil),
       (["iPad 2"], Query.Configured([FBSimulatorConfiguration.iPad2()]), nil),
       (["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"], Query.UDID(["B8EEA6C4-841B-47E5-92DE-014E0ECD8139"]), nil),
       (["iPhone 5", "--state=shutdown", "iPhone 6"], Query.And([.Configured([FBSimulatorConfiguration.iPhone5(), FBSimulatorConfiguration.iPhone6()]), .State([.Shutdown])]), nil),


### PR DESCRIPTION
There's currently no way of selecting 'all' simulators when performing a query, this means that killing or deleting all the simulators has to be done via pool preconditions like `--delete-all` and `--kill-all`. This doesn't make a huge amount of sense, as having purpose built operations is much more obvious. 

Also adds defaulting of `Query` for the `list` command so that `fbsimctl list` lists all Simulators.