### PR TITLE
Fix missing -[SimDevice setPath] in Xcode 7 Betas

### DIFF
--- a/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration+Helpers.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration+Helpers.m
@@ -10,6 +10,7 @@
 #import "FBSimulatorLaunchConfiguration+Helpers.h"
 
 #import <CoreSimulator/SimDevice.h>
+#import <CoreSimulator/SimDeviceSet.h>
 
 #import "FBSimulator.h"
 #import "FBSimulatorControlConfiguration.h"
@@ -29,7 +30,7 @@
     @"-ConnectHardwareKeyboard", @"0",
     [self lastScaleCommandLineSwitchForSimulator:simulator], self.scaleString
   ]];
-  NSString *setPath = simulator.device.setPath;
+  NSString *setPath = simulator.set.deviceSet.setPath;
   if (setPath) {
     if (!FBSimulatorControlGlobalConfiguration.supportsCustomDeviceSets) {
       return [[[FBSimulatorError describe:@"Cannot use custom Device Set on current platform"] inSimulator:simulator] fail:error];

--- a/FBSimulatorControl/Management/FBSimulator+Helpers.h
+++ b/FBSimulatorControl/Management/FBSimulator+Helpers.h
@@ -14,12 +14,39 @@
 @class FBSimulatorInteraction;
 @class FBSimulatorLaunchCtl;
 
+/**
+ Helper Methods & Properties for FBSimulator.
+ */
 @interface FBSimulator (Helpers)
 
+#pragma mark Properties
+
 /**
- Creates an `FBSimulatorInteraction` for the reciever.
+ Creates an FBSimulatorInteraction for the reciever.
  */
-- (FBSimulatorInteraction *)interact;
+@property (nonatomic, strong, readonly) FBSimulatorInteraction *interact;
+
+/**
+ Creates a FBSimDeviceWrapper for the Simulator.
+ */
+@property (nonatomic, strong, readonly) FBSimDeviceWrapper *simDeviceWrapper;
+
+/**
+ Creates a FBSimulatorLaunchCtl for the Simulator.
+ */
+@property (nonatomic, strong, readonly) FBSimulatorLaunchCtl *launchctl;
+
+/**
+ The DeviceSetPath of the Simulator.
+ */
+@property (nonatomic, copy, readonly) NSString *deviceSetPath;
+
+/*
+ Fetches an NSArray<FBProcessInfo *> of the subprocesses of the launchd_sim.
+ */
+@property (nonatomic, copy, readonly) NSArray *launchdSimSubprocesses;
+
+#pragma mark Methods
 
 /**
  Synchronously waits on the provided state.
@@ -99,21 +126,6 @@
  @return An FBProcessInfo for the Application if one is running, nil otherwise.
  */
 - (FBProcessInfo *)runningApplicationWithBundleID:(NSString *)bundleID error:(NSError **)error;
-
-/*
- Fetches an NSArray<FBProcessInfo *> of the subprocesses of the launchd_sim.
- */
-- (NSArray *)launchdSimSubprocesses;
-
-/**
- Creates a FBSimDeviceWrapper for the Simulator.
- */
-- (FBSimDeviceWrapper *)simDeviceWrapper;
-
-/**
- Creates a FBSimulatorLaunchCtl for the Simulator.
- */
-- (FBSimulatorLaunchCtl *)launchctl;
 
 /*
  A Set of process names that are used to determine whether all the Simulator OS services

--- a/FBSimulatorControl/Management/FBSimulator+Helpers.m
+++ b/FBSimulatorControl/Management/FBSimulator+Helpers.m
@@ -10,6 +10,7 @@
 #import "FBSimulator+Helpers.h"
 
 #import <CoreSimulator/SimDevice.h>
+#import <CoreSimulator/SimDeviceSet.h>
 
 #import "FBCollectionDescriptions.h"
 #import "FBProcessInfo.h"
@@ -29,10 +30,38 @@
 
 @implementation FBSimulator (Helpers)
 
+#pragma mark Properties
+
 - (FBSimulatorInteraction *)interact
 {
   return [FBSimulatorInteraction withSimulator:self];
 }
+
+- (FBSimDeviceWrapper *)simDeviceWrapper
+{
+  return [FBSimDeviceWrapper withSimulator:self configuration:self.set.configuration processQuery:self.processQuery];
+}
+
+- (FBSimulatorLaunchCtl *)launchctl
+{
+  return [FBSimulatorLaunchCtl withSimulator:self];
+}
+
+- (NSString *)deviceSetPath
+{
+  return self.set.deviceSet.setPath;
+}
+
+- (NSArray *)launchdSimSubprocesses
+{
+  FBProcessInfo *launchdSim = self.launchdSimProcess;
+  if (!launchdSim) {
+    return @[];
+  }
+  return [self.processQuery subprocessesOf:launchdSim.processIdentifier];
+}
+
+#pragma mark Methods
 
 + (FBSimulatorState)simulatorStateFromStateString:(NSString *)stateString
 {
@@ -167,25 +196,6 @@
     launchdSimSubprocesses]
     filteredArrayUsingPredicate:[FBSimulator predicateForApplicationProcessOfApplication:application]]
     firstObject];
-}
-
-- (FBSimDeviceWrapper *)simDeviceWrapper
-{
-  return [FBSimDeviceWrapper withSimulator:self configuration:self.set.configuration processQuery:self.processQuery];
-}
-
-- (FBSimulatorLaunchCtl *)launchctl
-{
-  return [FBSimulatorLaunchCtl withSimulator:self];
-}
-
-- (NSArray *)launchdSimSubprocesses
-{
-  FBProcessInfo *launchdSim = self.launchdSimProcess;
-  if (!launchdSim) {
-    return @[];
-  }
-  return [self.processQuery subprocessesOf:launchdSim.processIdentifier];
 }
 
 - (NSSet *)requiredProcessNamesToVerifyBooted

--- a/PrivateHeaders/CoreSimulator/SimDevice.h
+++ b/PrivateHeaders/CoreSimulator/SimDevice.h
@@ -53,7 +53,6 @@
 @property(retain) NSMutableDictionary *registeredServices; // @synthesize registeredServices=_registeredServices;
 @property(retain) NSObject<OS_dispatch_queue> *bootstrapQueue; // @synthesize bootstrapQueue=_bootstrapQueue;
 @property(retain) SimDeviceNotificationManager *notificationManager; // @synthesize notificationManager=_notificationManager;
-@property(copy) NSString *setPath; // @synthesize setPath=_setPath;
 @property(retain) SimServiceContext *serviceContext; // @synthesize serviceContext=_serviceContext;
 @property(readonly) SimDeviceSet *deviceSet; // @synthesize deviceSet=_deviceSet;
 @property(copy) NSUUID *UDID; // @synthesize UDID=_UDID;

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -247,7 +247,7 @@ private struct SimulatorRunner : Runner {
 
   func interactWithSimulator(translator: EventSinkTranslator, _ eventName: EventName, _ subject: SimulatorControlSubject, interact: FBSimulatorInteraction -> Void) throws {
     translator.reportSimulator(eventName, EventType.Started, subject)
-    let interaction = translator.simulator.interact()
+    let interaction = translator.simulator.interact
     interact(interaction)
     try interaction.perform()
     translator.reportSimulator(eventName, EventType.Ended, subject)


### PR DESCRIPTION
This appears to have gone recently, it still exists on `SimDevieSet`