### PR TITLE
Workaround 'Duplicate Protocol Conformance' Errors

### DIFF
--- a/fbsimctl/FBSimulatorControlKit/FBSimulatorControlKit.h
+++ b/fbsimctl/FBSimulatorControlKit/FBSimulatorControlKit.h
@@ -15,4 +15,4 @@ FOUNDATION_EXPORT double FBSimulatorControlKitVersionNumber;
 //! Project version string for FBSimulatorControlKit.
 FOUNDATION_EXPORT const unsigned char FBSimulatorControlKitVersionString[];
 
-#import <FBSimulatorControlKit/Constants.h>
+#import <FBSimulatorControlKit/Bridging.h>

--- a/fbsimctl/FBSimulatorControlKit/Sources/Bridging.h
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Bridging.h
@@ -9,6 +9,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import <FBSimulatorControl/FBSimulatorControl.h>
+
 /**
  Bridging Preprocessor Macros to values, so that they can be read in Swift.
  */
@@ -21,4 +23,10 @@
 + (int32_t)asl_level_debug;
 + (int32_t)asl_level_err;
 
+@end
+
+@interface NSString (FBJSONSerializationDescribeable) <FBJSONSerializationDescribeable>
+@end
+
+@interface NSArray (FBJSONSerializationDescribeable) <FBJSONSerializationDescribeable>
 @end

--- a/fbsimctl/FBSimulatorControlKit/Sources/Bridging.m
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Bridging.m
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import "Constants.h"
+#import "Bridging.h"
 
 #import <asl.h>
 #import <sys/socket.h>
@@ -37,6 +37,24 @@
 + (int32_t)asl_level_err
 {
   return ASL_LEVEL_ERR;
+}
+
+@end
+
+@implementation NSString (FBJSONSerializationDescribeable)
+
+- (id)jsonSerializableRepresentation
+{
+  return self;
+}
+
+@end
+
+@implementation NSArray (FBJSONSerializationDescribeable)
+
+- (id)jsonSerializableRepresentation
+{
+  return self;
 }
 
 @end

--- a/fbsimctl/FBSimulatorControlKit/Sources/Events.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Events.swift
@@ -39,24 +39,6 @@ public enum EventType : String {
   case Discrete = "discrete"
 }
 
-extension NSString : FBJSONSerializationDescribeable {
-  public func jsonSerializableRepresentation() -> AnyObject! {
-    return self
-  }
-}
-
-extension NSArray : FBJSONSerializationDescribeable {
-  public func jsonSerializableRepresentation() -> AnyObject! {
-    return self
-  }
-}
-
-extension NSDictionary : FBJSONSerializationDescribeable {
-  public func jsonSerializableRepresentation() -> AnyObject! {
-    return self
-  }
-}
-
 @objc class SimulatorControlSubjectBridge : NSObject, JSONDescribeable {
   let subject: SimulatorControlSubject
 

--- a/fbsimctl/fbsimctl.xcodeproj/project.pbxproj
+++ b/fbsimctl/fbsimctl.xcodeproj/project.pbxproj
@@ -14,8 +14,8 @@
 		AA1B7F6B1C2867EE0038C6A5 /* Bridging.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B7F5C1C2867EE0038C6A5 /* Bridging.swift */; };
 		AA1B7F6C1C2867EE0038C6A5 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B7F5D1C2867EE0038C6A5 /* Command.swift */; };
 		AA1B7F6D1C2867EE0038C6A5 /* CommandParsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B7F5E1C2867EE0038C6A5 /* CommandParsers.swift */; };
-		AA1B7F6E1C2867EE0038C6A5 /* Constants.h in Headers */ = {isa = PBXBuildFile; fileRef = AA1B7F5F1C2867EE0038C6A5 /* Constants.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AA1B7F6F1C2867EE0038C6A5 /* Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = AA1B7F601C2867EE0038C6A5 /* Constants.m */; };
+		AA1B7F6E1C2867EE0038C6A5 /* Bridging.h in Headers */ = {isa = PBXBuildFile; fileRef = AA1B7F5F1C2867EE0038C6A5 /* Bridging.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA1B7F6F1C2867EE0038C6A5 /* Bridging.m in Sources */ = {isa = PBXBuildFile; fileRef = AA1B7F601C2867EE0038C6A5 /* Bridging.m */; };
 		AA1B7F701C2867EE0038C6A5 /* Help.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B7F611C2867EE0038C6A5 /* Help.swift */; };
 		AA1B7F711C2867EE0038C6A5 /* LineBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B7F621C2867EE0038C6A5 /* LineBuffer.swift */; };
 		AA1B7F731C2867EE0038C6A5 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B7F641C2867EE0038C6A5 /* Parser.swift */; };
@@ -38,7 +38,7 @@
 		AA6085D11C287E02009B500E /* Bridging.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B7F5C1C2867EE0038C6A5 /* Bridging.swift */; };
 		AA6085D21C287E02009B500E /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B7F5D1C2867EE0038C6A5 /* Command.swift */; };
 		AA6085D31C287E02009B500E /* CommandParsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B7F5E1C2867EE0038C6A5 /* CommandParsers.swift */; };
-		AA6085D41C287E02009B500E /* Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = AA1B7F601C2867EE0038C6A5 /* Constants.m */; };
+		AA6085D41C287E02009B500E /* Bridging.m in Sources */ = {isa = PBXBuildFile; fileRef = AA1B7F601C2867EE0038C6A5 /* Bridging.m */; };
 		AA6085D51C287E02009B500E /* Help.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B7F611C2867EE0038C6A5 /* Help.swift */; };
 		AA6085D61C287E02009B500E /* LineBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B7F621C2867EE0038C6A5 /* LineBuffer.swift */; };
 		AA6085D71C287E02009B500E /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B7F641C2867EE0038C6A5 /* Parser.swift */; };
@@ -110,8 +110,8 @@
 		AA1B7F5C1C2867EE0038C6A5 /* Bridging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bridging.swift; sourceTree = "<group>"; };
 		AA1B7F5D1C2867EE0038C6A5 /* Command.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
 		AA1B7F5E1C2867EE0038C6A5 /* CommandParsers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandParsers.swift; sourceTree = "<group>"; };
-		AA1B7F5F1C2867EE0038C6A5 /* Constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Constants.h; sourceTree = "<group>"; };
-		AA1B7F601C2867EE0038C6A5 /* Constants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Constants.m; sourceTree = "<group>"; };
+		AA1B7F5F1C2867EE0038C6A5 /* Bridging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Bridging.h; sourceTree = "<group>"; };
+		AA1B7F601C2867EE0038C6A5 /* Bridging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Bridging.m; sourceTree = "<group>"; };
 		AA1B7F611C2867EE0038C6A5 /* Help.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Help.swift; sourceTree = "<group>"; };
 		AA1B7F621C2867EE0038C6A5 /* LineBuffer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineBuffer.swift; sourceTree = "<group>"; };
 		AA1B7F641C2867EE0038C6A5 /* Parser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
@@ -183,11 +183,11 @@
 			children = (
 				AABDEDF31C68D0A200DBA9D8 /* ActionPerformer.swift */,
 				AA54EF711C4814BA006D5118 /* Arguments.swift */,
+				AA1B7F5F1C2867EE0038C6A5 /* Bridging.h */,
+				AA1B7F601C2867EE0038C6A5 /* Bridging.m */,
 				AA1B7F5C1C2867EE0038C6A5 /* Bridging.swift */,
 				AA1B7F5D1C2867EE0038C6A5 /* Command.swift */,
 				AA1B7F5E1C2867EE0038C6A5 /* CommandParsers.swift */,
-				AA1B7F5F1C2867EE0038C6A5 /* Constants.h */,
-				AA1B7F601C2867EE0038C6A5 /* Constants.m */,
 				AA54EF6E1C47E9FC006D5118 /* Constants.swift */,
 				AA3ADDB71C2B0B2D004E4FA9 /* Defaults.swift */,
 				AACF9F521C46E5C100B17E82 /* Environment.swift */,
@@ -295,7 +295,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AA1B7F6E1C2867EE0038C6A5 /* Constants.h in Headers */,
+				AA1B7F6E1C2867EE0038C6A5 /* Bridging.h in Headers */,
 				AAE35AC51C2865C10073CC70 /* FBSimulatorControlKit.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -422,7 +422,7 @@
 				AA6085D31C287E02009B500E /* CommandParsers.swift in Sources */,
 				AAF2D34F1C32EAE100434516 /* Writer.swift in Sources */,
 				AA0DE44D1C68894000B4D2AF /* HttpRelay.swift in Sources */,
-				AA6085D41C287E02009B500E /* Constants.m in Sources */,
+				AA6085D41C287E02009B500E /* Bridging.m in Sources */,
 				AA6085D51C287E02009B500E /* Help.swift in Sources */,
 				AA54EF761C48DE6F006D5118 /* JSON.swift in Sources */,
 				AA83D5E61C57E5FE003B253E /* JSONLogger.m in Sources */,
@@ -449,7 +449,7 @@
 				AACF9F531C46E5C100B17E82 /* Environment.swift in Sources */,
 				AA3ADDB81C2B0B2D004E4FA9 /* Defaults.swift in Sources */,
 				AA1B7F781C2867EE0038C6A5 /* StdIORelay.swift in Sources */,
-				AA1B7F6F1C2867EE0038C6A5 /* Constants.m in Sources */,
+				AA1B7F6F1C2867EE0038C6A5 /* Bridging.m in Sources */,
 				AA1B7F771C2867EE0038C6A5 /* SocketRelay.swift in Sources */,
 				AA54EF751C48275B006D5118 /* JSON.swift in Sources */,
 				AAE0C5531C4904BC005DE6D9 /* Query.swift in Sources */,

--- a/fbsimctl/fbsimctl/JSONLogger.h
+++ b/fbsimctl/fbsimctl/JSONLogger.h
@@ -19,12 +19,12 @@
 @interface JSONLogger : NSObject <FBSimulatorLogger>
 
 /**
- Constructs a new JSONLogger instance with the provided reporter
+ Constructs a new JSONLogger instance with the provided reporter.
 
- @param reporter the the Reporter to report to.
+ @param reporter the the Reporter to report to. Declared as 'id' to prevent the Swift Typechecker getting confused.
  @param debug YES if debug messages should be reported, NO otherwise.
  @return a new JSONLogger instance.
  */
-+ (instancetype)withEventReporter:(JSONEventReporter *)reporter debug:(BOOL)debug;
++ (instancetype)withEventReporter:(id)reporter debug:(BOOL)debug;
 
 @end

--- a/fbsimctl/fbsimctl/fbsimctl.h
+++ b/fbsimctl/fbsimctl/fbsimctl.h
@@ -9,5 +9,5 @@
 
 // Bridging Header for fbsimctl
 
-#import "Bridging.h"
 #import "JSONLogger.h"
+#import "Bridging.h"

--- a/fbsimctl/fbsimctl/fbsimctl.h
+++ b/fbsimctl/fbsimctl/fbsimctl.h
@@ -9,5 +9,5 @@
 
 // Bridging Header for fbsimctl
 
-#import "Constants.h"
+#import "Bridging.h"
 #import "JSONLogger.h"

--- a/fbsimctl/fbsimctl/main.swift
+++ b/fbsimctl/fbsimctl/main.swift
@@ -18,8 +18,8 @@ do {
   let debugEnabled = configuration.options.contains(Configuration.Options.DebugLogging)
 
   if jsonEnabled {
-    let reporter = JSONEventReporter(writer: FileHandleWriter.stdOutWriter, pretty: false)
-    let logger = JSONLogger.withEventReporter(reporter, debug: debugEnabled)
+    let eventReporter = JSONEventReporter(writer: FileHandleWriter.stdOutWriter, pretty: false)
+    let logger = JSONLogger.withEventReporter(eventReporter, debug: debugEnabled)
     FBSimulatorControlGlobalConfiguration.setDefaultLogger(logger)
   } else {
     FBSimulatorControlGlobalConfiguration.setDefaultLoggerToASLWithStderrLogging(true, debugLogging: debugEnabled)


### PR DESCRIPTION
Looks like Swift doesn't like certain protocol extensions and will sporadically fail. This should fix that.