### PR TITLE
Additional Robustness in FBSimulatorSet

### DIFF
--- a/FBSimulatorControl/Management/FBSimulatorControl+PrincipalClass.h
+++ b/FBSimulatorControl/Management/FBSimulatorControl+PrincipalClass.h
@@ -14,6 +14,8 @@
 @class FBSimulatorApplication;
 @class FBSimulatorConfiguration;
 @class FBSimulatorControlConfiguration;
+@class FBSimulatorPool;
+@class FBSimulatorSet;
 @protocol FBSimulatorLogger;
 
 /**
@@ -60,24 +62,17 @@
  */
 + (void)loadPrivateFrameworksOrAbort;
 
-#pragma mark Simulators
-
-/**
- Obtains a Simulator for the given configuration and allocation options from the pool.
-
- @param simulatorConfiguration the Configuration of the Simulator to Launch.
- @param options the options to for the allocation/freeing of the Simulator.
- @param error an outparam for describing any error that occured during the allocation of the Simulator.
- @returns A FBSimulator instance, or nil if an error occured.
- */
-- (FBSimulator *)obtainSimulatorWithConfiguration:(FBSimulatorConfiguration *)simulatorConfiguration options:(FBSimulatorAllocationOptions)options error:(NSError **)error;
-
 #pragma mark Properties
 
 /**
  The Pool that the FBSimulatorControl instance uses.
  */
-@property (nonatomic, strong, readonly) FBSimulatorPool *simulatorPool;
+@property (nonatomic, strong, readonly) FBSimulatorPool *pool;
+
+/**
+ The Pool that the FBSimulatorControl instance uses.
+ */
+@property (nonatomic, strong, readonly) FBSimulatorSet *set;
 
 /**
  The Configuration that FBSimulatorControl uses.

--- a/FBSimulatorControl/Management/FBSimulatorPool.h
+++ b/FBSimulatorControl/Management/FBSimulatorPool.h
@@ -46,12 +46,11 @@ typedef NS_OPTIONS(NSUInteger, FBSimulatorAllocationOptions){
 /**
  Creates and returns an FBSimulatorPool.
 
- @param configuration the configuration to use. Must not be nil.
+ @param set the FBSimulatorSet to Manage.
  @param logger the logger to use to verbosely describe what is going on. May be nil.
- @param error any error that occurred during the creation of the pool.
  @returns a new FBSimulatorPool.
  */
-+ (instancetype)poolWithConfiguration:(FBSimulatorControlConfiguration *)configuration logger:(id<FBSimulatorLogger>)logger error:(NSError **)error;
++ (instancetype)poolWithSet:(FBSimulatorSet *)set logger:(id<FBSimulatorLogger>)logger;
 
 #pragma mark Methods
 

--- a/FBSimulatorControl/Management/FBSimulatorPool.m
+++ b/FBSimulatorControl/Management/FBSimulatorPool.m
@@ -33,12 +33,8 @@
 
 #pragma mark - Initializers
 
-+ (instancetype)poolWithConfiguration:(FBSimulatorControlConfiguration *)configuration logger:(id<FBSimulatorLogger>)logger error:(NSError **)error
++ (instancetype)poolWithSet:(FBSimulatorSet *)set logger:(id<FBSimulatorLogger>)logger
 {
-  FBSimulatorSet *set = [FBSimulatorSet setWithConfiguration:configuration logger:logger error:error];
-  if (!set) {
-    return nil;
-  }
   return [[self alloc] initWithSet:set logger:logger];
 }
 

--- a/FBSimulatorControl/Management/FBSimulatorSet+Private.h
+++ b/FBSimulatorControl/Management/FBSimulatorSet+Private.h
@@ -13,6 +13,6 @@
 
 @property (nonatomic, strong, readonly) NSMutableDictionary *inflatedSimulators;
 
-- (instancetype)initWithConfiguration:(FBSimulatorControlConfiguration *)configuration deviceSet:(SimDeviceSet *)deviceSet logger:(id<FBSimulatorLogger>)logger;
+- (instancetype)initWithConfiguration:(FBSimulatorControlConfiguration *)configuration deviceSet:(SimDeviceSet *)deviceSet control:(FBSimulatorControl *)control logger:(id<FBSimulatorLogger>)logger;
 
 @end

--- a/FBSimulatorControl/Management/FBSimulatorSet.h
+++ b/FBSimulatorControl/Management/FBSimulatorSet.h
@@ -15,6 +15,7 @@
 @class FBProcessQuery;
 @class FBSimulator;
 @class FBSimulatorConfiguration;
+@class FBSimulatorControl;
 @class FBSimulatorControlConfiguration;
 @class SimDeviceSet;
 @protocol FBSimulatorLogger;
@@ -33,7 +34,7 @@
  @param error any error that occurred during the creation of the pool.
  @returns a new FBSimulatorPool.
  */
-+ (instancetype)setWithConfiguration:(FBSimulatorControlConfiguration *)configuration logger:(id<FBSimulatorLogger>)logger error:(NSError **)error;
++ (instancetype)setWithConfiguration:(FBSimulatorControlConfiguration *)configuration control:(FBSimulatorControl *)control logger:(id<FBSimulatorLogger>)logger error:(NSError **)error;
 
 /**
  Creates and returns a FBSimulator fbased on a configuration.
@@ -86,7 +87,17 @@
 @property (nonatomic, strong, readonly) id<FBSimulatorLogger> logger;
 
 /**
- The SimDeviceSet to which the Simulators belong.
+ Returns the configuration for the reciever.
+ */
+@property (nonatomic, copy, readonly) FBSimulatorControlConfiguration *configuration;
+
+/**
+ The FBSimulatorControl Instance to which the Set Belongs.
+ */
+@property (nonatomic, weak, readonly) FBSimulatorControl *control;
+
+/**
+ The SimDeviceSet to that is owned by the reciever.
  */
 @property (nonatomic, strong, readonly) SimDeviceSet *deviceSet;
 
@@ -94,11 +105,6 @@
  The FBProcessQuery that is used to obtain Simulator Process Information.
  */
 @property (nonatomic, strong, readonly) FBProcessQuery *processQuery;
-
-/**
- Returns the configuration for the reciever.
- */
-@property (nonatomic, copy, readonly) FBSimulatorControlConfiguration *configuration;
 
 /**
  An NSArray<FBSimulator> of all Simulators in the Set.

--- a/FBSimulatorControl/Management/FBSimulatorSet.m
+++ b/FBSimulatorControl/Management/FBSimulatorSet.m
@@ -30,7 +30,7 @@
   [FBSimulatorControl loadPrivateFrameworksOrAbort];
 }
 
-+ (instancetype)setWithConfiguration:(FBSimulatorControlConfiguration *)configuration logger:(id<FBSimulatorLogger>)logger error:(NSError **)error
++ (instancetype)setWithConfiguration:(FBSimulatorControlConfiguration *)configuration control:(FBSimulatorControl *)control logger:(id<FBSimulatorLogger>)logger error:(NSError **)error
 {
   NSError *innerError = nil;
   SimDeviceSet *deviceSet = [self createDeviceSetWithConfiguration:configuration error:&innerError];
@@ -38,14 +38,14 @@
     return [[[FBSimulatorError describe:@"Failed to create device set"] causedBy:innerError] fail:error];
   }
 
-  FBSimulatorSet *set = [[FBSimulatorSet alloc] initWithConfiguration:configuration deviceSet:deviceSet logger:logger];
+  FBSimulatorSet *set = [[FBSimulatorSet alloc] initWithConfiguration:configuration deviceSet:deviceSet control:control logger:logger];
   if (![set performSetPreconditionsWithConfiguration:configuration Error:&innerError]) {
     return [[[FBSimulatorError describe:@"Failed meet pool preconditions"] causedBy:innerError] fail:error];
   }
   return set;
 }
 
-- (instancetype)initWithConfiguration:(FBSimulatorControlConfiguration *)configuration deviceSet:(SimDeviceSet *)deviceSet logger:(id<FBSimulatorLogger>)logger
+- (instancetype)initWithConfiguration:(FBSimulatorControlConfiguration *)configuration deviceSet:(SimDeviceSet *)deviceSet control:(FBSimulatorControl *)control logger:(id<FBSimulatorLogger>)logger
 {
   self = [super init];
   if (!self) {
@@ -54,6 +54,7 @@
 
   _logger = logger;
   _deviceSet = deviceSet;
+  _control = control;
   _configuration = configuration;
 
   _inflatedSimulators = [NSMutableDictionary dictionary];

--- a/FBSimulatorControl/Management/FBSimulatorSet.m
+++ b/FBSimulatorControl/Management/FBSimulatorSet.m
@@ -192,11 +192,17 @@
   return simulator;
 }
 
-
 - (BOOL)deleteSimulator:(FBSimulator *)simulator error:(NSError **)error
 {
   NSParameterAssert(simulator);
-  NSParameterAssert(simulator.device.deviceSet != self.deviceSet);
+
+  // Confirm that this Simulator belongs to us.
+  if (simulator.set != self) {
+    return [[[FBSimulatorError
+      describeFormat:@"Simulator's set %@ is not %@", simulator.set, self]
+      inSimulator:simulator]
+      failBool:error];
+  }
 
   // Kill the Simulators before deleting them.
   NSError *innerError = nil;
@@ -236,7 +242,14 @@
 - (BOOL)killSimulator:(FBSimulator *)simulator error:(NSError **)error
 {
   NSParameterAssert(simulator);
-  NSParameterAssert(simulator.device.deviceSet != self.deviceSet);
+
+  // Confirm that this Simulator belongs to us.
+  if (simulator.set != self) {
+    return [[[FBSimulatorError
+      describeFormat:@"Simulator's set %@ is not %@", simulator.set, self]
+      inSimulator:simulator]
+      failBool:error];
+  }
 
   return [self.simulatorTerminationStrategy killSimulators:@[simulator] withError:error] != nil;
 }

--- a/FBSimulatorControlTests/Tests/FBSimulatorLaunchTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorLaunchTests.m
@@ -105,7 +105,7 @@
   FBSimulator *simulator2 = [self obtainSimulatorWithConfiguration:FBSimulatorConfiguration.iPhone5];
   FBSimulator *simulator3 = [self obtainSimulatorWithConfiguration:FBSimulatorConfiguration.iPad2];
 
-  XCTAssertEqual(self.control.simulatorPool.allocatedSimulators.count, 3u);
+  XCTAssertEqual(self.control.pool.allocatedSimulators.count, 3u);
   XCTAssertEqual(([[NSSet setWithArray:@[simulator1.udid, simulator2.udid, simulator3.udid]] count]), 3u);
 
   [self assertInteractionSuccessful:[simulator1.interact bootSimulator:self.simulatorLaunchConfiguration]];
@@ -125,7 +125,7 @@
     [self assertShutdownSimulatorAndTerminateSession:simulator];
   }
 
-  XCTAssertEqual(self.control.simulatorPool.allocatedSimulators.count, 0u);
+  XCTAssertEqual(self.control.pool.allocatedSimulators.count, 0u);
 }
 
 - (void)testLaunchesSafariApplication

--- a/FBSimulatorControlTests/Tests/FBSimulatorPoolTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorPoolTests.m
@@ -120,7 +120,7 @@
 - (void)assertFreesSimulator:(FBSimulator *)simulator
 {
   NSError *error = nil;
-  BOOL success = [self.control.simulatorPool freeSimulator:simulator error:&error];
+  BOOL success = [self.control.pool freeSimulator:simulator error:&error];
   XCTAssertNil(error);
   XCTAssertTrue(success);
   XCTAssertNil(simulator.pool);
@@ -165,7 +165,7 @@
   NSString *simulatorUUID = simulator.udid;
   [self assertFreesSimulator:simulator];
 
-  NSOrderedSet *uuidSet = [self.control.simulatorPool.set.allSimulators valueForKey:@"udid"];
+  NSOrderedSet *uuidSet = [self.control.pool.set.allSimulators valueForKey:@"udid"];
   XCTAssertFalse([uuidSet containsObject:simulatorUUID]);
 }
 
@@ -181,10 +181,10 @@
   }
 
   NSError *error = nil;
-  XCTAssertTrue([self.control.simulatorPool.set deleteAllWithError:&error]);
+  XCTAssertTrue([self.control.pool.set deleteAllWithError:&error]);
   XCTAssertNil(error);
 
-  NSSet *uuidSet = [NSSet setWithArray:[self.control.simulatorPool.set.allSimulators valueForKey:@"udid"]];
+  NSSet *uuidSet = [NSSet setWithArray:[self.control.pool.set.allSimulators valueForKey:@"udid"]];
   [simulatorUUIDs intersectSet:uuidSet];
   XCTAssertEqual(simulatorUUIDs.count, 0u);
 }

--- a/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
@@ -59,7 +59,7 @@ static NSString *const DirectLaunchRecordVideoKey = @"FBSIMULATORCONTROL_RECORD_
     XCTAssertNil(error);
     XCTAssertNotNil(control);
     _control = control;
-    _assert = [FBSimulatorControlNotificationAssertions withTestCase:self pool:control.simulatorPool];
+    _assert = [FBSimulatorControlNotificationAssertions withTestCase:self pool:control.pool];
   }
   return _control;
 }
@@ -75,7 +75,7 @@ static NSString *const DirectLaunchRecordVideoKey = @"FBSIMULATORCONTROL_RECORD_
 - (FBSimulator *)obtainSimulatorWithConfiguration:(FBSimulatorConfiguration *)configuration
 {
   NSError *error = nil;
-  FBSimulator *simulator = [self.control obtainSimulatorWithConfiguration:configuration options:self.allocationOptions error:&error];
+  FBSimulator *simulator = [self.control.pool allocateSimulatorWithConfiguration:configuration options:self.allocationOptions error:&error];
   XCTAssertNil(error);
   XCTAssertNotNil(simulator);
   return simulator;
@@ -153,7 +153,7 @@ static NSString *const DirectLaunchRecordVideoKey = @"FBSIMULATORCONTROL_RECORD_
 
 - (void)tearDown
 {
-  [self.control.simulatorPool.set killAllWithError:nil];
+  [self.control.pool.set killAllWithError:nil];
   _control = nil;
   _assert = nil;
 }

--- a/FBSimulatorControlTests/Utilities/FBSimulatorPoolTestCase.m
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorPoolTestCase.m
@@ -57,7 +57,7 @@
   deviceSet.availableDevices = [simulators copy];
 
   FBSimulatorControlConfiguration *configuration = [FBSimulatorControlConfiguration configurationWithDeviceSetPath:nil options:0];
-  _set = [[FBSimulatorSet alloc] initWithConfiguration:configuration deviceSet:(id)deviceSet logger:nil];
+  _set = [[FBSimulatorSet alloc] initWithConfiguration:configuration deviceSet:(id)deviceSet control:nil logger:nil];
   _pool = [[FBSimulatorPool alloc] initWithSet:_set logger:nil];
 
   return deviceSet.availableDevices;

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -106,7 +106,7 @@ struct ActionRunner : Runner {
       return CreationRunner(configuration: self.configuration, control: control, defaults: self.defaults, format: self.format, simulatorConfiguration: configuration).run(reporter)
     default:
       do {
-        let simulators = try Query.perform(self.control.simulatorPool.set, query: self.query, defaults: self.defaults, action: self.action)
+        let simulators = try Query.perform(self.control.set, query: self.query, defaults: self.defaults, action: self.action)
         let format = self.format ?? defaults.format
         let runners: [Runner] = simulators.map { simulator in
           SimulatorRunner(simulator: simulator, action: action.appendEnvironment(NSProcessInfo.processInfo().environment), format: format)
@@ -161,7 +161,7 @@ struct CreationRunner : Runner {
   func run(reporter: EventReporter) -> CommandResult {
     do {
       reporter.reportSimpleBridge(EventName.Create, EventType.Started, self.simulatorConfiguration)
-      let simulator = try self.control.simulatorPool.set.createSimulatorWithConfiguration(simulatorConfiguration)
+      let simulator = try self.control.set.createSimulatorWithConfiguration(simulatorConfiguration)
       self.defaults.updateLastQuery(Query.UDID([simulator.udid]))
       reporter.reportSimpleBridge(EventName.Create, EventType.Ended, simulator)
       return CommandResult.Success


### PR DESCRIPTION
- Add a backreference from `FBSimulatorSet` to `FBSimulatorControl`
- Don't assert on wrong sim, return error.
- Create `FBSimulatorSet` and pass-from-above to `FBSimulatorPool`