### PR TITLE
Scale at the SimDeviceFramebufferService level

### DIFF
--- a/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration.h
@@ -33,12 +33,12 @@ typedef NS_OPTIONS(NSUInteger, FBSimulatorLaunchOptions) {
 @property (nonatomic, strong, readonly) NSLocale *locale;
 
 /**
- A String representing the Scale at which to launch the Simulator.
+ A String representing the Scaling Factor at which to launch the Simulator.
  */
 @property (nonatomic, copy, readonly) NSString *scaleString;
 
 /**
- Options for using a useFramebuffer App instead of Xcode's Simulator.app
+ Options for how the Simulator should be launched.
  */
 @property (nonatomic, assign, readonly) FBSimulatorLaunchOptions options;
 
@@ -71,6 +71,14 @@ typedef NS_OPTIONS(NSUInteger, FBSimulatorLaunchOptions) {
  */
 + (instancetype)scale100Percent;
 - (instancetype)scale100Percent;
+
+/**
+ Scales the provided size with the receiver's scale/
+ 
+ @param size the size to scale.
+ @return a scaled size.
+ */
+- (CGSize)scaleSize:(CGSize)size;
 
 #pragma mark Locale
 

--- a/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration.m
@@ -217,6 +217,13 @@
   return [[self.class alloc] initWithScale:scale locale:self.locale options:self.options];
 }
 
+- (CGSize)scaleSize:(CGSize)size
+{
+  NSDecimalNumber *scaleNumber = [NSDecimalNumber decimalNumberWithString:self.scaleString];
+  CGFloat scale = scaleNumber.doubleValue;
+  return CGSizeMake(size.width * scale, size.height * scale);
+}
+
 #pragma mark Locale
 
 + (instancetype)withLocale:(NSLocale *)locale

--- a/FBSimulatorControl/Framebuffer/FBFramebufferVideo.h
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferVideo.h
@@ -27,11 +27,10 @@
  Creates a new FBFramebufferVideo instance.
 
  @param diagnostic the log to base the video file from.
- @param scale the scaling factor of the video. Must be 1 or lower.
  @param logger the logger object to log events to, may be nil.
  @param eventSink an event sink to report video output to.
  @return a new FBFramebufferVideo instance.
  */
-+ (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic scale:(CGFloat)scale logger:(id<FBSimulatorLogger>)logger eventSink:(id<FBSimulatorEventSink>)eventSink;
++ (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic logger:(id<FBSimulatorLogger>)logger eventSink:(id<FBSimulatorEventSink>)eventSink;
 
 @end

--- a/FBSimulatorControl/Framebuffer/FBSimulatorFramebuffer.m
+++ b/FBSimulatorControl/Framebuffer/FBSimulatorFramebuffer.m
@@ -69,8 +69,7 @@ static const NSInteger FBFramebufferLogFrameFrequency = 100;
 
   BOOL recordVideo = (launchConfiguration.options & FBSimulatorLaunchOptionsRecordVideo) == FBSimulatorLaunchOptionsRecordVideo;
   if (recordVideo) {
-    NSDecimalNumber *scaleNumber = [NSDecimalNumber decimalNumberWithString:launchConfiguration.scaleString];
-    [sinks addObject:[FBFramebufferVideo withDiagnostic:simulator.diagnostics.video scale:scaleNumber.floatValue logger:logger eventSink:simulator.eventSink]];
+    [sinks addObject:[FBFramebufferVideo withDiagnostic:simulator.diagnostics.video logger:logger eventSink:simulator.eventSink]];
   }
   [sinks addObject:[FBFramebufferImage withDiagnostic:simulator.diagnostics.screenshot eventSink:simulator.eventSink]];
 


### PR DESCRIPTION
The current way of creating the `SimDeviceFramebufferService` uses the `mainScreen` resolution. When recording a video, this is then thrown away and downscaled, which is a waste of resources. A 50% scale is a 4X reduction in the Framebuffer size and means less bytes are going to be copied around, leading to a lower resource utilisation on the host.