### PR TITLE
Don't fail on an empty pool

### DIFF
--- a/fbsimctl/FBSimulatorControlKit/Sources/Events.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Events.swift
@@ -26,6 +26,7 @@ public enum EventName : String {
   case Launch = "launch"
   case List = "list"
   case Listen = "listen"
+  case Query = "query"
   case Relaunch = "relaunch"
   case Shutdown = "shutdown"
   case Signalled = "signalled"

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -24,12 +24,12 @@ extension Configuration {
 
 public extension Command {
   func runFromCLI() -> Int32 {
-    let writer = FileHandleWriter.stdOutWriter
-    switch CommandRunner.bootstrap(self, writer: writer) {
+    let (reporter, result) = CommandRunner.bootstrap(self, writer: FileHandleWriter.stdOutWriter)
+    switch result {
     case .Success:
       return 0
     case .Failure(let string):
-      writer.write(string)
+      reporter.reportSimpleBridge(EventName.Failure, EventType.Discrete, string as NSString)
       return 1
     }
   }
@@ -83,10 +83,10 @@ private struct CommandRunner : Runner {
     }
   }
 
-  static func bootstrap(command: Command, writer: Writer) -> CommandResult {
+  static func bootstrap(command: Command, writer: Writer) -> (EventReporter, CommandResult) {
     let reporter = command.createReporter(writer)
     let runner = CommandRunner(command: command, defaults: nil, control: nil)
-    return runner.run(reporter)
+    return (reporter, runner.run(reporter))
   }
 }
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -112,6 +112,9 @@ struct ActionRunner : Runner {
           SimulatorRunner(simulator: simulator, action: action.appendEnvironment(NSProcessInfo.processInfo().environment), format: format)
         }
         return SequenceRunner(runners: runners).run(reporter)
+      } catch QueryError.PoolIsEmpty {
+        reporter.reportSimpleBridge(EventName.Query, EventType.Discrete, "Pool is empty")
+        return CommandResult.Success
       } catch let error as QueryError {
         return CommandResult.Failure(error.description)
       } catch {


### PR DESCRIPTION
Calling `fbsimct all delete` on an empty pool really shouldn't error. In fact all commands that operate on an empty pool should return fine with a logger message.

Additionally, failure messages weren't sent to the reporter, which would mean that some failure messages aren't json-ified.