### PR TITLE
Add FBProcessInteraction

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -159,6 +159,8 @@
 		AAC241261BB311690054570C /* ApplicationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAC241251BB311690054570C /* ApplicationServices.framework */; };
 		AACA2C371C2976B100979C45 /* FBAddVideoPolyfill.h in Headers */ = {isa = PBXBuildFile; fileRef = AACA2C351C2976B100979C45 /* FBAddVideoPolyfill.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AACA2C381C2976B100979C45 /* FBAddVideoPolyfill.m in Sources */ = {isa = PBXBuildFile; fileRef = AACA2C361C2976B100979C45 /* FBAddVideoPolyfill.m */; };
+		AACD41F81C6A658A00FB1212 /* FBProcessInteraction.h in Headers */ = {isa = PBXBuildFile; fileRef = AACD41F61C6A658A00FB1212 /* FBProcessInteraction.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AACD41F91C6A658A00FB1212 /* FBProcessInteraction.m in Sources */ = {isa = PBXBuildFile; fileRef = AACD41F71C6A658A00FB1212 /* FBProcessInteraction.m */; };
 		AAD3051F1BD4D5B10047376E /* photo0.png in Resources */ = {isa = PBXBuildFile; fileRef = AAD3051D1BD4D5B10047376E /* photo0.png */; };
 		AAD305201BD4D5B10047376E /* photo1.png in Resources */ = {isa = PBXBuildFile; fileRef = AAD3051E1BD4D5B10047376E /* photo1.png */; };
 		AAD497851C50F0BB00ABC1A7 /* FBJSONSerializationDescribeable.h in Headers */ = {isa = PBXBuildFile; fileRef = AAD497841C50F0BB00ABC1A7 /* FBJSONSerializationDescribeable.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -955,6 +957,8 @@
 		AAC241251BB311690054570C /* ApplicationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ApplicationServices.framework; path = System/Library/Frameworks/ApplicationServices.framework; sourceTree = SDKROOT; };
 		AACA2C351C2976B100979C45 /* FBAddVideoPolyfill.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBAddVideoPolyfill.h; sourceTree = "<group>"; };
 		AACA2C361C2976B100979C45 /* FBAddVideoPolyfill.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBAddVideoPolyfill.m; sourceTree = "<group>"; };
+		AACD41F61C6A658A00FB1212 /* FBProcessInteraction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBProcessInteraction.h; sourceTree = "<group>"; };
+		AACD41F71C6A658A00FB1212 /* FBProcessInteraction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBProcessInteraction.m; sourceTree = "<group>"; };
 		AAD3051D1BD4D5B10047376E /* photo0.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = photo0.png; sourceTree = "<group>"; };
 		AAD3051E1BD4D5B10047376E /* photo1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = photo1.png; sourceTree = "<group>"; };
 		AAD497841C50F0BB00ABC1A7 /* FBJSONSerializationDescribeable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBJSONSerializationDescribeable.h; sourceTree = "<group>"; };
@@ -1793,6 +1797,8 @@
 			children = (
 				AA9516E01C15F54600A89CAD /* FBInteraction.h */,
 				AA9516E11C15F54600A89CAD /* FBInteraction.m */,
+				AACD41F61C6A658A00FB1212 /* FBProcessInteraction.h */,
+				AACD41F71C6A658A00FB1212 /* FBProcessInteraction.m */,
 				AA9516F11C15F54600A89CAD /* FBSimulatorInteraction.h */,
 				AA9516F21C15F54600A89CAD /* FBSimulatorInteraction.m */,
 				AA9516E21C15F54600A89CAD /* FBSimulatorInteraction+Agents.h */,
@@ -2015,6 +2021,7 @@
 				AA9517471C15F54600A89CAD /* FBProcessLaunchConfiguration+Helpers.h in Headers */,
 				AA9517AA1C15F54600A89CAD /* FBTaskExecutor.h in Headers */,
 				AA5639551C060005009BAFAA /* FBSimulatorControl.h in Headers */,
+				AACD41F81C6A658A00FB1212 /* FBProcessInteraction.h in Headers */,
 				AA9517A41C15F54600A89CAD /* FBTask+Private.h in Headers */,
 				AA9517571C15F54600A89CAD /* FBSimulatorResourceManager.h in Headers */,
 				AA4242FD1C529366008ABD80 /* FBFramebufferVideo.h in Headers */,
@@ -2200,6 +2207,7 @@
 				AAAB13291C74EC0300F3B083 /* FBSimulatorSet.m in Sources */,
 				AA9517C31C15F60B00A89CAD /* FBCompositeSimulatorEventSink.m in Sources */,
 				AAD51EA41C3AEFEA00A763D0 /* FBSimulatorLaunchConfiguration+Helpers.m in Sources */,
+				AACD41F91C6A658A00FB1212 /* FBProcessInteraction.m in Sources */,
 				AA791BA21C6364F500AE49EB /* FBSimulatorBridge.m in Sources */,
 				AA9517831C15F54600A89CAD /* FBSimulatorControl+PrincipalClass.m in Sources */,
 				AA4242F21C529145008ABD80 /* FBFramebufferCompositeDelegate.m in Sources */,

--- a/FBSimulatorControl/FBSimulatorControl.h
+++ b/FBSimulatorControl/FBSimulatorControl.h
@@ -70,6 +70,7 @@
 #import <FBSimulatorControl/FBSimulatorLaunchConfiguration.h>
 #import <FBSimulatorControl/FBSimulatorLaunchCtl.h>
 #import <FBSimulatorControl/FBSimulatorLogger.h>
+#import <FBSimulatorControl/FBProcessInteraction.h>
 #import <FBSimulatorControl/FBSimulatorLoggingEventSink.h>
 #import <FBSimulatorControl/FBSimulatorNotificationEventSink.h>
 #import <FBSimulatorControl/FBSimulatorPool+Private.h>

--- a/FBSimulatorControl/Interactions/FBProcessInteraction.h
+++ b/FBSimulatorControl/Interactions/FBProcessInteraction.h
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <FBSimulatorControl/FBSimulatorInteraction.h>
+
+@class FBProcessInfo;
+@class FBSimulatorApplication;
+@class FBSimulatorBinary;
+
+/**
+ Interactions for Processes.
+ */
+@interface FBProcessInteraction : FBSimulatorInteraction
+
+/**
+ Sends a signal(3) to the Process, verifying that is is a subprocess of the Simulator.
+
+ @param signo the unix signo to send.
+ @return an FBSimulatorInteraction for chaining.
+ */
+- (FBSimulatorInteraction *)signal:(int)signo;
+
+/**
+ SIGKILL's the provided Process, verifying that issignal: is a subprocess of the Simulator.
+
+ @return an FBSimulatorInteraction for chaining.
+ */
+- (FBSimulatorInteraction *)kill;
+
+@end
+
+@interface FBSimulatorInteraction (FBProcessInteraction)
+
+/**
+ Creates a Process Interaction for the provided process.
+
+ @param process the process to interact with. Must not be nil.
+ @return a FBProcessInteraction
+ */
+- (FBProcessInteraction *)process:(FBProcessInfo *)process;
+
+/**
+ Creates a Process Interaction for the Application with the provided Application.
+
+ @param application the process to interact with. Must not be nil.
+ @return a FBProcessInteraction
+ */
+- (FBProcessInteraction *)applicationProcess:(FBSimulatorApplication *)application;
+
+/**
+ Creates a Process Interaction for the Application with the provided bundle id.
+
+ @param bundleID the process to interact with. Must not be nil.
+ @return a FBProcessInteraction
+ */
+- (FBProcessInteraction *)applicationProcessWithBundleID:(NSString *)bundleID;
+
+/**
+ Creates a Process Interaction for the Application with the Provided Binary.
+
+ @param binary the process to interact with. Must not be nil.
+ @return a FBProcessInteraction
+ */
+- (FBProcessInteraction *)agentProcess:(FBSimulatorBinary *)binary;
+
+/**
+ Creates a Process Interaction for the last-launched Application.
+
+ @return a FBProcessInteraction
+ */
+- (FBProcessInteraction *)lastLaunchedApplication;
+
+@end

--- a/FBSimulatorControl/Interactions/FBProcessInteraction.m
+++ b/FBSimulatorControl/Interactions/FBProcessInteraction.m
@@ -1,0 +1,312 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBProcessInteraction.h"
+
+#import "FBProcessInfo.h"
+#import "FBProcessQuery.h"
+#import "FBSimulatorError.h"
+#import "FBSimulator.h"
+#import "FBSimulator+Helpers.h"
+#import "FBSimulatorHistory.h"
+#import "FBSimulatorHistory+Queries.h"
+#import "FBSimulator+Private.h"
+#import "FBSimulatorLogger.h"
+#import "FBSimulatorApplication.h"
+#import "FBSimulatorInteraction+Private.h"
+#import "FBSimulatorControlGlobalConfiguration.h"
+#import "FBProcessLaunchConfiguration.h"
+#import "FBSimulatorLaunchCtl.h"
+#import "NSRunLoop+SimulatorControlAdditions.h"
+#import "FBProcessTerminationStrategy.h"
+#import "FBSimulatorEventSink.h"
+
+@implementation FBProcessInteraction
+
+#pragma mark Public
+
+- (FBSimulatorInteraction *)signal:(int)signo
+{
+  return [self interactWithProcess:^ BOOL (NSError **error, FBSimulator *simulator, FBProcessInfo *process) {
+    // Confirm that the process has the launchd_sim as a parent process.
+    // The interaction should restrict itself to simulator processes so this is a guard
+    // to ensure that this interaction can't go around killing random processes.
+    pid_t parentProcessIdentifier = [simulator.processQuery parentOf:process.processIdentifier];
+    if (parentProcessIdentifier != simulator.launchdSimProcess.processIdentifier) {
+      return [[FBSimulatorError
+        describeFormat:@"Parent of %@ is not the launchd_sim (%@) it has a pid %d", process.shortDescription, simulator.launchdSimProcess.shortDescription, parentProcessIdentifier]
+        failBool:error];
+    }
+
+    // Notify the eventSink of the process getting killed, before it is killed.
+    // This is done to prevent being marked as an unexpected termination when the
+    // detecting of the process getting killed kicks in.
+    FBProcessLaunchConfiguration *configuration = simulator.history.processLaunchConfigurations[process];
+    if ([configuration isKindOfClass:FBApplicationLaunchConfiguration.class]) {
+      [simulator.eventSink applicationDidTerminate:process expected:YES];
+    } else if ([configuration isKindOfClass:FBAgentLaunchConfiguration.class]) {
+      [simulator.eventSink agentDidTerminate:process expected:YES];
+    }
+
+    // Use FBProcessTerminationStrategy to do the actual process killing
+    // as it has more intelligent backoff strategies and error messaging.
+    NSError *innerError = nil;
+    if (![[FBProcessTerminationStrategy withProcessQuery:simulator.processQuery logger:simulator.logger] killProcess:process error:&innerError]) {
+      return [FBSimulatorError failBoolWithError:innerError errorOut:error];
+    }
+
+    // Ensure that the Simulator's launchctl knows that the process is gone
+    // Killing the process should guarantee that tha Simulator knows that the process has terminated.
+    [simulator.logger.debug logFormat:@"Waiting for %@ to be removed from launchctl", process.shortDescription];
+    BOOL isGoneFromLaunchCtl = [NSRunLoop.currentRunLoop spinRunLoopWithTimeout:FBSimulatorControlGlobalConfiguration.fastTimeout untilTrue:^ BOOL {
+      return ![simulator.launchctl processIsRunningOnSimulator:process error:nil];
+    }];
+    if (!isGoneFromLaunchCtl) {
+      return [[FBSimulatorError
+        describeFormat:@"Process %@ did not get removed from launchctl", process.shortDescription]
+        failBool:error];
+    }
+    [simulator.logger.debug logFormat:@"%@ has been removed from launchctl", process.shortDescription];
+
+    return YES;
+  }];
+}
+
+- (FBSimulatorInteraction *)kill
+{
+  return [self signal:SIGKILL];
+}
+
+#pragma mark Private
+
+- (FBSimulatorInteraction *)interactWithProcess:(BOOL (^)(NSError **error, FBSimulator *simulator, FBProcessInfo *process))block
+{
+  NSAssert(NO, @"-[%@ %@] is abstract and should be overridden", NSStringFromClass(self.class), NSStringFromSelector(_cmd));
+  return nil;
+}
+
+- (FBSimulatorInteraction *)withProcess:(FBProcessInfo *)process interact:(BOOL (^)(NSError **error, FBSimulator *simulator, FBProcessInfo *process))block
+{
+  NSParameterAssert(block);
+
+  return [self interactWithBootedSimulator:^BOOL(id interaction, NSError **error, FBSimulator *simulator) {
+    return block(error, simulator, process);
+  }];
+}
+
+@end
+
+@interface FBProcessInteraction_Process : FBProcessInteraction
+
+@property (nonatomic, strong, readonly) FBProcessInfo *process;
+
+@end
+
+@implementation FBProcessInteraction_Process
+
+#pragma mark Initializers
+
+- (instancetype)initWithInteraction:(id<FBInteraction>)interaction simulator:(FBSimulator *)simulator process:(FBProcessInfo *)process
+{
+  self = [super initWithInteraction:interaction simulator:simulator];
+  if (!self) {
+    return nil;
+  }
+
+  _process = process;
+  return self;
+}
+
+#pragma mark NSCopying
+
+- (instancetype)copyWithZone:(NSZone *)zone
+{
+  FBProcessInteraction_Process *interaction = [super copyWithZone:zone];
+  interaction->_process = self.process;
+  return interaction;
+}
+
+#pragma mark Private
+
+- (FBSimulatorInteraction *)interactWithProcess:(BOOL (^)(NSError **error, FBSimulator *simulator, FBProcessInfo *process))block
+{
+  return [self withProcess:self.process interact:block];
+}
+
+@end
+
+@interface FBProcessInteraction_BundleID : FBProcessInteraction
+
+@property (nonatomic, strong, readonly) NSString *bundleID;
+
+@end
+
+@implementation FBProcessInteraction_BundleID
+
+#pragma mark Initializers
+
+- (instancetype)initWithInteraction:(id<FBInteraction>)interaction simulator:(FBSimulator *)simulator bundleID:(NSString *)bundleID
+{
+  self = [super initWithInteraction:interaction simulator:simulator];
+  if (!self) {
+    return nil;
+  }
+
+  _bundleID = bundleID;
+  return self;
+}
+
+#pragma mark NSCopying
+
+- (instancetype)copyWithZone:(NSZone *)zone
+{
+  FBProcessInteraction_BundleID *interaction = [super copyWithZone:zone];
+  interaction->_bundleID = self.bundleID;
+  return interaction;
+}
+
+#pragma mark Private
+
+- (FBSimulatorInteraction *)interactWithProcess:(BOOL (^)(NSError **error, FBSimulator *simulator, FBProcessInfo *process))block
+{
+  NSString *bundleID = self.bundleID;
+
+  return [self interactWithBootedSimulator:^ BOOL (id interaction, NSError **error, FBSimulator *simulator) {
+    NSError *innerError = nil;
+    FBProcessInfo *process = [simulator runningApplicationWithBundleID:bundleID error:&innerError];
+    if (!process) {
+      return [[[[FBSimulatorError
+        describeFormat:@"Could not find a running application for '%@'", bundleID]
+        inSimulator:simulator]
+        causedBy:innerError]
+        failBool:error];
+    }
+    return block(error, simulator, process);
+  }];
+}
+
+@end
+
+@interface FBProcessInteraction_Binary : FBProcessInteraction
+
+@property (nonatomic, strong, readonly) FBSimulatorBinary *binary;
+
+@end
+
+@implementation FBProcessInteraction_Binary
+
+- (instancetype)initWithInteraction:(id<FBInteraction>)interaction simulator:(FBSimulator *)simulator binary:(FBSimulatorBinary *)binary
+{
+  self = [super initWithInteraction:interaction simulator:simulator];
+  if (!self) {
+    return nil;
+  }
+
+  _binary = binary;
+
+  return self;
+}
+
+#pragma mark NSCopying
+
+- (instancetype)copyWithZone:(NSZone *)zone
+{
+  FBProcessInteraction_Binary *interaction = [super copyWithZone:zone];
+  interaction->_binary = self.binary;
+  return interaction;
+}
+
+#pragma mark Private
+
+- (FBSimulatorInteraction *)interactWithProcess:(BOOL (^)(NSError **error, FBSimulator *simulator, FBProcessInfo *process))block
+{
+  FBSimulatorBinary *binary = self.binary;
+
+  return [self binary:binary interact:^ BOOL (id interaction, NSError **error, FBSimulator *simulator, FBProcessInfo *process) {
+    return block(error, simulator, process);
+  }];
+}
+
+@end
+
+@interface FBProcessInteraction_LastLaunched : FBProcessInteraction
+
+@property (nonatomic, assign, readonly) BOOL application;
+
+@end
+
+@implementation FBProcessInteraction_LastLaunched
+
+- (instancetype)initWithInteraction:(id<FBInteraction>)interaction simulator:(FBSimulator *)simulator application:(BOOL)application
+{
+  self = [super initWithInteraction:interaction simulator:simulator];
+  if (!self) {
+    return nil;
+  }
+
+  _application = application;
+
+  return self;
+}
+
+#pragma mark NSCopying
+
+- (instancetype)copyWithZone:(NSZone *)zone
+{
+  FBProcessInteraction_LastLaunched *interaction = [super copyWithZone:zone];
+  interaction->_application = self.application;
+  return interaction;
+}
+
+#pragma mark Private
+
+- (FBSimulatorInteraction *)interactWithProcess:(BOOL (^)(NSError **error, FBSimulator *simulator, FBProcessInfo *process))block
+{
+  return [self interactWithBootedSimulator:^ BOOL (FBProcessInteraction_LastLaunched *interaction, NSError **error, FBSimulator *simulator) {
+    FBProcessInfo *process = interaction.application ? simulator.history.lastLaunchedApplicationProcess : simulator.history.lastLaunchedAgentProcess;
+    if (!process) {
+      return [[[FBSimulatorError
+        describe:@"Could not find a last launched process"]
+        inSimulator:simulator]
+        failBool:error];
+    }
+    return block(error, simulator, process);
+  }];
+}
+
+@end
+
+@implementation FBSimulatorInteraction (FBProcessInteraction)
+
+- (FBProcessInteraction *)process:(FBProcessInfo *)process
+{
+  return [[FBProcessInteraction_Process alloc] initWithInteraction:self.interaction simulator:self.simulator process:process];
+}
+
+- (FBProcessInteraction *)applicationProcess:(FBSimulatorApplication *)application
+{
+  return [[FBProcessInteraction_BundleID alloc] initWithInteraction:self.interaction simulator:self.simulator bundleID:application.bundleID];
+}
+
+- (FBProcessInteraction *)applicationProcessWithBundleID:(NSString *)bundleID
+{
+  return [[FBProcessInteraction_BundleID alloc] initWithInteraction:self.interaction simulator:self.simulator bundleID:bundleID];
+}
+
+- (FBProcessInteraction *)agentProcess:(FBSimulatorBinary *)binary
+{
+  return [[FBProcessInteraction_Binary alloc] initWithInteraction:self.interaction simulator:self.simulator binary:binary];
+}
+
+- (FBProcessInteraction *)lastLaunchedApplication
+{
+  return [[FBProcessInteraction_LastLaunched alloc] initWithInteraction:self.interaction simulator:self.simulator application:YES];
+}
+
+@end

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Agents.h
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Agents.h
@@ -22,12 +22,4 @@
  */
 - (instancetype)launchAgent:(FBAgentLaunchConfiguration *)agentLaunch;
 
-/**
- Launches the provided Agent.
-
- @param agent the Agent Launch Configuration to Launch.
- @return the reciever, for chaining.
- */
-- (instancetype)killAgent:(FBSimulatorBinary *)agent;
-
 @end

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Agents.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Agents.m
@@ -59,17 +59,4 @@
   }];
 }
 
-- (instancetype)killAgent:(FBSimulatorBinary *)agent
-{
-  NSParameterAssert(agent);
-
-  return [self binary:agent interact:^ BOOL (id _, NSError **error, FBSimulator *simulator, FBProcessInfo *process) {
-    if (!kill(process.processIdentifier, SIGKILL)) {
-      return [[[FBSimulatorError describeFormat:@"SIGKILL of Agent %@ of PID %d failed", agent, process.processIdentifier] inSimulator:simulator] failBool:error];
-    }
-    [self.simulator.eventSink agentDidTerminate:process expected:YES];
-    return YES;
-  }];
-}
-
 @end

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Agents.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Agents.m
@@ -31,7 +31,7 @@
 {
   NSParameterAssert(agentLaunch);
 
-  return [self interactWithBootedSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
+  return [self interactWithBootedSimulator:^ BOOL (id _, NSError **error, FBSimulator *simulator) {
     NSError *innerError = nil;
     NSFileHandle *stdOut = nil;
     NSFileHandle *stdErr = nil;
@@ -63,7 +63,7 @@
 {
   NSParameterAssert(agent);
 
-  return [self binary:agent interact:^ BOOL (NSError **error, FBSimulator *simulator, FBProcessInfo *process) {
+  return [self binary:agent interact:^ BOOL (id _, NSError **error, FBSimulator *simulator, FBProcessInfo *process) {
     if (!kill(process.processIdentifier, SIGKILL)) {
       return [[[FBSimulatorError describeFormat:@"SIGKILL of Agent %@ of PID %d failed", agent, process.processIdentifier] inSimulator:simulator] failBool:error];
     }

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.h
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.h
@@ -41,24 +41,6 @@
 - (instancetype)launchOrRelaunchApplication:(FBApplicationLaunchConfiguration *)appLaunch;
 
 /**
- Terminates an Application based on the Application.
- Will fail if a running Application could not be found, or the kill fails.
-
- @param application the Application to terminate.
- @return the reciever, for chaining.
- */
-- (instancetype)terminateApplication:(FBSimulatorApplication *)application;
-
-/**
- Terminates an Application based on the Bundle ID.
- Will fail if a running Application for the Bundle ID could not be found, or the kill fails.
-
- @param bundleID the bundle ID of the Application to Terminate.
- @return the reciever, for chaining.
- */
-- (instancetype)terminateApplicationWithBundleID:(NSString *)bundleID;
-
-/**
  Relaunches the last-launched Application:
  - If the Application is running, it will be killed first then launched.
  - If the Application has terminated, it will be launched.

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.m
@@ -36,7 +36,7 @@
 {
   NSParameterAssert(application);
 
-  return [self interactWithBootedSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
+  return [self interactWithBootedSimulator:^ BOOL (id interaction, NSError **error, FBSimulator *simulator) {
     if ([simulator isSystemApplicationWithBundleID:application.bundleID error:nil]) {
       return YES;
     }
@@ -62,7 +62,7 @@
 {
   NSParameterAssert(appLaunch);
 
-  return [self interactWithBootedSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
+  return [self interactWithBootedSimulator:^ BOOL (id interaction, NSError **error, FBSimulator *simulator) {
     NSError *innerError = nil;
     FBSimulatorApplication *application = [simulator installedApplicationWithBundleID:appLaunch.bundleID error:&innerError];
     if (!application) {
@@ -109,7 +109,7 @@
 {
   NSParameterAssert(appLaunch);
 
-  return [self interactWithBootedSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
+  return [self interactWithBootedSimulator:^ BOOL (id interaction, NSError **error, FBSimulator *simulator) {
     // Kill the Application if it exists. Don't bother killing the process if it doesn't exist
     NSError *innerError = nil;
     FBProcessInfo *process = [simulator runningApplicationWithBundleID:appLaunch.bundleID error:&innerError];
@@ -141,7 +141,7 @@
 {
   NSParameterAssert(bundleID);
 
-  return [self interactWithBootedSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
+  return [self interactWithBootedSimulator:^ BOOL (id interaction, NSError **error, FBSimulator *simulator) {
     NSError *innerError = nil;
     FBProcessInfo *process = [simulator runningApplicationWithBundleID:bundleID error:&innerError];
     if (!process) {
@@ -160,7 +160,7 @@
 
 - (instancetype)relaunchLastLaunchedApplication
 {
-  return [self interactWithLastLaunchedApplicationProcess:^ BOOL (NSError **error, FBSimulator *simulator, FBProcessInfo *process) {
+  return [self interactWithLastLaunchedApplicationProcess:^ BOOL (id interaction, NSError **error, FBSimulator *simulator, FBProcessInfo *process) {
     // Obtain the Launch Config for the process.
     FBApplicationLaunchConfiguration *launchConfig = simulator.history.processLaunchConfigurations[process];
     if (!process) {
@@ -176,7 +176,7 @@
 
 - (instancetype)terminateLastLaunchedApplication
 {
-  return [self interactWithLastLaunchedApplicationProcess:^ BOOL (NSError **error, FBSimulator *simulator, FBProcessInfo *process) {
+  return [self interactWithLastLaunchedApplicationProcess:^ BOOL (id interaction, NSError **error, FBSimulator *simulator, FBProcessInfo *process) {
     // Kill the Application Process
     NSError *innerError = nil;
     if (![[simulator.interact killProcess:process] perform:&innerError]) {
@@ -192,9 +192,9 @@
 
 #pragma mark Private
 
-- (instancetype)interactWithLastLaunchedApplicationProcess:(BOOL (^)(NSError **error, FBSimulator *simulator, FBProcessInfo *process))block
+- (instancetype)interactWithLastLaunchedApplicationProcess:(BOOL (^)(id interaction, NSError **error, FBSimulator *simulator, FBProcessInfo *process))block
 {
-  return [self interactWithBootedSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
+  return [self interactWithBootedSimulator:^ BOOL (id interaction, NSError **error, FBSimulator *simulator) {
     // Obtain Application Launch info for the last launch.
     FBProcessInfo *process = simulator.history.lastLaunchedApplicationProcess;
     if (!process) {
@@ -204,7 +204,7 @@
         failBool:error];
     }
 
-    return block(error, simulator, process);
+    return block(interaction, error, simulator, process);
   }];
 }
 

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Applications.m
@@ -28,6 +28,7 @@
 #import "FBSimulatorInteraction+Private.h"
 #import "FBSimulatorLaunchCtl.h"
 #import "FBSimulatorPool.h"
+#import "FBProcessInteraction.h"
 #import "NSRunLoop+SimulatorControlAdditions.h"
 
 @implementation FBSimulatorInteraction (Applications)
@@ -114,7 +115,7 @@
     NSError *innerError = nil;
     FBProcessInfo *process = [simulator runningApplicationWithBundleID:appLaunch.bundleID error:&innerError];
     if (process) {
-      if (![[simulator.interact killProcess:process] perform:&innerError]) {
+      if (![[[simulator.interact process:process] kill] perform:&innerError]) {
         return [FBSimulatorError failBoolWithError:innerError errorOut:error];
       }
     }
@@ -151,7 +152,7 @@
         causedBy:innerError]
         failBool:error];
     }
-    if (![[simulator.interact killProcess:process] perform:&innerError]) {
+    if (![[[simulator.interact process:process] kill] perform:&innerError]) {
       return [FBSimulatorError failBoolWithError:innerError errorOut:error];
     }
     return YES;
@@ -179,7 +180,7 @@
   return [self interactWithLastLaunchedApplicationProcess:^ BOOL (id interaction, NSError **error, FBSimulator *simulator, FBProcessInfo *process) {
     // Kill the Application Process
     NSError *innerError = nil;
-    if (![[simulator.interact killProcess:process] perform:&innerError]) {
+    if (![[[simulator.interact process:process] kill] perform:&innerError]) {
       return [[[[FBSimulatorError
         describeFormat:@"Failed to terminate app %@", process.shortDescription]
         causedBy:innerError]

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Diagnostics.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Diagnostics.m
@@ -52,7 +52,7 @@ typedef id<FBTask>(^FBDiagnosticTaskFactory)(FBTaskExecutor *executor, pid_t pro
   NSParameterAssert(application);
   NSParameterAssert(name);
 
-  return [self binary:application.binary interact:^ BOOL (NSError **error, FBSimulator *simulator, FBProcessInfo *process) {
+  return [self binary:application.binary interact:^ BOOL (id interaction, NSError **error, FBSimulator *simulator, FBProcessInfo *process) {
     id<FBTask> task = taskFactory(FBTaskExecutor.sharedInstance, process.processIdentifier);
     NSCAssert(task, @"Task should not be nil");
 
@@ -76,7 +76,7 @@ typedef id<FBTask>(^FBDiagnosticTaskFactory)(FBTaskExecutor *executor, pid_t pro
   NSParameterAssert(application);
   NSParameterAssert(name);
 
-  return [self binary:application.binary interact:^ BOOL (NSError **error, FBSimulator *simulator, FBProcessInfo *process) {
+  return [self binary:application.binary interact:^ BOOL (id interaction, NSError **error, FBSimulator *simulator, FBProcessInfo *process) {
     id<FBTask> task = taskFactory(FBTaskExecutor.sharedInstance, process.processIdentifier);
     NSCAssert(task, @"Task should not be nil");
 

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.h
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.h
@@ -50,21 +50,4 @@
  */
 - (instancetype)openURL:(NSURL *)url;
 
-/**
- Sends a signal(3) to the Process, verifying that is is a subprocess of the Simulator.
-
- @param signo the unix signo to send.
- @param process the process to send a Signal to.
- @return the reciever, for chaining.
- */
-- (instancetype)signal:(int)signo process:(FBProcessInfo *)process;
-
-/**
- SIGKILL's the provided Process, verifying that is is a subprocess of the Simulator.
-
- @param process the Process to kill.
- @return the reciever, for chaining.
- */
-- (instancetype)killProcess:(FBProcessInfo *)process;
-
 @end

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.m
@@ -52,7 +52,7 @@
 
 - (instancetype)bootSimulator:(FBSimulatorLaunchConfiguration *)configuration
 {
-  return [self interactWithShutdownSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
+  return [self interactWithShutdownSimulator:^ BOOL (id _, NSError **error, FBSimulator *simulator) {
     BOOL useDirectLaunch = (configuration.options & FBSimulatorLaunchOptionsEnableDirectLaunch) == FBSimulatorLaunchOptionsEnableDirectLaunch;
     if (useDirectLaunch) {
       return [FBSimulatorInteraction launchSimulatorDirectly:simulator configuration:configuration error:error];
@@ -63,7 +63,7 @@
 
 - (instancetype)shutdownSimulator
 {
-  return [self interactWithBootedSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
+  return [self interactWithBootedSimulator:^ BOOL (id _, NSError **error, FBSimulator *simulator) {
     return [simulator.set killSimulator:simulator error:error];
   }];
 }
@@ -72,7 +72,7 @@
 {
   NSParameterAssert(url);
 
-  return [self interactWithBootedSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
+  return [self interactWithBootedSimulator:^ BOOL (id _, NSError **error, FBSimulator *simulator) {
     NSError *innerError = nil;
     if (![simulator.device openURL:url error:&innerError]) {
       NSString *description = [NSString stringWithFormat:@"Failed to open URL %@ on simulator %@", url, simulator];
@@ -86,7 +86,7 @@
 {
   NSParameterAssert(process);
 
-  return [self process:process interact:^ BOOL (NSError **error, FBSimulator *simulator) {
+  return [self process:process interact:^ BOOL (id interaction, NSError **error, FBSimulator *simulator) {
     // Confirm that the process has the launchd_sim as a parent process.
     // The interaction should restrict itself to simulator processes so this is a guard
     // to ensure that this interaction can't go around killing random processes.

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Private.h
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Private.h
@@ -20,13 +20,12 @@
 @property (nonatomic, strong, readonly) FBSimulator *simulator;
 
 /**
- Chains an interaction on an process, for the given application.
-
- @param process the process to interact with.
- @param block the block to execute with the process.
- @return the reciever, for chaining.
+ Designated Initializer.
+ 
+ @param interaction the base interaction.
+ @param simulator the Simulator Subject.
  */
-- (instancetype)process:(FBProcessInfo *)process interact:(BOOL (^)(id interaction, NSError **error, FBSimulator *simulator))block;
+- (instancetype)initWithInteraction:(id<FBInteraction>)interaction simulator:(FBSimulator *)simulator;
 
 /**
  Chains an interaction on an process, for the given binary.

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Private.h
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Private.h
@@ -26,7 +26,7 @@
  @param block the block to execute with the process.
  @return the reciever, for chaining.
  */
-- (instancetype)process:(FBProcessInfo *)process interact:(BOOL (^)(NSError **error, FBSimulator *simulator))block;
+- (instancetype)process:(FBProcessInfo *)process interact:(BOOL (^)(id interaction, NSError **error, FBSimulator *simulator))block;
 
 /**
  Chains an interaction on an process, for the given binary.
@@ -35,7 +35,7 @@
  @param block the block to execute with the process.
  @return the reciever, for chaining.
  */
-- (instancetype)binary:(FBSimulatorBinary *)binary interact:(BOOL (^)(NSError **error, FBSimulator *simulator, FBProcessInfo *process))block;
+- (instancetype)binary:(FBSimulatorBinary *)binary interact:(BOOL (^)(id interaction, NSError **error, FBSimulator *simulator, FBProcessInfo *process))block;
 
 /**
  Interact with the Simulator.
@@ -43,7 +43,7 @@
  @param block the block to execute with the Simulator.
  @return the reciever, for chaining.
  */
-- (instancetype)interactWithSimulator:(BOOL (^)(NSError **error, FBSimulator *simulator))block;
+- (instancetype)interactWithSimulator:(BOOL (^)(id interaction, NSError **error, FBSimulator *simulator))block;
 
 /**
  Interact with the Simulator. Will ensure that the Simulator is in the appropriate state.
@@ -52,7 +52,7 @@
  @param block the block to execute with the Simulator.
  @return the reciever, for chaining.
  */
-- (instancetype)interactWithSimulatorAtState:(FBSimulatorState)state block:(BOOL (^)(NSError **error, FBSimulator *simulator))block;
+- (instancetype)interactWithSimulatorAtState:(FBSimulatorState)state block:(BOOL (^)(id interaction, NSError **error, FBSimulator *simulator))block;
 
 /**
  Interact with a Shutdown Simulator. Will ensure that the Simulator is in the appropriate state.
@@ -60,7 +60,7 @@
  @param block the block to execute with the Shutdown Simulator.
  @return the reciever, for chaining.
  */
-- (instancetype)interactWithShutdownSimulator:(BOOL (^)(NSError **error, FBSimulator *simulator))block;
+- (instancetype)interactWithShutdownSimulator:(BOOL (^)(id interaction, NSError **error, FBSimulator *simulator))block;
 
 /**
  Interact with a Shutdown Simulator. Will ensure that the Simulator is in the appropriate state.s
@@ -68,6 +68,6 @@
  @param block the block to execute with the Shutdown Simulator.
  @return the reciever, for chaining.
  */
-- (instancetype)interactWithBootedSimulator:(BOOL (^)(NSError **error, FBSimulator *simulator))block;
+- (instancetype)interactWithBootedSimulator:(BOOL (^)(id interaction, NSError **error, FBSimulator *simulator))block;
 
 @end

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Setup.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Setup.m
@@ -32,7 +32,7 @@
     return [self succeed];
   }
 
-  return [self interactWithShutdownSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
+  return [self interactWithShutdownSimulator:^ BOOL (id _, NSError **error, FBSimulator *simulator) {
     NSString *localeIdentifier = [locale localeIdentifier];
     NSString *languageIdentifier = [NSLocale canonicalLanguageIdentifierFromString:localeIdentifier];
 
@@ -56,7 +56,7 @@
 {
   NSParameterAssert(bundleIDs);
 
-  return [self interactWithShutdownSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
+  return [self interactWithShutdownSimulator:^ BOOL (id _, NSError **error, FBSimulator *simulator) {
     return [FBSimulatorInteraction
       forSimulator:simulator
       relativeFromRootPath:@"Library/Caches/locationd/clients.plist"
@@ -88,7 +88,7 @@
   NSParameterAssert(bundleIDs);
   NSParameterAssert(timeout);
 
-  return [self interactWithShutdownSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
+  return [self interactWithShutdownSimulator:^ BOOL (id _, NSError **error, FBSimulator *simulator) {
     return [FBSimulatorInteraction
       forSimulator:simulator
       relativeFromRootPath:@"Library/Preferences/com.apple.springboard.plist"
@@ -105,7 +105,7 @@
 
 - (instancetype)setupKeyboard
 {
-  return [self interactWithShutdownSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
+  return [self interactWithShutdownSimulator:^ BOOL (id _, NSError **error, FBSimulator *simulator) {
     return [FBSimulatorInteraction
       forSimulator:simulator
       relativeFromRootPath:@"Library/Preferences/com.apple.Preferences.plist"

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Upload.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Upload.m
@@ -30,7 +30,7 @@
     return [self succeed];
   }
 
-  return [self interactWithBootedSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
+  return [self interactWithBootedSimulator:^ BOOL (id _, NSError **error, FBSimulator *simulator) {
     if (simulator.state != FBSimulatorStateBooted) {
       return [[FBSimulatorError describeFormat:@"Simulator must be booted to upload photos, is %@", simulator.device.stateString] failBool:error];
     }
@@ -53,7 +53,7 @@
     return [self succeed];
   }
 
-  return [self interactWithBootedSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
+  return [self interactWithBootedSimulator:^ BOOL (id _, NSError **error, FBSimulator *simulator) {
     NSError *innerError = nil;
     BOOL success = [simulator.simDeviceWrapper addVideos:videoPaths error:&innerError];
     if (!success) {

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction.m
@@ -90,23 +90,6 @@
   return [self interactWithSimulatorAtState:FBSimulatorStateBooted block:block];
 }
 
-- (instancetype)process:(FBProcessInfo *)process interact:(BOOL (^)(id interaction, NSError **error, FBSimulator *simulator))block
-{
-  NSParameterAssert(process);
-  NSParameterAssert(block);
-
-  return [self interactWithBootedSimulator:^ BOOL (id interaction, NSError **error, FBSimulator *simulator) {
-    FBProcessInfo *launchdSimProcess = simulator.launchdSimProcess;
-    pid_t ppid = [simulator.processQuery parentOf:process.processIdentifier];
-    if (launchdSimProcess.processIdentifier != ppid) {
-      return [[FBSimulatorError
-        describeFormat:@"Process %@ has parent %d but should have parent %@", process.shortDescription, ppid, launchdSimProcess.shortDescription]
-        failBool:error];
-    }
-    return block(interaction, error, simulator);
-  }];
-}
-
 - (instancetype)binary:(FBSimulatorBinary *)binary interact:(BOOL (^)(id interaction, NSError **error, FBSimulator *simulator, FBProcessInfo *process))block
 {
   NSParameterAssert(binary);

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction.m
@@ -60,42 +60,42 @@
 
 #pragma mark Private
 
-- (instancetype)interactWithSimulator:(BOOL (^)(NSError **error, FBSimulator *simulator))block
+- (instancetype)interactWithSimulator:(BOOL (^)(id interaction, NSError **error, FBSimulator *simulator))block
 {
   return [self interact:^ BOOL (NSError **error, FBSimulatorInteraction *interaction) {
-    return block(error, interaction.simulator);
+    return block(interaction, error, interaction.simulator);
   }];
 }
 
-- (instancetype)interactWithSimulatorAtState:(FBSimulatorState)state block:(BOOL (^)(NSError **error, FBSimulator *simulator))block
+- (instancetype)interactWithSimulatorAtState:(FBSimulatorState)state block:(BOOL (^)(id interaction, NSError **error, FBSimulator *simulator))block
 {
-  return [self interactWithSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
+  return [self interactWithSimulator:^ BOOL (id interaction, NSError **error, FBSimulator *simulator) {
     if (simulator.state != state) {
       return [[[FBSimulatorError
         describeFormat:@"Expected Simulator %@ to be %@, but it was '%@'", simulator.udid, [FBSimulator stateStringFromSimulatorState:state], simulator.stateString]
         inSimulator:simulator]
         failBool:error];
     }
-    return block(error, simulator);
+    return block(interaction, error, simulator);
   }];
 }
 
-- (instancetype)interactWithShutdownSimulator:(BOOL (^)(NSError **error, FBSimulator *simulator))block
+- (instancetype)interactWithShutdownSimulator:(BOOL (^)(id interaction, NSError **error, FBSimulator *simulator))block
 {
   return [self interactWithSimulatorAtState:FBSimulatorStateShutdown block:block];
 }
 
-- (instancetype)interactWithBootedSimulator:(BOOL (^)(NSError **error, FBSimulator *simulator))block
+- (instancetype)interactWithBootedSimulator:(BOOL (^)(id interaction, NSError **error, FBSimulator *simulator))block
 {
   return [self interactWithSimulatorAtState:FBSimulatorStateBooted block:block];
 }
 
-- (instancetype)process:(FBProcessInfo *)process interact:(BOOL (^)(NSError **error, FBSimulator *simulator))block
+- (instancetype)process:(FBProcessInfo *)process interact:(BOOL (^)(id interaction, NSError **error, FBSimulator *simulator))block
 {
   NSParameterAssert(process);
   NSParameterAssert(block);
 
-  return [self interactWithBootedSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
+  return [self interactWithBootedSimulator:^ BOOL (id interaction, NSError **error, FBSimulator *simulator) {
     FBProcessInfo *launchdSimProcess = simulator.launchdSimProcess;
     pid_t ppid = [simulator.processQuery parentOf:process.processIdentifier];
     if (launchdSimProcess.processIdentifier != ppid) {
@@ -103,16 +103,16 @@
         describeFormat:@"Process %@ has parent %d but should have parent %@", process.shortDescription, ppid, launchdSimProcess.shortDescription]
         failBool:error];
     }
-    return block(error, simulator);
+    return block(interaction, error, simulator);
   }];
 }
 
-- (instancetype)binary:(FBSimulatorBinary *)binary interact:(BOOL (^)(NSError **error, FBSimulator *simulator, FBProcessInfo *process))block
+- (instancetype)binary:(FBSimulatorBinary *)binary interact:(BOOL (^)(id interaction, NSError **error, FBSimulator *simulator, FBProcessInfo *process))block
 {
   NSParameterAssert(binary);
   NSParameterAssert(block);
 
-  return [self interactWithBootedSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
+  return [self interactWithBootedSimulator:^ BOOL (id interaction, NSError **error, FBSimulator *simulator) {
     FBProcessInfo *processInfo = [[[simulator
       launchdSimSubprocesses]
       filteredArrayUsingPredicate:[FBProcessQuery processesForBinary:binary]]
@@ -121,7 +121,7 @@
     if (!processInfo) {
       return [[[FBSimulatorError describeFormat:@"Could not find an active process for %@", binary] inSimulator:simulator] failBool:error];
     }
-    return block(error, simulator, processInfo);
+    return block(interaction, error, simulator, processInfo);
   }];
 }
 

--- a/FBSimulatorControl/Utility/FBAddVideoPolyfill.m
+++ b/FBSimulatorControl/Utility/FBAddVideoPolyfill.m
@@ -18,6 +18,7 @@
 #import "FBSimulatorHistory+Queries.h"
 #import "FBSimulatorInteraction+Applications.h"
 #import "FBSimulatorInteraction+Lifecycle.h"
+#import "FBProcessInteraction.h"
 #import "NSRunLoop+SimulatorControlAdditions.h"
 
 @interface FBAddVideoPolyfill ()
@@ -114,7 +115,7 @@
       failBool:error];
   }
 
-  if (![[simulator.interact killProcess:photosAppProcess] perform:nil]) {
+  if (![[[simulator.interact process:photosAppProcess] kill] perform:nil]) {
     return [[[FBSimulatorError
       describe:@"Couldn't kill MobileSlideShow after uploading videos"]
       causedBy:innerError]

--- a/FBSimulatorControlTests/Tests/FBSimulatorAutomaticUpdatingTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorAutomaticUpdatingTests.m
@@ -108,7 +108,7 @@
   }
 
   [self.assert consumeAllNotifications];
-  [self assertInteractionSuccessful:[simulator.interact killProcess:process]];
+  [self assertInteractionSuccessful:[[simulator.interact process:process] kill]];
 
   NSNotification *actual = [self.assert consumeNotification:FBSimulatorApplicationProcessDidTerminateNotification timeout:20];
   XCTAssertTrue([actual.userInfo[FBSimulatorExpectedTerminationKey] boolValue]);

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -235,7 +235,7 @@ private struct SimulatorRunner : Runner {
       }
     case .Terminate(let bundleID):
       try interactWithSimulator(translator, EventName.Relaunch, bundleID as NSString) { interaction in
-        interaction.terminateApplicationWithBundleID(bundleID)
+        interaction.applicationProcessWithBundleID(bundleID).kill()
       }
     default:
       assertionFailure("Unhandled")


### PR DESCRIPTION
There are a whole bunch of ways of specifying a way of killing a process based on the different ways that a running process can be specified. By bringing these together in `FBProcessInteraction` the method that does the killing can be consolidated. 