### PR TITLE
Monotonic Framebuffer Frame Times

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		AA4243041C5295FC008ABD80 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA4243031C5295FC008ABD80 /* CoreMedia.framework */; };
 		AA4243061C529644008ABD80 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA4243051C529644008ABD80 /* CoreVideo.framework */; };
 		AA5639551C060005009BAFAA /* FBSimulatorControl.h in Headers */ = {isa = PBXBuildFile; fileRef = AA5639541C05FFF5009BAFAA /* FBSimulatorControl.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA59E2861C85AA9400C17ED3 /* FBFramebufferFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = AA59E2841C85AA9400C17ED3 /* FBFramebufferFrame.h */; };
+		AA59E2871C85AA9400C17ED3 /* FBFramebufferFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = AA59E2851C85AA9400C17ED3 /* FBFramebufferFrame.m */; };
 		AA6424FE1C44E99B00AA9BFB /* FBSimulatorLaunchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA6424FD1C44E99B00AA9BFB /* FBSimulatorLaunchTests.m */; };
 		AA7490051C4E6CBA00F3BDBA /* FBSimulatorLaunchConfiguration+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7490041C4E6C7700F3BDBA /* FBSimulatorLaunchConfiguration+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA78DCDA1C5005D2006FAB41 /* FBSimulatorLaunchCtl.h in Headers */ = {isa = PBXBuildFile; fileRef = AA78DCD81C5005D2006FAB41 /* FBSimulatorLaunchCtl.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -833,6 +835,8 @@
 		AA4879941BAC74DD007F7D23 /* SimDeviceType-DVTAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SimDeviceType-DVTAdditions.h"; sourceTree = "<group>"; };
 		AA4879951BAC74DD007F7D23 /* SimRuntime-DVTAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SimRuntime-DVTAdditions.h"; sourceTree = "<group>"; };
 		AA5639541C05FFF5009BAFAA /* FBSimulatorControl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBSimulatorControl.h; sourceTree = "<group>"; };
+		AA59E2841C85AA9400C17ED3 /* FBFramebufferFrame.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBFramebufferFrame.h; sourceTree = "<group>"; };
+		AA59E2851C85AA9400C17ED3 /* FBFramebufferFrame.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBFramebufferFrame.m; sourceTree = "<group>"; };
 		AA6424FD1C44E99B00AA9BFB /* FBSimulatorLaunchTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorLaunchTests.m; sourceTree = "<group>"; };
 		AA7490041C4E6C7700F3BDBA /* FBSimulatorLaunchConfiguration+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FBSimulatorLaunchConfiguration+Private.h"; sourceTree = "<group>"; };
 		AA78DCD81C5005D2006FAB41 /* FBSimulatorLaunchCtl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorLaunchCtl.h; sourceTree = "<group>"; };
@@ -1049,6 +1053,8 @@
 				AA4242F71C52927F008ABD80 /* FBFramebufferDebugWindow.h */,
 				AA4242F81C529280008ABD80 /* FBFramebufferDebugWindow.m */,
 				AA4242DF1C528338008ABD80 /* FBFramebufferDelegate.h */,
+				AA59E2841C85AA9400C17ED3 /* FBFramebufferFrame.h */,
+				AA59E2851C85AA9400C17ED3 /* FBFramebufferFrame.m */,
 				AABD8DF71C592DBA008527CD /* FBFramebufferImage.h */,
 				AABD8DF81C592DBA008527CD /* FBFramebufferImage.m */,
 				AA4242FB1C529366008ABD80 /* FBFramebufferVideo.h */,
@@ -2007,6 +2013,7 @@
 				AA9517991C15F54600A89CAD /* FBDispatchSourceNotifier.h in Headers */,
 				AA95178E1C15F54600A89CAD /* FBSimulatorApplication.h in Headers */,
 				AA9517851C15F54600A89CAD /* FBSimulatorPool.h in Headers */,
+				AA59E2861C85AA9400C17ED3 /* FBFramebufferFrame.h in Headers */,
 				AA9517511C15F54600A89CAD /* FBSimulatorConfiguration.h in Headers */,
 				AA0771F11C1ADFA300E7FD52 /* FBBinaryParser.h in Headers */,
 				AAAB13281C74EC0300F3B083 /* FBSimulatorSet.h in Headers */,
@@ -2241,6 +2248,7 @@
 				AA95175F1C15F54600A89CAD /* FBSimulatorHistoryGenerator.m in Sources */,
 				AA95178A1C15F54600A89CAD /* FBSimulatorTerminationStrategy.m in Sources */,
 				AA2219921C3D868300371B01 /* FBProcessTerminationStrategy.m in Sources */,
+				AA59E2871C85AA9400C17ED3 /* FBFramebufferFrame.m in Sources */,
 				AA9517B51C15F54600A89CAD /* FBConcurrentCollectionOperations.m in Sources */,
 				AACA2C381C2976B100979C45 /* FBAddVideoPolyfill.m in Sources */,
 				AA9517921C15F54600A89CAD /* FBSimulatorHistory+Queries.m in Sources */,

--- a/FBSimulatorControl/Framebuffer/FBFramebufferCompositeDelegate.m
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferCompositeDelegate.m
@@ -36,17 +36,17 @@
 
 #pragma mark FBFramebufferDelegate Implementation
 
-- (void)framebufferDidUpdate:(FBSimulatorFramebuffer *)framebuffer withImage:(CGImageRef)image count:(NSUInteger)count size:(CGSize)size
+- (void)framebuffer:(FBSimulatorFramebuffer *)framebuffer didUpdate:(FBFramebufferFrame *)frame
 {
   for (id<FBFramebufferDelegate> delegate in self.delegates) {
-    [delegate framebufferDidUpdate:framebuffer withImage:image count:count size:size];
+    [delegate framebuffer:framebuffer didUpdate:frame];
   }
 }
 
-- (void)framebufferDidBecomeInvalid:(FBSimulatorFramebuffer *)framebuffer error:(NSError *)error teardownGroup:(dispatch_group_t)teardownGroup
+- (void)framebuffer:(FBSimulatorFramebuffer *)framebuffer didBecomeInvalidWithError:(NSError *)error teardownGroup:(dispatch_group_t)teardownGroup
 {
   for (id<FBFramebufferDelegate> delegate in self.delegates) {
-    [delegate framebufferDidBecomeInvalid:framebuffer error:error teardownGroup:teardownGroup];
+    [delegate framebuffer:framebuffer didBecomeInvalidWithError:error teardownGroup:teardownGroup];
   }
 }
 

--- a/FBSimulatorControl/Framebuffer/FBFramebufferDebugWindow.m
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferDebugWindow.m
@@ -11,6 +11,8 @@
 
 #import <Cocoa/Cocoa.h>
 
+#import "FBFramebufferFrame.h"
+
 @interface FBFramebufferDebugWindow () <NSApplicationDelegate>
 
 @property (nonatomic, copy, readonly) NSString *name;
@@ -50,17 +52,17 @@
 
 #pragma mark FBFramebufferDelegate Implementation
 
-- (void)framebufferDidUpdate:(FBSimulatorFramebuffer *)framebuffer withImage:(CGImageRef)image count:(NSUInteger)count size:(CGSize)size
+- (void)framebuffer:(FBSimulatorFramebuffer *)framebuffer didUpdate:(FBFramebufferFrame *)frame
 {
   dispatch_async(dispatch_get_main_queue(), ^{
-    if (count == 0) {
-      self.window = [self createWindowWithSize:size];
+    if (frame.count == 0) {
+      self.window = [self createWindowWithSize:frame.size];
     }
-    [self updateWindowWithImage:image];
+    [self updateWindowWithImage:frame.image];
   });
 }
 
-- (void)framebufferDidBecomeInvalid:(FBSimulatorFramebuffer *)framebuffer error:(NSError *)error teardownGroup:(dispatch_group_t)teardownGroup
+- (void)framebuffer:(FBSimulatorFramebuffer *)framebuffer didBecomeInvalidWithError:(NSError *)error teardownGroup:(dispatch_group_t)teardownGroup
 {
   [self teardownWindow];
 }

--- a/FBSimulatorControl/Framebuffer/FBFramebufferDelegate.h
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferDelegate.h
@@ -8,8 +8,10 @@
  */
 
 #import <CoreGraphics/CoreGraphics.h>
+#import <CoreMedia/CoreMedia.h>
 #import <Foundation/Foundation.h>
 
+@class FBFramebufferFrame;
 @class FBSimulatorFramebuffer;
 
 /**
@@ -20,12 +22,9 @@
 /**
  Called when an Image Frame is available.
 
- @param framebuffer the framebuffer that was updated.
- @param size the size of the image.
- @param count the frame count.
- @param image the updated image.
+ @param frame the updated frame.
  */
-- (void)framebufferDidUpdate:(FBSimulatorFramebuffer *)framebuffer withImage:(CGImageRef)image count:(NSUInteger)count size:(CGSize)size;
+- (void)framebuffer:(FBSimulatorFramebuffer *)framebuffer didUpdate:(FBFramebufferFrame *)frame;
 
 /**
  Called when the framebuffer is no longer valid, typically when the Simulator shuts down.
@@ -34,6 +33,6 @@
  @param error an error, if any occured in the teardown of the simulator.
  @param teardownGroup a dispatch_group to add asynchronous tasks to that should be performed in the teardown of the Framebuffer.
  */
-- (void)framebufferDidBecomeInvalid:(FBSimulatorFramebuffer *)framebuffer error:(NSError *)error teardownGroup:(dispatch_group_t)teardownGroup;
+- (void)framebuffer:(FBSimulatorFramebuffer *)framebuffer didBecomeInvalidWithError:(NSError *)error teardownGroup:(dispatch_group_t)teardownGroup;
 
 @end

--- a/FBSimulatorControl/Framebuffer/FBFramebufferFrame.h
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferFrame.h
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <CoreGraphics/CoreGraphics.h>
+#import <CoreMedia/CoreMedia.h>
+#import <CoreVideo/CoreVideo.h>
+#import <Foundation/Foundation.h>
+
+/**
+ An NSObject Container for a Framebuffer's Frame.
+ */
+@interface FBFramebufferFrame : NSObject
+
+@property (nonatomic, assign, readonly) CMTime time;
+@property (nonatomic, assign, readonly) CMTimebaseRef timebase;
+@property (nonatomic, assign, readonly) NSUInteger count;
+@property (nonatomic, assign, readonly) CGImageRef image;
+@property (nonatomic, assign, readonly) CGSize size;
+
+/**
+ The Designated Initializer.
+
+ @param time the time the frame was recieved.
+ @param timebase the timebase the time was constructed with.
+ @param image the image data of the frame.
+ @param count the ordering of the frame in all frames.
+ @param size the size of the image.
+ */
+- (instancetype)initWithTime:(CMTime)time timebase:(CMTimebaseRef)timebase image:(CGImageRef)image count:(NSUInteger)count size:(CGSize)size;
+
+/**
+ Constructs a new FBFramebufferFrame by translating it to a destination timebase and scale.
+
+ @param destinationTimebase the timebase to convert to.
+ @param timescale the Timescale to convert to.
+ @param roundingMethod the rounding method to use.
+ @return a new FBFramebufferFrame in the destination timebase.
+ */
+- (instancetype)convertToTimebase:(CMTimebaseRef)destinationTimebase timescale:(CMTimeScale)timescale roundingMethod:(CMTimeRoundingMethod)roundingMethod;
+
+@end

--- a/FBSimulatorControl/Framebuffer/FBFramebufferFrame.m
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferFrame.m
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBFramebufferFrame.h"
+
+@implementation FBFramebufferFrame
+
+- (instancetype)initWithTime:(CMTime)time timebase:(CMTimebaseRef)timebase image:(CGImageRef)image count:(NSUInteger)count size:(CGSize)size
+{
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  _time = time;
+  _timebase = (CMTimebaseRef) CFRetain(timebase);
+  _image = CGImageRetain(image);
+  _count = count;
+  _size = size;
+
+  return self;
+}
+
+- (void)dealloc
+{
+  CGImageRelease(_image);
+  CFRelease(_timebase);
+}
+
+- (instancetype)convertToTimebase:(CMTimebaseRef)destinationTimebase timescale:(CMTimeScale)timescale roundingMethod:(CMTimeRoundingMethod)roundingMethod
+{
+  CMTime destinationTime = CMSyncConvertTime(self.time, self.timebase, destinationTimebase);
+  destinationTime = CMTimeConvertScale(destinationTime, timescale, roundingMethod);
+  return [[FBFramebufferFrame alloc] initWithTime:destinationTime timebase:destinationTimebase image:self.image count:self.count size:self.size];
+}
+
+- (NSString *)description
+{
+  return [NSString stringWithFormat:@"Time %f | Count %lu", CMTimeGetSeconds(self.time), self.count];
+}
+
+@end


### PR DESCRIPTION
Instead of constructing the current time of a frame at the `FBFramebufferVideo`'s `mediaQueue`, we should construct it at the time that the `FBSimulatorFramebuffer` gets the frames on it's own queue, with increased precision.

This should give a more accurate time than on the `mediaQueue`, both in terms of resolution of the time (by using a timescale that matches the system clock) and because `CMTime` values are created from the timebase when frames are pushed to the `FBSimulatorFramebuffer`'s private queue. Time conversions to a timescale more suitable for video encoding can then occur in `FBFramebufferVideo`.

Since there are a boatload of values passed around on the `FBSimulatorFramebufferDelegate` methods the params are now put inside a `FBFramebufferFrame` object. This also aids with conversions between timebases and rounding modes.