### PR TITLE
Chainable Actions

### DIFF
--- a/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
@@ -44,47 +44,38 @@ public enum Keyword : String {
 public typealias Format = [Keyword]
 
 /**
- An Interaction represents a Single, synchronous interaction with a Simulator.
- */
-public enum Interaction {
-  case List
-  case Approve([String])
-  case Boot(FBSimulatorLaunchConfiguration?)
-  case Shutdown
-  case Diagnose
-  case Delete
-  case Install(FBSimulatorApplication)
-  case Launch(FBProcessLaunchConfiguration)
-  case Relaunch(FBApplicationLaunchConfiguration)
-  case Terminate(String)
-}
-
-/**
- An Action represents either:
- 1) An Interaction with a Query of Simulators and a Format of textual output.
- 2) The Creation of a Simulator based on a FBSimulatorConfiguration and Format textual output.
-*/
-public enum Action {
-  case Interact([Interaction], Query?, Format?)
-  case Create(FBSimulatorConfiguration, Format?)
-}
-
-/**
  Options for Creating a Server for listening to commands on.
  */
 public enum Server {
   case StdIO
   case Socket(in_port_t)
-  case Http(Query, in_port_t)
+  case Http(in_port_t)
+}
+
+/**
+ An Interaction represents a Single, synchronous interaction with a Simulator.
+ */
+public enum Action {
+  case Approve([String])
+  case Boot(FBSimulatorLaunchConfiguration?)
+  case Create(FBSimulatorConfiguration)
+  case Delete
+  case Diagnose
+  case Install(FBSimulatorApplication)
+  case Launch(FBProcessLaunchConfiguration)
+  case List
+  case Listen(Server)
+  case Relaunch(FBApplicationLaunchConfiguration)
+  case Shutdown
+  case Terminate(String)
 }
 
 /**
  The entry point for all commands.
  */
-public enum Command {
-  case Perform(Configuration, Action)
-  case Listen(Configuration, Server)
-  case Help(Bool, Interaction?)
+public indirect enum Command {
+  case Perform(Configuration, [Action], Query?, Format?)
+  case Help(Bool, Command?)
 }
 
 extension Configuration : Equatable {}
@@ -92,51 +83,60 @@ public func == (left: Configuration, right: Configuration) -> Bool {
   return left.options == right.options && left.deviceSetPath == right.deviceSetPath && left.managementOptions == right.managementOptions
 }
 
-extension Command : Equatable {}
-public func == (left: Command, right: Command) -> Bool {
+extension Action : Equatable { }
+public func == (left: Action, right: Action) -> Bool {
   switch (left, right) {
-  case (.Perform(let leftConfiguration, let lefts), .Perform(let rightConfiguration, let rights)):
-    return leftConfiguration == rightConfiguration && lefts == rights
-  case (.Listen(let leftConfiguration, let leftServer), .Listen(let rightConfiguration, let rightServer)):
-    return leftConfiguration == rightConfiguration && leftServer == rightServer
-  case (.Help(let leftSuccess, let leftCommand), .Help(let rightSuccess, let rightCommand)):
-    return leftSuccess == rightSuccess && leftCommand == rightCommand
+  case (.Approve(let leftBundleIDs), .Approve(let rightBundleIDs)):
+    return leftBundleIDs == rightBundleIDs
+  case (.Boot(let leftConfiguration), .Boot(let rightConfiguration)):
+    return leftConfiguration == rightConfiguration
+  case (.Create(let leftConfiguration), .Create(let rightConfiguration)):
+    return leftConfiguration == rightConfiguration
+  case (.Delete, .Delete):
+    return true
+  case (.Diagnose, .Diagnose):
+    return true
+  case (.Install(let leftApp), .Install(let rightApp)):
+    return leftApp == rightApp
+  case (.Launch(let leftLaunch), .Launch(let rightLaunch)):
+    return leftLaunch == rightLaunch
+  case (.List, .List):
+    return true
+  case (.Listen(let leftServer), .Listen(let rightServer)):
+    return leftServer == rightServer
+  case (.Relaunch(let leftLaunch), .Relaunch(let rightLaunch)):
+    return leftLaunch == rightLaunch
+  case (.Shutdown, .Shutdown):
+    return true
+  case (.Terminate(let leftBundleID), .Terminate(let rightBundleID)):
+    return leftBundleID == rightBundleID
   default:
     return false
   }
 }
 
-extension Action : Equatable { }
-public func == (left: Action, right: Action) -> Bool {
-  // The == function isn't as concise as it could be as Format? isn't automatically Equatable
-  // This is despite [Equatable] Equatable? and Format all being Equatable
+extension Command : Equatable {}
+public func == (left: Command, right: Command) -> Bool {
   switch (left, right) {
-    case (.Interact(let leftInteractions, let leftQuery, let leftMaybeFormat), .Interact(let rightInteractions, let rightQuery, let rightMaybeFormat)):
-      if leftInteractions != rightInteractions || leftQuery != rightQuery {
-        return false
-      }
-      switch (leftMaybeFormat, rightMaybeFormat) {
-      case (.Some(let leftFormat), .Some(let rightFormat)):
-        return leftFormat == rightFormat
-      case (.None, .None):
-        return true
-      default:
-        return false
-      }
-    case (.Create(let leftConfiguration, let leftMaybeFormat), .Create(let rightConfiguration, let rightMaybeFormat)):
-      if leftConfiguration != rightConfiguration {
-        return false
-      }
-      switch (leftMaybeFormat, rightMaybeFormat) {
-      case (.Some(let leftFormat), .Some(let rightFormat)):
-        return leftFormat == rightFormat
-      case (.None, .None):
-        return true
-      default:
-        return false
-      }
-    default:
+  case (.Perform(let leftConfiguration, let leftActions, let leftQuery, let leftMaybeFormat), .Perform(let rightConfiguration, let rightActions, let rightQuery, let rightMaybeFormat)):
+    if leftConfiguration != rightConfiguration || leftActions != rightActions || leftQuery != rightQuery {
+      return false
+    }
+
+    // The == function isn't as concise as it could be as Format? isn't automatically Equatable
+    // This is despite [Equatable] Equatable? and Format all being Equatable
+    switch (leftMaybeFormat, rightMaybeFormat) {
+    case (.Some(let leftFormat), .Some(let rightFormat)):
+      return leftFormat == rightFormat
+    case (.None, .None):
       return true
+    default:
+      return false
+    }
+  case (.Help(let leftSuccess, let leftCommand), .Help(let rightSuccess, let rightCommand)):
+    return leftSuccess == rightSuccess && leftCommand == rightCommand
+  default:
+    return false
   }
 }
 
@@ -147,36 +147,8 @@ public func == (left: Server, right: Server) -> Bool {
     return true
   case (.Socket(let leftPort), .Socket(let rightPort)):
     return leftPort == rightPort
-  case (.Http(let leftQuery, let leftPort), .Http(let rightQuery, let rightPort)):
-    return leftQuery == rightQuery && leftPort == rightPort
-  default:
-    return false
-  }
-}
-
-extension Interaction : Equatable { }
-public func == (left: Interaction, right: Interaction) -> Bool {
-  switch (left, right) {
-  case (.List, .List):
-    return true
-  case (.Approve(let leftBundleIDs), .Approve(let rightBundleIDs)):
-    return leftBundleIDs == rightBundleIDs
-  case (.Boot(let leftConfiguration), .Boot(let rightConfiguration)):
-    return leftConfiguration == rightConfiguration
-  case (.Shutdown, .Shutdown):
-    return true
-  case (.Diagnose, .Diagnose):
-    return true
-  case (.Delete, .Delete):
-    return true
-  case (.Install(let leftApp), .Install(let rightApp)):
-    return leftApp == rightApp
-  case (.Launch(let leftLaunch), .Launch(let rightLaunch)):
-    return leftLaunch == rightLaunch
-  case (.Relaunch(let leftLaunch), .Relaunch(let rightLaunch)):
-    return leftLaunch == rightLaunch
-  case (.Terminate(let leftBundleID), .Terminate(let rightBundleID)):
-    return leftBundleID == rightBundleID
+  case (.Http(let leftPort), .Http(let rightPort)):
+    return leftPort == rightPort
   default:
     return false
   }
@@ -195,7 +167,7 @@ extension Server : JSONDescribeable, CustomStringConvertible {
           "type" : JSON.JString("socket"),
           "port" : JSON.JNumber(NSNumber(int: Int32(port)))
         ])
-      case .Http(_, let port):
+      case .Http(let port):
         return JSON.JDictionary([
           "type" : JSON.JString("http"),
           "port" : JSON.JNumber(NSNumber(int: Int32(port)))
@@ -209,7 +181,7 @@ extension Server : JSONDescribeable, CustomStringConvertible {
       switch self {
       case .StdIO: return "stdio"
       case .Socket(let port): return "Socket: Port \(port)"
-      case .Http(_, let port): return "HTTP: Port \(port)"
+      case .Http(let port): return "HTTP: Port \(port)"
       }
     }
   }

--- a/fbsimctl/FBSimulatorControlKit/Sources/Defaults.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Defaults.swift
@@ -73,19 +73,12 @@ public class Defaults {
     self.query = query
   }
 
-  func queryForInteraction(interactions: [Interaction]) -> Query? {
+  func queryForAction(action: Action) -> Query? {
     // Always use the last query, if present
     if let query = self.query {
       return query
     }
-    // Otherwise only allow [.List]
-    if interactions.count != 1 {
-      return nil
-    }
-    guard let first = interactions.first else {
-      return nil
-    }
-    switch first {
+    switch action {
       case .List: return .And([])
       default: return nil
     }

--- a/fbsimctl/FBSimulatorControlKit/Sources/Environment.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Environment.swift
@@ -15,8 +15,13 @@ let EnvironmentPrefix = "FBSIMCTL_CHILD_"
 public extension Command {
   func appendEnvironment(environment: [String : String]) -> Command {
     switch self {
-    case .Perform(let config, let action):
-      return .Perform(config, action.appendEnvironment(environment))
+    case .Perform(let configuration, let actions, let query, let format):
+      return .Perform(
+        configuration,
+        actions.map { $0.appendEnvironment(environment) },
+        query,
+        format
+      )
     default:
       return self
     }
@@ -26,21 +31,10 @@ public extension Command {
 public extension Action {
   func appendEnvironment(environment: [String : String]) -> Action {
     switch self {
-    case .Interact(let interactions, let query, let format):
-      return .Interact(interactions.map { $0.appendEnvironment(environment) }, query, format)
-    default:
-      return self
-    }
-  }
-}
-
-public extension Interaction {
-  func appendEnvironment(environment: [String : String]) -> Interaction {
-    switch self {
     case .Launch(let configuration):
       return .Launch(
         configuration.withEnvironmentAdditions(
-          Interaction.subprocessEnvironment(environment)
+          Action.subprocessEnvironment(environment)
         )
       )
     default:

--- a/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
@@ -205,6 +205,20 @@ extension Parser {
       .describe("\(a) followed by \(b) followed by \(c)")
   }
 
+  static func ofFourSequenced<B, C, D>(a: Parser<A>, _ b: Parser<B>, _ c: Parser<C>, _ d: Parser<D>) -> Parser<(A, B, C, D)> {
+    return
+      a.bind({ valueA in
+        return b.bind { valueB in
+          return c.bind { valueC in
+            return d.fmap { valueD in
+              return (valueA, valueB, valueC, valueD)
+            }
+          }
+        }
+      })
+      .describe("\(a) followed by \(b) followed by \(c) followed by \(d)")
+  }
+
   static func alternative(parsers: [Parser<A>]) -> Parser<A> {
     return Parser<A>("Any of \(parsers)") { tokens in
       for parser in parsers {

--- a/fbsimctl/FBSimulatorControlKit/Sources/Query.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Query.swift
@@ -42,8 +42,8 @@ public indirect enum Query {
  Given a Query and a Pool, obtain a list of the Simulators
 */
 extension Query {
-  static func perform(pool: FBSimulatorPool, query: Query?, defaults: Defaults, interactions: [Interaction]) throws -> [FBSimulator] {
-    guard let query = query ?? defaults.queryForInteraction(interactions) else {
+  static func perform(pool: FBSimulatorPool, query: Query?, defaults: Defaults, action: Action) throws -> [FBSimulator] {
+    guard let query = query ?? defaults.queryForAction(action) else {
       throw QueryError.NoQueryProvided
     }
     if pool.allSimulators.count == 0 {

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/EnvironmentTests.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/EnvironmentTests.swift
@@ -19,8 +19,8 @@ class EnvironmentTests : XCTestCase {
       "FBSIMCTL_CHILD_BING" : "BONG",
     ]
     let launchConfig = FBApplicationLaunchConfiguration(application: Fixtures.application(), arguments: [], environment: [:])
-    let actual = Interaction.Launch(launchConfig).appendEnvironment(environment)
-    let expteced  = Interaction.Launch(launchConfig.withEnvironmentAdditions([
+    let actual = Action.Launch(launchConfig).appendEnvironment(environment)
+    let expteced  = Action.Launch(launchConfig.withEnvironmentAdditions([
       "FOO" : "BAR",
       "BING" : "BONG",
     ]))


### PR DESCRIPTION
Removing the distinction between `Interaction` and `Action` is worthwhile as it will allow actions to compose far easier. With the presence of `Defaults` to pass through 'the last Simulator we called' chains with booting and listening become easy:

`fbsimct create 'iPhone 5' boot --direct-launch --record-video listen --http 8090 shutdown diagnose`

This will create then boot a simulator, recording the Framebuffer's video, then listen on port 8090. When a `SIGTERM` is sent to the process, it will shutdown and print out the logs.

This should also make it a bit easier to write help.