### PR TITLE
Build ActionPerformer from CommandPerformer

### DIFF
--- a/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
@@ -11,21 +11,24 @@ import Foundation
 import FBSimulatorControl
 
 /**
-  Describes the Configuration for the running of a Command
+  Base Options that are also used in Help.
 */
-public struct Configuration {
-  public struct Options : OptionSetType {
-    public let rawValue : Int
-    public init(rawValue: Int) {
-      self.rawValue = rawValue
-    }
-
-    static let DebugLogging = Options(rawValue: 1 << 0)
-    static let JSON = Options(rawValue: 1 << 1)
-    static let Pretty = Options(rawValue: 1 << 2)
+public struct OutputOptions : OptionSetType {
+  public let rawValue : Int
+  public init(rawValue: Int) {
+    self.rawValue = rawValue
   }
 
-  let options: Options
+  static let DebugLogging = OutputOptions(rawValue: 1 << 0)
+  static let JSON = OutputOptions(rawValue: 1 << 1)
+  static let Pretty = OutputOptions(rawValue: 1 << 2)
+}
+
+/**
+  Describes the Configuration for the running FBSimulatorControl Commands
+*/
+public struct Configuration {
+  let output: OutputOptions
   let deviceSetPath: String?
   let managementOptions: FBSimulatorManagementOptions
 }
@@ -75,12 +78,12 @@ public enum Action {
  */
 public indirect enum Command {
   case Perform(Configuration, [Action], Query?, Format?)
-  case Help(Bool, Command?)
+  case Help(OutputOptions, Bool, Command?)
 }
 
 extension Configuration : Equatable {}
 public func == (left: Configuration, right: Configuration) -> Bool {
-  return left.options == right.options && left.deviceSetPath == right.deviceSetPath && left.managementOptions == right.managementOptions
+  return left.output == right.output && left.deviceSetPath == right.deviceSetPath && left.managementOptions == right.managementOptions
 }
 
 extension Action : Equatable { }
@@ -133,8 +136,8 @@ public func == (left: Command, right: Command) -> Bool {
     default:
       return false
     }
-  case (.Help(let leftSuccess, let leftCommand), .Help(let rightSuccess, let rightCommand)):
-    return leftSuccess == rightSuccess && leftCommand == rightCommand
+  case (.Help(let leftOutput, let leftSuccess, let leftCommand), .Help(let rightOutput, let rightSuccess, let rightCommand)):
+    return leftOutput == rightOutput && leftSuccess == rightSuccess && leftCommand == rightCommand
   default:
     return false
   }

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandPerformer.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandPerformer.swift
@@ -10,18 +10,33 @@
 import Foundation
 
 /**
- A Protocol for performing an Action producing an ActionResult.
+ A Protocol for performing an Command producing an CommandResult.
  */
-protocol ActionPerformer {
-  func perform(action: Action, reporter: EventReporter) -> ActionResult
+protocol CommandPerformer {
+  func perform(command: Command, reporter: EventReporter) -> CommandResult
 }
 
-extension ActionPerformer {
-  func perform(input: String, reporter: EventReporter) -> ActionResult {
+/**
+ Forwards to a CommandPerformer based on Constructor Arguments
+ */
+struct ActionPerformer {
+  let commandPerformer: CommandPerformer
+  let configuration: Configuration
+  let query: Query?
+  let format: Format?
+
+  func perform(action: Action, reporter: EventReporter) -> CommandResult {
+    let command = Command.Perform(self.configuration, [action], self.query, self.format)
+    return self.commandPerformer.perform(command, reporter: reporter)
+  }
+}
+
+extension CommandPerformer {
+  func perform(input: String, reporter: EventReporter) -> CommandResult {
     do {
       let arguments = Arguments.fromString(input)
-      let (_, action) = try Action.parser().parse(arguments)
-      return self.perform(action, reporter: reporter)
+      let (_, command) = try Command.parser().parse(arguments)
+      return self.perform(command, reporter: reporter)
     } catch let error as ParseError {
       return .Failure("Error: \(error.description)")
     } catch let error as NSError {
@@ -33,11 +48,11 @@ extension ActionPerformer {
 /**
  Enum for defining the result of a translation.
  */
-public enum ActionResult {
+public enum CommandResult {
   case Success
   case Failure(String)
 
-  func append(second: ActionResult) -> ActionResult {
+  func append(second: CommandResult) -> CommandResult {
     switch (self, second) {
     case (.Success, .Success):
       return .Success
@@ -51,7 +66,7 @@ public enum ActionResult {
   }
 }
 
-extension ActionResult : CustomStringConvertible, CustomDebugStringConvertible {
+extension CommandResult : CustomStringConvertible, CustomDebugStringConvertible {
   public var description: String {
     get {
       switch self {

--- a/fbsimctl/FBSimulatorControlKit/Sources/Defaults.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Defaults.swift
@@ -32,7 +32,7 @@ extension Configuration : Defaultable {
   public static var defaultValue: Configuration {
     get {
       return Configuration(
-        options: Configuration.Options(),
+        output: OutputOptions(),
         deviceSetPath: nil,
         managementOptions: FBSimulatorManagementOptions()
       )

--- a/fbsimctl/FBSimulatorControlKit/Sources/EventReporter.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/EventReporter.swift
@@ -145,3 +145,14 @@ public extension OutputOptions {
     return HumanReadableEventReporter(writer: writer)
   }
 }
+
+public extension Command {
+  public func createReporter(writer: Writer) -> EventReporter {
+    switch self {
+    case .Help(let outputOptions, _, _):
+      return outputOptions.createReporter(writer)
+    case .Perform(let configuration, _, _, _):
+      return configuration.output.createReporter(writer)
+    }
+  }
+}

--- a/fbsimctl/FBSimulatorControlKit/Sources/EventReporter.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/EventReporter.swift
@@ -136,10 +136,10 @@ public class HumanReadableEventReporter : EventReporter {
   }
 }
 
-public extension Configuration.Options {
+public extension OutputOptions {
   public func createReporter(writer: Writer) -> EventReporter {
-    if self.contains(Configuration.Options.JSON) {
-      let pretty = self.contains(Configuration.Options.Pretty)
+    if self.contains(OutputOptions.JSON) {
+      let pretty = self.contains(OutputOptions.Pretty)
       return JSONEventReporter(writer: writer, pretty: pretty)
     }
     return HumanReadableEventReporter(writer: writer)

--- a/fbsimctl/FBSimulatorControlKit/Sources/HttpRelay.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/HttpRelay.swift
@@ -87,7 +87,7 @@ class HttpRelay : Relay {
 
   private func dispatchAction(action: Action) -> HttpResponse {
     let reporter = HttpEventReporter()
-    var result = ActionResult.Success
+    var result = CommandResult.Success
     dispatch_sync(dispatch_get_main_queue()) {
       result = self.performer.perform(action, reporter: reporter)
     }
@@ -103,7 +103,7 @@ class HttpRelay : Relay {
     return HttpResponse.BadRequest(.Json(json.decode()))
   }
 
-  private func interactionResultResponse(eventReporter: HttpEventReporter, result: ActionResult) -> HttpResponse {
+  private func interactionResultResponse(eventReporter: HttpEventReporter, result: CommandResult) -> HttpResponse {
     switch result {
     case .Failure(let string):
       let json = JSON.JDictionary([

--- a/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Parser.swift
@@ -17,10 +17,10 @@ public extension Command {
       return command.appendEnvironment(environment)
     } catch let error as ParseError {
       print("Failed to Parse Command \(error)")
-      return Command.Help(false, nil)
+      return Command.Help(OutputOptions(), false, nil)
     } catch let error as NSError {
       print("Failed to Parse Command \(error)")
-      return Command.Help(false, nil)
+      return Command.Help(OutputOptions(), false, nil)
     }
   }
 }

--- a/fbsimctl/FBSimulatorControlKit/Sources/Relay.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Relay.swift
@@ -40,11 +40,11 @@ struct RelayReporter {
  A Connection of Reporter-to-Transformer, linebuffering an input
  */
 class RelayConnection : LineBufferDelegate {
-  let performer: ActionPerformer
+  let performer: CommandPerformer
   let reporter: EventReporter
   lazy var lineBuffer: LineBuffer = LineBuffer(delegate: self)
 
-  init (performer: ActionPerformer, reporter: EventReporter) {
+  init (performer: CommandPerformer, reporter: EventReporter) {
     self.performer = performer
     self.reporter = reporter
   }

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -42,7 +42,7 @@ private struct CommandBootstrap {
   func bootstrap() -> ActionResult {
     do {
       switch (self.command) {
-      case .Help(let userSpecified, _):
+      case .Help(_, let userSpecified, _):
         self.writer.write(Command.getHelp())
         if userSpecified {
           return .Success
@@ -50,7 +50,7 @@ private struct CommandBootstrap {
           return .Failure("")
         }
       case .Perform(let configuration, let actions, let query, let format):
-        let reporter = configuration.options.createReporter(self.writer)
+        let reporter = configuration.output.createReporter(self.writer)
         let defaults = try Defaults.create(configuration, logWriter: FileHandleWriter.stdOutWriter)
         let control = try defaults.configuration.buildSimulatorControl()
         return SequenceRunner(runners:

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -11,7 +11,7 @@ import Foundation
 import FBSimulatorControl
 
 protocol Runner {
-  func run(reporter: EventReporter) -> ActionResult
+  func run(reporter: EventReporter) -> CommandResult
 }
 
 extension Configuration {
@@ -25,7 +25,7 @@ extension Configuration {
 public extension Command {
   func runFromCLI() -> Int32 {
     let writer = FileHandleWriter.stdOutWriter
-    switch CommandBootstrap(command: self, writer: writer).bootstrap() {
+    switch CommandRunner.bootstrap(self, writer: writer) {
     case .Success:
       return 0
     case .Failure(let string):
@@ -35,43 +35,11 @@ public extension Command {
   }
 }
 
-private struct CommandBootstrap {
-  let command: Command
-  let writer: Writer
-
-  func bootstrap() -> ActionResult {
-    do {
-      switch (self.command) {
-      case .Help(_, let userSpecified, _):
-        self.writer.write(Command.getHelp())
-        if userSpecified {
-          return .Success
-        } else {
-          return .Failure("")
-        }
-      case .Perform(let configuration, let actions, let query, let format):
-        let reporter = configuration.output.createReporter(self.writer)
-        let defaults = try Defaults.create(configuration, logWriter: FileHandleWriter.stdOutWriter)
-        let control = try defaults.configuration.buildSimulatorControl()
-        return SequenceRunner(runners:
-          actions.map { action in
-            return ActionRunner(action: action, configuration: configuration, control: control, defaults: defaults, format: format, query: query)
-          }
-        ).run(reporter)
-      }
-    } catch DefaultsError.UnreadableRCFile(let string) {
-      return .Failure("Unreadable .rc file " + string)
-    } catch let error as NSError {
-      return .Failure(error.description)
-    }
-  }
-}
-
 private struct SequenceRunner : Runner {
   let runners: [Runner]
 
-  func run(reporter: EventReporter) -> ActionResult {
-    var output = ActionResult.Success
+  func run(reporter: EventReporter) -> CommandResult {
+    var output = CommandResult.Success
     for runner in runners {
       output = output.append(runner.run(reporter))
       switch output {
@@ -83,6 +51,45 @@ private struct SequenceRunner : Runner {
   }
 }
 
+private struct CommandRunner : Runner {
+  let command: Command
+  var defaults: Defaults?
+  var control: FBSimulatorControl?
+
+  func run(reporter: EventReporter) -> CommandResult {
+    switch (self.command) {
+    case .Help(_, let userSpecified, _):
+      reporter.reportSimpleBridge(EventName.Help, EventType.Discrete, Command.getHelp() as NSString)
+      if userSpecified {
+        return .Success
+      } else {
+        return .Failure("")
+      }
+    case .Perform(let configuration, let actions, let query, let format):
+      do {
+        let defaults = try self.defaults ?? Defaults.create(configuration, logWriter: FileHandleWriter.stdOutWriter)
+        let control = try self.control ?? defaults.configuration.buildSimulatorControl()
+        let runner = SequenceRunner(runners:
+            actions.map { action in
+              return ActionRunner(action: action, configuration: configuration, control: control, defaults: defaults, format: format, query: query)
+            }
+        )
+        return runner.run(reporter)
+      } catch DefaultsError.UnreadableRCFile(let string) {
+        return .Failure("Unreadable .rc file " + string)
+      } catch let error as NSError {
+        return .Failure(error.description)
+      }
+    }
+  }
+
+  static func bootstrap(command: Command, writer: Writer) -> CommandResult {
+    let reporter = command.createReporter(writer)
+    let runner = CommandRunner(command: command, defaults: nil, control: nil)
+    return runner.run(reporter)
+  }
+}
+
 struct ActionRunner : Runner {
   let action: Action
   let configuration: Configuration
@@ -91,7 +98,7 @@ struct ActionRunner : Runner {
   let format: Format?
   let query: Query?
 
-  func run(reporter: EventReporter) -> ActionResult {
+  func run(reporter: EventReporter) -> CommandResult {
     switch self.action {
     case .Listen(let server):
       return ServerRunner(configuration: self.configuration, control: control, defaults: self.defaults, format: self.format, query: self.query, serverConfiguration: server).run(reporter)
@@ -106,15 +113,15 @@ struct ActionRunner : Runner {
         }
         return SequenceRunner(runners: runners).run(reporter)
       } catch let error as QueryError {
-        return ActionResult.Failure(error.description)
+        return CommandResult.Failure(error.description)
       } catch {
-        return ActionResult.Failure("Unknown Query Error")
+        return CommandResult.Failure("Unknown Query Error")
       }
     }
   }
 }
 
-struct ServerRunner : Runner, ActionPerformer {
+struct ServerRunner : Runner, CommandPerformer {
   let configuration: Configuration
   let control: FBSimulatorControl
   let defaults: Defaults
@@ -122,21 +129,22 @@ struct ServerRunner : Runner, ActionPerformer {
   let query: Query?
   let serverConfiguration: Server
 
-  func run(reporter: EventReporter) -> ActionResult {
+  func run(reporter: EventReporter) -> CommandResult {
     let relayReporter = RelayReporter(reporter: reporter, subject: self.serverConfiguration)
     switch serverConfiguration {
     case .StdIO:
-      StdIORelay(configuration: self.configuration, performer: self, reporter: relayReporter).start()
+      StdIORelay(outputOptions: self.configuration.output, performer: self, reporter: relayReporter).start()
     case .Socket(let portNumber):
-      SocketRelay(configuration: self.configuration, portNumber: portNumber, performer: self, reporter: relayReporter).start()
+      SocketRelay(outputOptions: self.configuration.output, portNumber: portNumber, performer: self, reporter: relayReporter).start()
     case .Http(let portNumber):
-      HttpRelay(portNumber: portNumber, performer: self, reporter: relayReporter).start()
+      let performer = ActionPerformer(commandPerformer: self, configuration: self.configuration, query: self.query, format: self.format)
+      HttpRelay(portNumber: portNumber, performer: performer, reporter: relayReporter).start()
     }
     return .Success
   }
 
-  func perform(action: Action, reporter: EventReporter) -> ActionResult {
-    return ActionRunner(action: action, configuration: self.configuration, control: self.control, defaults: self.defaults, format: self.format, query: self.query).run(reporter)
+  func perform(command: Command, reporter: EventReporter) -> CommandResult {
+    return CommandRunner(command: command, defaults: self.defaults, control: self.control).run(reporter)
   }
 }
 
@@ -147,16 +155,16 @@ struct CreationRunner : Runner {
   let format: Format?
   let simulatorConfiguration: FBSimulatorConfiguration
 
-  func run(reporter: EventReporter) -> ActionResult {
+  func run(reporter: EventReporter) -> CommandResult {
     do {
       let options = FBSimulatorAllocationOptions.Create
       reporter.reportSimpleBridge(EventName.Create, EventType.Started, self.simulatorConfiguration)
       let simulator = try self.control.simulatorPool.allocateSimulatorWithConfiguration(simulatorConfiguration, options: options)
       self.defaults.updateLastQuery(Query.UDID([simulator.udid]))
       reporter.reportSimpleBridge(EventName.Create, EventType.Ended, simulator)
-      return ActionResult.Success
+      return CommandResult.Success
     } catch let error as NSError {
-      return ActionResult.Failure("Failed to Create Simulator \(error.description)")
+      return CommandResult.Failure("Failed to Create Simulator \(error.description)")
     }
   }
 }
@@ -167,7 +175,7 @@ private struct SimulatorRunner : Runner {
   let action: Action
   let format: Format
 
-  func run(reporter: EventReporter) -> ActionResult {
+  func run(reporter: EventReporter) -> CommandResult {
     do {
       let translator = EventSinkTranslator(simulator: self.simulator, format: self.format, reporter: reporter)
       defer {

--- a/fbsimctl/FBSimulatorControlKit/Sources/SocketRelay.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/SocketRelay.swift
@@ -175,7 +175,7 @@ class SocketConnection {
   init(readStream: NSInputStream, writeStream: NSOutputStream, configuration: Configuration, delegate: SocketConnectionDelegate, performer: ActionPerformer) {
     self.writeStream = writeStream
     self.writeStreamDelegate = OutputDelegate(stream: writeStream)
-    self.relayConnection = RelayConnection(performer: performer, reporter: configuration.options.createReporter(self.writeStreamDelegate))
+    self.relayConnection = RelayConnection(performer: performer, reporter: configuration.output.createReporter(self.writeStreamDelegate))
     self.readStream = readStream
     self.readStreamDelegate = InputDelegate(lineBuffer: self.relayConnection.lineBuffer)
   }

--- a/fbsimctl/FBSimulatorControlKit/Sources/StdIORelay.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/StdIORelay.swift
@@ -44,7 +44,7 @@ class StdIORelay : Relay {
   let reporter: RelayReporter
 
   init(configuration: Configuration, performer: ActionPerformer, reporter: RelayReporter) {
-    self.relayConnection = RelayConnection(performer: performer, reporter: configuration.options.createReporter(FileHandleWriter.stdOutWriter))
+    self.relayConnection = RelayConnection(performer: performer, reporter: configuration.output.createReporter(FileHandleWriter.stdOutWriter))
     self.stdIn = NSFileHandle.fileHandleWithStandardInput()
     self.reporter = reporter
   }

--- a/fbsimctl/FBSimulatorControlKit/Sources/StdIORelay.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/StdIORelay.swift
@@ -43,8 +43,8 @@ class StdIORelay : Relay {
   let stdIn: NSFileHandle
   let reporter: RelayReporter
 
-  init(configuration: Configuration, performer: ActionPerformer, reporter: RelayReporter) {
-    self.relayConnection = RelayConnection(performer: performer, reporter: configuration.output.createReporter(FileHandleWriter.stdOutWriter))
+  init(outputOptions: OutputOptions, performer: CommandPerformer, reporter: RelayReporter) {
+    self.relayConnection = RelayConnection(performer: performer, reporter: outputOptions.createReporter(FileHandleWriter.stdOutWriter))
     self.stdIn = NSFileHandle.fileHandleWithStandardInput()
     self.reporter = reporter
   }

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
@@ -202,7 +202,7 @@ class ConfigurationParserTests : XCTestCase {
       Configuration.parser(),
       ["--debug-logging"],
       Configuration(
-        options: Configuration.Options.DebugLogging,
+        output: OutputOptions.DebugLogging,
         deviceSetPath: nil,
         managementOptions: FBSimulatorManagementOptions()
       )
@@ -214,7 +214,7 @@ class ConfigurationParserTests : XCTestCase {
       Configuration.parser(),
       ["--set", "/usr/bin"],
       Configuration(
-        options: Configuration.Options(),
+        output: OutputOptions(),
         deviceSetPath: "/usr/bin",
         managementOptions: FBSimulatorManagementOptions()
       )
@@ -226,7 +226,7 @@ class ConfigurationParserTests : XCTestCase {
       Configuration.parser(),
       ["--kill-all", "--kill-spurious"],
       Configuration(
-        options: Configuration.Options(),
+        output: OutputOptions(),
         deviceSetPath: nil,
         managementOptions: FBSimulatorManagementOptions.KillAllOnFirstStart.union(.KillSpuriousSimulatorsOnFirstStart)
       )
@@ -238,7 +238,7 @@ class ConfigurationParserTests : XCTestCase {
       Configuration.parser(),
       ["--set", "/usr/bin", "--delete-all", "--kill-spurious"],
       Configuration(
-        options: Configuration.Options(),
+        output: OutputOptions(),
         deviceSetPath: "/usr/bin",
         managementOptions: FBSimulatorManagementOptions.DeleteAllOnFirstStart.union(.KillSpuriousSimulatorsOnFirstStart)
       )
@@ -250,7 +250,7 @@ class ConfigurationParserTests : XCTestCase {
       Configuration.parser(),
       ["--debug-logging", "--set", "/usr/bin", "--delete-all", "--kill-spurious"],
       Configuration(
-        options: Configuration.Options.DebugLogging,
+        output: OutputOptions.DebugLogging,
         deviceSetPath: "/usr/bin",
         managementOptions: FBSimulatorManagementOptions.DeleteAllOnFirstStart.union(.KillSpuriousSimulatorsOnFirstStart)
       )
@@ -293,7 +293,7 @@ class ActionParserTests : XCTestCase {
 class CommandParserTests : XCTestCase {
   func testParsesHelp() {
     self.assertParsesAll(Command.parser(), [
-      (["help"], Command.Help(true, nil))
+      (["help"], Command.Help(OutputOptions(), true, nil))
     ])
   }
 

--- a/fbsimctl/fbsimctl.xcodeproj/project.pbxproj
+++ b/fbsimctl/fbsimctl.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		AA54EF731C4818F9006D5118 /* Arguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA54EF711C4814BA006D5118 /* Arguments.swift */; };
 		AA54EF751C48275B006D5118 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA54EF741C48275B006D5118 /* JSON.swift */; };
 		AA54EF761C48DE6F006D5118 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA54EF741C48275B006D5118 /* JSON.swift */; };
+		AA60468F1C7A96E500639DD5 /* CommandPerformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA60468E1C7A96E500639DD5 /* CommandPerformer.swift */; };
+		AA6046901C7A96E500639DD5 /* CommandPerformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA60468E1C7A96E500639DD5 /* CommandPerformer.swift */; };
 		AA6085BE1C287AC3009B500E /* FBSimulatorControl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA93B7C91BE8361800CF6A56 /* FBSimulatorControl.framework */; };
 		AA6085CF1C287DBD009B500E /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE35A7C1C2863EB0073CC70 /* main.swift */; };
 		AA6085D11C287E02009B500E /* Bridging.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B7F5C1C2867EE0038C6A5 /* Bridging.swift */; };
@@ -51,8 +53,6 @@
 		AA83D5EB1C58E368003B253E /* Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA83D5EA1C58E368003B253E /* Events.swift */; };
 		AA83D5EC1C58E368003B253E /* Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA83D5EA1C58E368003B253E /* Events.swift */; };
 		AAA27E721C478F4C00C9EC28 /* EnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA27E711C478F4C00C9EC28 /* EnvironmentTests.swift */; };
-		AABDEDF41C68D0A200DBA9D8 /* ActionPerformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABDEDF31C68D0A200DBA9D8 /* ActionPerformer.swift */; };
-		AABDEDF51C68D0A200DBA9D8 /* ActionPerformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABDEDF31C68D0A200DBA9D8 /* ActionPerformer.swift */; };
 		AACF9F531C46E5C100B17E82 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACF9F521C46E5C100B17E82 /* Environment.swift */; };
 		AACF9F541C46E85800B17E82 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACF9F521C46E5C100B17E82 /* Environment.swift */; };
 		AAD999551C68D1460014D61F /* Swifter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAD999541C68D1460014D61F /* Swifter.framework */; };
@@ -123,6 +123,7 @@
 		AA3ADDB71C2B0B2D004E4FA9 /* Defaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Defaults.swift; sourceTree = "<group>"; };
 		AA54EF711C4814BA006D5118 /* Arguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Arguments.swift; sourceTree = "<group>"; };
 		AA54EF741C48275B006D5118 /* JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
+		AA60468E1C7A96E500639DD5 /* CommandPerformer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandPerformer.swift; sourceTree = "<group>"; };
 		AA6085BF1C287B36009B500E /* fbsimctl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fbsimctl.h; sourceTree = "<group>"; };
 		AA78DCD51C4E9A09006FAB41 /* EventReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventReporter.swift; sourceTree = "<group>"; };
 		AA83D5E41C57E5FE003B253E /* JSONLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSONLogger.h; sourceTree = "<group>"; };
@@ -131,7 +132,6 @@
 		AA93B7B01BE8351000CF6A56 /* fbsimctl */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = fbsimctl; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA93B7C91BE8361800CF6A56 /* FBSimulatorControl.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = FBSimulatorControl.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AAA27E711C478F4C00C9EC28 /* EnvironmentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnvironmentTests.swift; sourceTree = "<group>"; };
-		AABDEDF31C68D0A200DBA9D8 /* ActionPerformer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionPerformer.swift; sourceTree = "<group>"; };
 		AACF9F521C46E5C100B17E82 /* Environment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		AAD999541C68D1460014D61F /* Swifter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Swifter.framework; path = Carthage/Build/Mac/Swifter.framework; sourceTree = "<group>"; };
 		AAE0C5521C4904BC005DE6D9 /* Query.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Query.swift; sourceTree = "<group>"; };
@@ -178,13 +178,13 @@
 		AA1B7F5A1C2867EE0038C6A5 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				AABDEDF31C68D0A200DBA9D8 /* ActionPerformer.swift */,
 				AA54EF711C4814BA006D5118 /* Arguments.swift */,
 				AA1B7F5F1C2867EE0038C6A5 /* Bridging.h */,
 				AA1B7F601C2867EE0038C6A5 /* Bridging.m */,
 				AA1B7F5C1C2867EE0038C6A5 /* Bridging.swift */,
 				AA1B7F5D1C2867EE0038C6A5 /* Command.swift */,
 				AA1B7F5E1C2867EE0038C6A5 /* CommandParsers.swift */,
+				AA60468E1C7A96E500639DD5 /* CommandPerformer.swift */,
 				AA3ADDB71C2B0B2D004E4FA9 /* Defaults.swift */,
 				AACF9F521C46E5C100B17E82 /* Environment.swift */,
 				AA78DCD51C4E9A09006FAB41 /* EventReporter.swift */,
@@ -409,7 +409,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				AAE0C5571C492158005DE6D9 /* Query.swift in Sources */,
-				AABDEDF41C68D0A200DBA9D8 /* ActionPerformer.swift in Sources */,
 				AA54EF731C4818F9006D5118 /* Arguments.swift in Sources */,
 				AA78DCD71C4E9F61006FAB41 /* EventReporter.swift in Sources */,
 				AA6085D11C287E02009B500E /* Bridging.swift in Sources */,
@@ -419,6 +418,7 @@
 				AA0DE44D1C68894000B4D2AF /* HttpRelay.swift in Sources */,
 				AA6085D41C287E02009B500E /* Bridging.m in Sources */,
 				AA6085D51C287E02009B500E /* Help.swift in Sources */,
+				AA60468F1C7A96E500639DD5 /* CommandPerformer.swift in Sources */,
 				AA54EF761C48DE6F006D5118 /* JSON.swift in Sources */,
 				AA83D5E61C57E5FE003B253E /* JSONLogger.m in Sources */,
 				AA83D5EB1C58E368003B253E /* Events.swift in Sources */,
@@ -445,11 +445,11 @@
 				AA3ADDB81C2B0B2D004E4FA9 /* Defaults.swift in Sources */,
 				AA1B7F781C2867EE0038C6A5 /* StdIORelay.swift in Sources */,
 				AA1B7F6F1C2867EE0038C6A5 /* Bridging.m in Sources */,
+				AA6046901C7A96E500639DD5 /* CommandPerformer.swift in Sources */,
 				AA1B7F771C2867EE0038C6A5 /* SocketRelay.swift in Sources */,
 				AA54EF751C48275B006D5118 /* JSON.swift in Sources */,
 				AAE0C5531C4904BC005DE6D9 /* Query.swift in Sources */,
 				AA78DCD61C4E9A09006FAB41 /* EventReporter.swift in Sources */,
-				AABDEDF51C68D0A200DBA9D8 /* ActionPerformer.swift in Sources */,
 				AAF2D34E1C32EA4D00434516 /* Writer.swift in Sources */,
 				AA83D5EC1C58E368003B253E /* Events.swift in Sources */,
 				AA1B7F701C2867EE0038C6A5 /* Help.swift in Sources */,

--- a/fbsimctl/fbsimctl/main.swift
+++ b/fbsimctl/fbsimctl/main.swift
@@ -14,8 +14,8 @@ import FBSimulatorControl
 let arguments = Array(NSProcessInfo.processInfo().arguments.dropFirst(1))
 do {
   let (_, configuration) = try Configuration.parser().parse(arguments)
-  let jsonEnabled = configuration.options.contains(Configuration.Options.JSON)
-  let debugEnabled = configuration.options.contains(Configuration.Options.DebugLogging)
+  let jsonEnabled = configuration.output.contains(OutputOptions.JSON)
+  let debugEnabled = configuration.output.contains(OutputOptions.DebugLogging)
 
   if jsonEnabled {
     let eventReporter = JSONEventReporter(writer: FileHandleWriter.stdOutWriter, pretty: false)


### PR DESCRIPTION
Previous iterations of any `Listen` mode have fixed the `Query` to the `Query` of the `Listen` command. This is less desirable than allowing this to be optionally changed.