### PR TITLE
Add Automatic and Manual Video Recording

### DIFF
--- a/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration.h
@@ -17,7 +17,7 @@
  */
 typedef NS_OPTIONS(NSUInteger, FBSimulatorLaunchOptions) {
   FBSimulatorLaunchOptionsEnableDirectLaunch = 1 << 0, /** Launches Simulators directly with a Framebuffer instead of with Simulator.app */
-  FBSimulatorLaunchOptionsRecordVideo = 1 << 1, /** Records the Framebuffer to a video */
+  FBSimulatorLaunchOptionsRecordVideo = 1 << 1, /** Automatically starts the recording of video when the simulator is launched. */
   FBSimulatorLaunchOptionsShowDebugWindow = 1 << 2, /** Relays the Simulator Framebuffer to a window */
   FBSimulatorLaunchOptionsUseNSWorkspace = 1 << 4, /** Uses -[NSWorkspace launchApplicationAtURL:options:configuration::error:] to launch Simulator.app */
 };

--- a/FBSimulatorControl/Framebuffer/FBFramebufferFrame.h
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferFrame.h
@@ -25,7 +25,7 @@
 
 /**
  The Designated Initializer.
-
+ 
  @param time the time the frame was recieved.
  @param timebase the timebase the time was constructed with.
  @param image the image data of the frame.

--- a/FBSimulatorControl/Framebuffer/FBFramebufferVideo.h
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferVideo.h
@@ -27,10 +27,25 @@
  Creates a new FBFramebufferVideo instance.
 
  @param diagnostic the log to base the video file from.
+ @param autorecord whether the the instance shoud start recording when it recieves it's first frame.
  @param logger the logger object to log events to, may be nil.
  @param eventSink an event sink to report video output to.
  @return a new FBFramebufferVideo instance.
  */
-+ (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic logger:(id<FBSimulatorLogger>)logger eventSink:(id<FBSimulatorEventSink>)eventSink;
++ (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic shouldAutorecord:(BOOL)autorecord logger:(id<FBSimulatorLogger>)logger eventSink:(id<FBSimulatorEventSink>)eventSink;
+
+/**
+ Starts Recording Video.
+ If the video is already recording, this call will do nothing.
+ Is asynchronous with the caller so the Event Sink will be notified when the video starts recording.
+ */
+- (void)startRecording;
+
+/**
+ Stops Recording Video.
+ If the video is not recording, this call will do nothing.
+ Is asynchronous with the caller so the Event Sink will be notified when the video starts recording.
+ */
+- (void)stopRecording;
 
 @end

--- a/FBSimulatorControl/Framebuffer/FBFramebufferVideo.m
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferVideo.m
@@ -22,8 +22,9 @@
 
 typedef NS_ENUM(NSInteger, FBFramebufferVideoState) {
   FBFramebufferVideoStateNotStarted = 0,
-  FBFramebufferVideoStateRunning = 1,
-  FBFramebufferVideoStateTerminating = 2,
+  FBFramebufferVideoStateWaitingForFirstFrame = 1,
+  FBFramebufferVideoStateRunning = 2,
+  FBFramebufferVideoStateTerminating = 3,
 };
 
 static const OSType FBFramebufferPixelFormat = kCVPixelFormatType_32ARGB;
@@ -54,13 +55,13 @@ static const CMTimeScale FBFramebufferVideoRoundingMode = kCMTimeRoundingMethod_
 
 #pragma mark Initializers
 
-+ (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic logger:(id<FBSimulatorLogger>)logger eventSink:(id<FBSimulatorEventSink>)eventSink
++ (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic shouldAutorecord:(BOOL)autorecord logger:(id<FBSimulatorLogger>)logger eventSink:(id<FBSimulatorEventSink>)eventSink
 {
   dispatch_queue_t queue = dispatch_queue_create("com.facebook.FBSimulatorControl.media", DISPATCH_QUEUE_SERIAL);
-  return [[self alloc] initWithDiagnostic:diagnostic onQueue:queue logger:[logger onQueue:queue] eventSink:eventSink];
+  return [[self alloc] initWithDiagnostic:diagnostic shouldAutorecord:autorecord onQueue:queue logger:[logger onQueue:queue] eventSink:eventSink];
 }
 
-- (instancetype)initWithDiagnostic:(FBDiagnostic *)diagnostic onQueue:(dispatch_queue_t)queue logger:(id<FBSimulatorLogger>)logger eventSink:(id<FBSimulatorEventSink>)eventSink
+- (instancetype)initWithDiagnostic:(FBDiagnostic *)diagnostic shouldAutorecord:(BOOL)autorecord onQueue:(dispatch_queue_t)queue logger:(id<FBSimulatorLogger>)logger eventSink:(id<FBSimulatorEventSink>)eventSink
 {
   self = [super init];
   if (!self) {
@@ -73,10 +74,44 @@ static const CMTimeScale FBFramebufferVideoRoundingMode = kCMTimeRoundingMethod_
 
   _mediaQueue = queue;
   _frameQueue = [FBCapacityQueue withCapacity:20];
-  _state = FBFramebufferVideoStateNotStarted;
+  _state = autorecord ? FBFramebufferVideoStateWaitingForFirstFrame : FBFramebufferVideoStateNotStarted;
   _timebase = NULL;
 
   return self;
+}
+
+#pragma mark Public Methods
+
+- (void)startRecording
+{
+  dispatch_async(self.mediaQueue, ^{
+    // Must be NotStarted to flick the First Frame wait switch.
+    if (self.state != FBFramebufferVideoStateNotStarted) {
+      [self.logger.info logFormat:@"Cannot start recording with state '%@'", [FBFramebufferVideo stateStringForState:self.state]];
+      return;
+    }
+    [self.logger.debug log:@"Manually starting recording"];
+    self.state = FBFramebufferVideoStateWaitingForFirstFrame;
+  });
+}
+
+- (void)stopRecording
+{
+  dispatch_group_t group = dispatch_group_create();
+  dispatch_async(self.mediaQueue, ^{
+    // No video has been recorded, so the recorder can just switch off.
+    if (self.state == FBFramebufferVideoStateWaitingForFirstFrame) {
+      self.state = FBFramebufferVideoStateNotStarted;
+      return;
+    }
+    // If not running, this is an invalid state to call from.
+    if (self.state != FBFramebufferVideoStateRunning) {
+      [self.logger.info logFormat:@"Cannot stop recording with state '%@'", [FBFramebufferVideo stateStringForState:self.state]];
+      return;
+    }
+    [self.logger.debug log:@"Manually stopping recording"];
+    [self teardownWriterWithGroup:group];
+  });
 }
 
 #pragma mark FBFramebufferDelegate Implementation
@@ -84,14 +119,7 @@ static const CMTimeScale FBFramebufferVideoRoundingMode = kCMTimeRoundingMethod_
 - (void)framebuffer:(FBSimulatorFramebuffer *)framebuffer didUpdate:(FBFramebufferFrame *)frame
 {
   dispatch_async(self.mediaQueue, ^{
-    // First frame means that the Video Session should be started.
-    // The Frame will be enqueued with the time of the session start time.
-    if (self.state == FBFramebufferVideoStateNotStarted) {
-      [self startRecordingWithFrame:frame error:nil];
-      return;
-    }
-
-    // Push the image at the current time.
+    // Push the image, converting to the new timebase.
     [self pushFrame:frame timebaseConversion:YES];
   });
 }
@@ -100,14 +128,6 @@ static const CMTimeScale FBFramebufferVideoRoundingMode = kCMTimeRoundingMethod_
 {
   dispatch_group_enter(teardownGroup);
   dispatch_barrier_async(self.mediaQueue, ^{
-    if (self.lastFrame) {
-      // Construct a time at the current timebase's time and push it to the queue.
-      // Timebase conversion does not need to apply.
-      CMTime time = CMTimebaseGetTime(self.timebase);
-      FBFramebufferFrame *finalFrame = [[FBFramebufferFrame alloc] initWithTime:time timebase:self.timebase image:self.lastFrame.image count:(self.lastFrame.count + 1) size:self.lastFrame.size];
-      [self.logger.info logFormat:@"Pushing last frame with new timing (%@) as this is the final frame", finalFrame];
-      [self pushFrame:finalFrame timebaseConversion:NO];
-    }
     [self teardownWriterWithGroup:teardownGroup];
     dispatch_group_leave(teardownGroup);
   });
@@ -133,19 +153,54 @@ static const CMTimeScale FBFramebufferVideoRoundingMode = kCMTimeRoundingMethod_
 
 - (void)pushFrame:(FBFramebufferFrame *)frame timebaseConversion:(BOOL)timebaseConversion
 {
-  frame = timebaseConversion ? [frame convertToTimebase:self.timebase timescale:FBFramebufferVideoTimescale roundingMethod:FBFramebufferVideoRoundingMode] : frame;
-  FBFramebufferFrame *evictedFrame = [self.frameQueue push:frame];
-  if (evictedFrame) {
-    [self.logger.debug logFormat:@"Evicted Frame (%@), frame dropped", evictedFrame];
+  // Discard frames when there's no reason to record them
+  if (self.state == FBFramebufferVideoStateNotStarted || self.state == FBFramebufferVideoStateTerminating) {
+    self.lastFrame = nil;
+    [self.frameQueue popAll];
+    return;
   }
+  // When waiting for first frame, start video recording.
+  if (self.state == FBFramebufferVideoStateWaitingForFirstFrame) {
+    self.lastFrame = nil;
+    [self.frameQueue popAll];
+    [self startRecordingWithFrame:frame error:nil];
+    return;
+  }
+
+  // Convert the timebase if required, then push the frame to the queue and drain.
+  frame = timebaseConversion ? [frame convertToTimebase:self.timebase timescale:FBFramebufferVideoTimescale roundingMethod:FBFramebufferVideoRoundingMode] : frame;
+  [self.frameQueue push:frame];
   [self drainQueue];
+}
+
+- (FBFramebufferFrame *)popFrame
+{
+  FBFramebufferFrame *frame = [self.frameQueue pop];
+  if (!frame) {
+    return nil;
+  }
+  // It's important that a number of conditions are met to ensure that this call is reliable as possible.
+  // Setting -[AVAssetWriter movieFragmentInterval] usually exacerbates any problems in the input.
+  // Much of the information here comes from the AVFoundation guru @rfistman.
+  //
+  // 1) The time used in -[AVAssetWriter startSessionAtSourceTime:] should have the same value as the first call to -[AVAssetWriterInputPixelBufferAdaptor appendPixelBuffer:withPresentationTime:]
+  // 2) The ordering of frames should always mean that each frame is sequential in it's presentation time. kCMTimeRoundingMethod_Default can result in strange values from rounding so kCMTimeRoundingMethod_RoundTowardNegativeInfinity is used.
+  //
+  // "The operation couldn't be completed. (OSStatus error -12633.)" is 'InvalidTimestamp': http://stackoverflow.com/a/23252239
+  // "An unknown error occurred (-16341)" is 'kMediaSampleTimingGeneratorError_InvalidTimeStamp': @rfistman
+  if (self.lastFrame && CMTimeCompare(frame.time, self.lastFrame.time) != 1) {
+    [self.logger.error logFormat:@"Dropping Frame (%@) as it's timestamp is not greater than a previous frame (%@)", frame, self.lastFrame];
+    return nil;
+  }
+  self.lastFrame = frame;
+  return frame;
 }
 
 - (void)drainQueue
 {
   NSInteger drainCount = 0;
   while (self.adaptor.assetWriterInput.readyForMoreMediaData) {
-    FBFramebufferFrame *frame = [self.frameQueue pop];
+    FBFramebufferFrame *frame = [self popFrame];
     if (!frame) {
       return;
     }
@@ -161,26 +216,11 @@ static const CMTimeScale FBFramebufferVideoRoundingMode = kCMTimeRoundingMethod_
       continue;
     }
 
-    // It's important that a number of conditions are met to ensure that this call is reliable as possible.
-    // Setting -[AVAssetWriter movieFragmentInterval] usually exacerbates any problems in the input.
-    // Much of the information here comes from the AVFoundation guru @rfistman.
-    //
-    // 1) The time used in -[AVAssetWriter startSessionAtSourceTime:] should have the same value as the first call to -[AVAssetWriterInputPixelBufferAdaptor appendPixelBuffer:withPresentationTime:]
-    // 2) The ordering of frames should always mean that each frame is sequential in it's presentation time. kCMTimeRoundingMethod_Default can result in strange values from rounding so kCMTimeRoundingMethod_RoundTowardNegativeInfinity is used.
-    //
-    // "The operation couldn't be completed. (OSStatus error -12633.)" is 'InvalidTimestamp': http://stackoverflow.com/a/23252239
-    // "An unknown error occurred (-16341)" is 'kMediaSampleTimingGeneratorError_InvalidTimeStamp': @rfistman
-
-    if (self.lastFrame && CMTimeCompare(frame.time, self.lastFrame.time) != 1) {
-      [self.logger.error logFormat:@"Dropping Frame (%@) as it's timestamp is not greater than a previous frame (%@)", frame, self.lastFrame];
-    } else if (![self.adaptor appendPixelBuffer:pixelBuffer withPresentationTime:frame.time]) {
+    // Append the PixelBuffer to the Adaptor.
+    if (![self.adaptor appendPixelBuffer:pixelBuffer withPresentationTime:frame.time]) {
       [self.logger.error logFormat:@"Failed to append pixel buffer of frame (%@) with error %@", frame, self.writer.error];
     }
-    self.lastFrame = frame;
     CVPixelBufferRelease(pixelBuffer);
-  }
-  if (drainCount == 0 && self.frameQueue.count > 0) {
-    [self.logger.debug logFormat:@"Failed to drain any frames with a queue of length %lu", drainCount];
   }
 }
 
@@ -188,7 +228,14 @@ static const CMTimeScale FBFramebufferVideoRoundingMode = kCMTimeRoundingMethod_
 
 - (BOOL)startRecordingWithFrame:(FBFramebufferFrame *)frame error:(NSError **)error
 {
-  // Create a Timebase based off frame's timebase, with a new base time.
+  // Bail out if we're not waiting to record.
+  if (self.state != FBFramebufferVideoStateWaitingForFirstFrame) {
+    return [[FBSimulatorError
+      describeFormat:@"Cannot start recording from state '%@'", [FBFramebufferVideo stateStringForState:self.state]]
+      failBool:error];
+  }
+
+  // Create a Timebase to construct the time of the first frame.
   CMTimebaseRef timebase = NULL;
   CMTimebaseCreateWithMasterTimebase(
     kCFAllocatorDefault,
@@ -206,14 +253,15 @@ static const CMTimeScale FBFramebufferVideoRoundingMode = kCMTimeRoundingMethod_
   if (![self createAssetWriterAtPath:path fromFrame:frame error:error]) {
     return NO;
   }
+  // Mark as running.
+  self.state = FBFramebufferVideoStateRunning;
 
-  // Enqueue the first frame
+  // Enqueue the first frame, converting it to the timebase that has just been created.
   [self pushFrame:frame timebaseConversion:YES];
 
   // Report the availability of the video
   [self.eventSink diagnosticAvailable:[[logBuilder updatePath:path] build]];
 
-  self.state = FBFramebufferVideoStateRunning;
   return YES;
 }
 
@@ -289,14 +337,33 @@ static const CMTimeScale FBFramebufferVideoRoundingMode = kCMTimeRoundingMethod_
 
 - (void)teardownWriterWithGroup:(dispatch_group_t)teardownGroup
 {
+  // Invalid to teardown when not running.
   if (self.state != FBFramebufferVideoStateRunning) {
+    [self.logger.info logFormat:@"Cannot stop recording with state '%@'", [FBFramebufferVideo stateStringForState:self.state]];
     return;
   }
+
+  // Push last frame if one exists.
+  if (self.lastFrame) {
+    // Construct a time at the current timebase's time and push it to the queue.
+    // Timebase conversion does not need to apply.
+    CMTime time = CMTimebaseGetTimeWithTimeScale(self.timebase, FBFramebufferVideoTimescale, FBFramebufferVideoRoundingMode);
+    FBFramebufferFrame *finalFrame = [[FBFramebufferFrame alloc] initWithTime:time timebase:self.timebase image:self.lastFrame.image count:(self.lastFrame.count + 1) size:self.lastFrame.size];
+    [self.logger.info logFormat:@"Pushing last frame (%@) with new timing (%@) as this is the final frame", self.lastFrame, finalFrame];
+    [self pushFrame:finalFrame timebaseConversion:NO];
+  }
+
+  // Update state.
   self.state = FBFramebufferVideoStateTerminating;
   [self.logger.info logFormat:@"Marking video at '%@ as finished", self.writer.outputURL];
+
+  // Free Resources
+  CFRelease(self.timebase);
+  self.timebase = nil;
   [self.adaptor.assetWriterInput markAsFinished];
   [self.writer removeObserver:self forKeyPath:@"readyForMoreMediaData"];
 
+  // Finish writing, making sure to update state on the media queue.
   [self.logger.info logFormat:@"Finishing Writing '%@'", self.writer.outputURL];
   dispatch_group_enter(teardownGroup);
   [self.writer finishWritingWithCompletionHandler:^{
@@ -390,6 +457,24 @@ static const CMTimeScale FBFramebufferVideoRoundingMode = kCMTimeRoundingMethod_
   CVPixelBufferUnlockBaseAddress(pixelBuffer, 0);
 
   return pixelBuffer;
+}
+
+#pragma mark String Formatting
+
++ (NSString *)stateStringForState:(FBFramebufferVideoState)state
+{
+  switch (state) {
+    case FBFramebufferVideoStateNotStarted:
+      return @"Not Started";
+    case FBFramebufferVideoStateWaitingForFirstFrame:
+      return @"Waiting for First Frame";
+    case FBFramebufferVideoStateRunning:
+      return @"Running";
+    case FBFramebufferVideoStateTerminating:
+      return @"Terminating";
+    default:
+      return @"Unknown";
+  }
 }
 
 @end

--- a/FBSimulatorControl/Framebuffer/FBSimulatorFramebuffer.h
+++ b/FBSimulatorControl/Framebuffer/FBSimulatorFramebuffer.h
@@ -11,6 +11,7 @@
 
 #import <FBSimulatorControl/FBJSONSerializationDescribeable.h>
 
+@class FBFramebufferVideo;
 @class FBSimulator;
 @class FBSimulatorLaunchConfiguration;
 @class SimDeviceFramebufferService;
@@ -51,5 +52,10 @@
  @param teardownGroup the dispatch_group to append asynchronous operations to.
  */
 - (void)stopListeningWithTeardownGroup:(dispatch_group_t)teardownGroup;
+
+/**
+ The FBFramebufferVideo instance owned by the receiver.
+ */
+@property (nonatomic, strong, readonly) FBFramebufferVideo *video;
 
 @end

--- a/FBSimulatorControl/Utility/FBCapacityQueue.h
+++ b/FBSimulatorControl/Utility/FBCapacityQueue.h
@@ -39,6 +39,13 @@
 - (id)pop;
 
 /**
+ Pops all items from the queue.
+
+ @return an Array of all the items popped from the queue.
+ */
+- (NSArray *)popAll;
+
+/**
  The count of the queue.
 
  @return the count of items in the queue

--- a/FBSimulatorControl/Utility/FBCapacityQueue.m
+++ b/FBSimulatorControl/Utility/FBCapacityQueue.m
@@ -63,6 +63,13 @@
   return item;
 }
 
+- (NSArray *)popAll
+{
+  NSArray *all = self.array.copy;
+  [self.array removeAllObjects];
+  return all;
+}
+
 - (NSUInteger)count
 {
   return self.array.count;


### PR DESCRIPTION
Prior to this PR, it starting and stopping of video recording was completely automatic and would be enabled/disabled per Simulator boot. This PR adds an start/stop recording API and an optional launch flag for enabling the automatic recording of video on Simulator boot.