### PR TITLE
Rename performInteractionWithError: -> perform:

### DIFF
--- a/FBSimulatorControl/Interactions/FBInteraction.h
+++ b/FBSimulatorControl/Interactions/FBInteraction.h
@@ -22,7 +22,7 @@
  @param error an errorOut if any ocurred.
  @returns YES if the interaction succeeded, NO otherwise.
  */
-- (BOOL)performInteractionWithError:(NSError **)error;
+- (BOOL)perform:(NSError **)error;
 
 @end
 

--- a/FBSimulatorControl/Interactions/FBInteraction.m
+++ b/FBSimulatorControl/Interactions/FBInteraction.m
@@ -95,7 +95,7 @@
   return self;
 }
 
-- (BOOL)performInteractionWithError:(NSError **)error
+- (BOOL)perform:(NSError **)error
 {
   NSError *innerError = nil;
   BOOL success = self.block(&innerError);
@@ -127,11 +127,11 @@
   return self;
 }
 
-- (BOOL)performInteractionWithError:(NSError **)error
+- (BOOL)perform:(NSError **)error
 {
   for (id<FBInteraction> interaction in self.interactions) {
     NSError *innerError = nil;
-    if (![interaction performInteractionWithError:&innerError]) {
+    if (![interaction perform:&innerError]) {
       return [FBSimulatorError failBoolWithError:innerError errorOut:error];
     }
   }
@@ -146,7 +146,7 @@
 
 @implementation FBInteraction_Success
 
-- (BOOL)performInteractionWithError:(NSError **)error
+- (BOOL)perform:(NSError **)error
 {
   return YES;
 }
@@ -173,7 +173,7 @@
   return self;
 }
 
-- (BOOL)performInteractionWithError:(NSError **)errorPtr
+- (BOOL)perform:(NSError **)errorPtr
 {
   if (errorPtr) {
     *errorPtr = self.error;
@@ -205,11 +205,11 @@
   return self;
 }
 
-- (BOOL)performInteractionWithError:(NSError **)error
+- (BOOL)perform:(NSError **)error
 {
   NSError *innerError = nil;
   for (NSUInteger index = 0; index < self.retries; index++) {
-    if ([self.interaction performInteractionWithError:&innerError]) {
+    if ([self.interaction perform:&innerError]) {
       return YES;
     }
   }
@@ -281,7 +281,7 @@
 
   return [self interact:^ BOOL (NSError **error) {
     NSError *innerError = nil;
-    [interaction performInteractionWithError:&innerError];
+    [interaction perform:&innerError];
     return YES;
   }];
 }
@@ -320,9 +320,9 @@
 
 #pragma mark FBInteraction
 
-- (BOOL)performInteractionWithError:(NSError **)error
+- (BOOL)perform:(NSError **)error
 {
-  return [self.interaction performInteractionWithError:error];
+  return [self.interaction perform:error];
 }
 
 @end

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.m
@@ -114,13 +114,13 @@
     NSError *innerError = nil;
     FBProcessInfo *process = [simulator runningApplicationWithBundleID:appLaunch.bundleID error:&innerError];
     if (process) {
-      if (![[simulator.interact killProcess:process] performInteractionWithError:&innerError]) {
+      if (![[simulator.interact killProcess:process] perform:&innerError]) {
         return [FBSimulatorError failBoolWithError:innerError errorOut:error];
       }
     }
 
     // Perform the launch usin the launch config
-    if (![[simulator.interact launchApplication:appLaunch] performInteractionWithError:&innerError]) {
+    if (![[simulator.interact launchApplication:appLaunch] perform:&innerError]) {
       return [[[[FBSimulatorError
         describeFormat:@"Failed to re-launch %@", appLaunch]
         inSimulator:simulator]
@@ -151,7 +151,7 @@
         causedBy:innerError]
         failBool:error];
     }
-    if (![[simulator.interact killProcess:process] performInteractionWithError:&innerError]) {
+    if (![[simulator.interact killProcess:process] perform:&innerError]) {
       return [FBSimulatorError failBoolWithError:innerError errorOut:error];
     }
     return YES;
@@ -170,7 +170,7 @@
         failBool:error];
     }
 
-    return [[simulator.interact launchOrRelaunchApplication:launchConfig] performInteractionWithError:error];
+    return [[simulator.interact launchOrRelaunchApplication:launchConfig] perform:error];
   }];
 }
 
@@ -179,7 +179,7 @@
   return [self interactWithLastLaunchedApplicationProcess:^ BOOL (NSError **error, FBSimulator *simulator, FBProcessInfo *process) {
     // Kill the Application Process
     NSError *innerError = nil;
-    if (![[simulator.interact killProcess:process] performInteractionWithError:&innerError]) {
+    if (![[simulator.interact killProcess:process] perform:&innerError]) {
       return [[[[FBSimulatorError
         describeFormat:@"Failed to terminate app %@", process.shortDescription]
         causedBy:innerError]

--- a/FBSimulatorControl/Utility/FBAddVideoPolyfill.m
+++ b/FBSimulatorControl/Utility/FBAddVideoPolyfill.m
@@ -94,7 +94,7 @@
     environment:@{@"SHIMULATOR_UPLOAD_VIDEO" : joinedPaths}]
     injectingShimulator];
 
-  if (![[simulator.interact launchApplication:appLaunch] performInteractionWithError:&innerError]) {
+  if (![[simulator.interact launchApplication:appLaunch] perform:&innerError]) {
     return [[[FBSimulatorError describe:@"Couldn't launch MobileSlideShow to upload videos"]
       causedBy:innerError]
       failBool:error];
@@ -114,7 +114,7 @@
       failBool:error];
   }
 
-  if (![[simulator.interact killProcess:photosAppProcess] performInteractionWithError:nil]) {
+  if (![[simulator.interact killProcess:photosAppProcess] perform:nil]) {
     return [[[FBSimulatorError
       describe:@"Couldn't kill MobileSlideShow after uploading videos"]
       causedBy:innerError]

--- a/FBSimulatorControlTests/Utilities/FBSimulatorControlAssertions.m
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorControlAssertions.m
@@ -20,7 +20,7 @@
 - (void)assertInteractionSuccessful:(id<FBInteraction>)interaction
 {
   NSError *error = nil;
-  BOOL success = [interaction performInteractionWithError:&error];
+  BOOL success = [interaction perform:&error];
   XCTAssertNil(error);
   XCTAssertTrue(success);
 }
@@ -28,7 +28,7 @@
 - (void)assertInteractionFailed:(id<FBInteraction>)interaction
 {
   NSError *error = nil;
-  BOOL success = [interaction performInteractionWithError:&error];
+  BOOL success = [interaction perform:&error];
   XCTAssertNotNil(error);
   XCTAssertFalse(success);
 }

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ To launch Safari on an iPhone 5, you can use the following:
     BOOL success = [[[simulator.interact
       bootSimulator]
       launchApplication:appLaunch]
-      performInteractionWithError:&error];
+      perform:&error];
 ```
 
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -233,7 +233,7 @@ private struct SimulatorRunner : Runner {
     translator.reportSimulator(eventName, EventType.Started, subject)
     let interaction = translator.simulator.interact()
     interact(interaction)
-    try interaction.performInteraction()
+    try interaction.perform()
     translator.reportSimulator(eventName, EventType.Ended, subject)
   }
 }


### PR DESCRIPTION
Seems a bit silly to encode the reciever's protocol in the method name. There's no ambiguity with existing selectors in Foundation.