### PR TITLE
Provisional IPC Support

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -52,6 +52,12 @@
 		AA791BA91C63668C00AE49EB /* SimulatorBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = AA791BA61C63668C00AE49EB /* SimulatorBridge.h */; };
 		AA79A1CE1C7766ED00D5C685 /* FBSimulatorSet+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = AA79A1CD1C77666000D5C685 /* FBSimulatorSet+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA819DB71B9FB40D002F58CA /* FBSimulatorControl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD70E291A4B50E500000001 /* FBSimulatorControl.framework */; };
+		AA8C49101C7D153E00F9C996 /* FBIPCServer.h in Headers */ = {isa = PBXBuildFile; fileRef = AA8C490E1C7D153E00F9C996 /* FBIPCServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA8C49111C7D153E00F9C996 /* FBIPCServer.m in Sources */ = {isa = PBXBuildFile; fileRef = AA8C490F1C7D153E00F9C996 /* FBIPCServer.m */; };
+		AA8C49151C7D167500F9C996 /* FBIPCClient.h in Headers */ = {isa = PBXBuildFile; fileRef = AA8C49131C7D167500F9C996 /* FBIPCClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA8C49161C7D167500F9C996 /* FBIPCClient.m in Sources */ = {isa = PBXBuildFile; fileRef = AA8C49141C7D167500F9C996 /* FBIPCClient.m */; };
+		AA8C49191C7D168D00F9C996 /* FBIPCManager.h in Headers */ = {isa = PBXBuildFile; fileRef = AA8C49171C7D168D00F9C996 /* FBIPCManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA8C491A1C7D168D00F9C996 /* FBIPCManager.m in Sources */ = {isa = PBXBuildFile; fileRef = AA8C49181C7D168D00F9C996 /* FBIPCManager.m */; };
 		AA9517471C15F54600A89CAD /* FBProcessLaunchConfiguration+Helpers.h in Headers */ = {isa = PBXBuildFile; fileRef = AA9516C21C15F54600A89CAD /* FBProcessLaunchConfiguration+Helpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA9517481C15F54600A89CAD /* FBProcessLaunchConfiguration+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = AA9516C31C15F54600A89CAD /* FBProcessLaunchConfiguration+Helpers.m */; };
 		AA9517491C15F54600A89CAD /* FBProcessLaunchConfiguration+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = AA9516C41C15F54600A89CAD /* FBProcessLaunchConfiguration+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -849,6 +855,12 @@
 		AA79A1CD1C77666000D5C685 /* FBSimulatorSet+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FBSimulatorSet+Private.h"; sourceTree = "<group>"; };
 		AA819DB21B9FB40D002F58CA /* FBSimulatorControlTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FBSimulatorControlTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA819E0B1B9FB427002F58CA /* FBSimulatorControlTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "FBSimulatorControlTests-Info.plist"; sourceTree = "<group>"; };
+		AA8C490E1C7D153E00F9C996 /* FBIPCServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBIPCServer.h; sourceTree = "<group>"; };
+		AA8C490F1C7D153E00F9C996 /* FBIPCServer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBIPCServer.m; sourceTree = "<group>"; };
+		AA8C49131C7D167500F9C996 /* FBIPCClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBIPCClient.h; sourceTree = "<group>"; };
+		AA8C49141C7D167500F9C996 /* FBIPCClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBIPCClient.m; sourceTree = "<group>"; };
+		AA8C49171C7D168D00F9C996 /* FBIPCManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBIPCManager.h; sourceTree = "<group>"; };
+		AA8C49181C7D168D00F9C996 /* FBIPCManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBIPCManager.m; sourceTree = "<group>"; };
 		AA9516C21C15F54600A89CAD /* FBProcessLaunchConfiguration+Helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FBProcessLaunchConfiguration+Helpers.h"; sourceTree = "<group>"; };
 		AA9516C31C15F54600A89CAD /* FBProcessLaunchConfiguration+Helpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "FBProcessLaunchConfiguration+Helpers.m"; sourceTree = "<group>"; };
 		AA9516C41C15F54600A89CAD /* FBProcessLaunchConfiguration+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FBProcessLaunchConfiguration+Private.h"; sourceTree = "<group>"; };
@@ -1715,10 +1727,11 @@
 				AA4876491BAC7399007F7D23 /* FBSimulatorControl-Info.plist */,
 				AAA46E431C0CB92A009D6452 /* FBSimulatorControl.xcconfig */,
 				AA9516C11C15F54600A89CAD /* Configuration */,
+				AA9516F31C15F54600A89CAD /* Diagnostics */,
 				AA9516D21C15F54600A89CAD /* Events */,
 				AA4242D81C528338008ABD80 /* Framebuffer */,
 				AA9516DE1C15F54600A89CAD /* Interactions */,
-				AA9516F31C15F54600A89CAD /* Diagnostics */,
+				AA8C490D1C7CF3A000F9C996 /* IPC */,
 				AA9516FA1C15F54600A89CAD /* Management */,
 				AA95170A1C15F54600A89CAD /* Model */,
 				AA9517171C15F54600A89CAD /* Notifiers */,
@@ -1727,6 +1740,19 @@
 				AA9517391C15F54600A89CAD /* Utility */,
 			);
 			path = FBSimulatorControl;
+			sourceTree = "<group>";
+		};
+		AA8C490D1C7CF3A000F9C996 /* IPC */ = {
+			isa = PBXGroup;
+			children = (
+				AA8C49131C7D167500F9C996 /* FBIPCClient.h */,
+				AA8C49141C7D167500F9C996 /* FBIPCClient.m */,
+				AA8C49171C7D168D00F9C996 /* FBIPCManager.h */,
+				AA8C49181C7D168D00F9C996 /* FBIPCManager.m */,
+				AA8C490E1C7D153E00F9C996 /* FBIPCServer.h */,
+				AA8C490F1C7D153E00F9C996 /* FBIPCServer.m */,
+			);
+			path = IPC;
 			sourceTree = "<group>";
 		};
 		AA8DFB0B1BAC76B60076A6C2 /* Utilities */ = {
@@ -2007,6 +2033,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AA8C49151C7D167500F9C996 /* FBIPCClient.h in Headers */,
 				AA9517971C15F54600A89CAD /* FBCoreSimulatorNotifier.h in Headers */,
 				AA9517591C15F54600A89CAD /* FBSimulatorEventRelay.h in Headers */,
 				AA95176B1C15F54600A89CAD /* FBSimulatorInteraction+Diagnostics.h in Headers */,
@@ -2040,6 +2067,7 @@
 				AA9517B41C15F54600A89CAD /* FBConcurrentCollectionOperations.h in Headers */,
 				AA95176D1C15F54600A89CAD /* FBSimulatorInteraction+Private.h in Headers */,
 				AA791BA81C63668C00AE49EB /* SimulatorBridge-Protocol.h in Headers */,
+				AA8C49191C7D168D00F9C996 /* FBIPCManager.h in Headers */,
 				AAF8DA6D1C1AFFF0003B519E /* FBProcessQuery+Helpers.h in Headers */,
 				AA9517931C15F54600A89CAD /* FBSimulatorHistory.h in Headers */,
 				AA9517741C15F54600A89CAD /* FBSimulatorInteraction.h in Headers */,
@@ -2058,6 +2086,7 @@
 				AAD51EA31C3AEFEA00A763D0 /* FBSimulatorLaunchConfiguration+Helpers.h in Headers */,
 				AA9517A71C15F54600A89CAD /* FBTaskExecutor+Convenience.h in Headers */,
 				AA791BA71C63668C00AE49EB /* CDStructures.h in Headers */,
+				AA8C49101C7D153E00F9C996 /* FBIPCServer.h in Headers */,
 				AA791BA11C6364F500AE49EB /* FBSimulatorBridge.h in Headers */,
 				AA95175B1C15F54600A89CAD /* FBSimulatorEventSink.h in Headers */,
 				AA95179B1C15F54600A89CAD /* FBProcessQuery+Simulators.h in Headers */,
@@ -2213,6 +2242,7 @@
 				AA9517781C15F54600A89CAD /* FBSimulatorDiagnostics.m in Sources */,
 				AABD8DFA1C592DBA008527CD /* FBFramebufferImage.m in Sources */,
 				AA95177D1C15F54600A89CAD /* FBSimulator+Helpers.m in Sources */,
+				AA8C491A1C7D168D00F9C996 /* FBIPCManager.m in Sources */,
 				AA4243021C529393008ABD80 /* FBCapacityQueue.m in Sources */,
 				AA9517B91C15F54600A89CAD /* FBSimulatorError.m in Sources */,
 				AAD51EA01C3ADECA00A763D0 /* FBSimulatorLaunchConfiguration.m in Sources */,
@@ -2222,6 +2252,7 @@
 				AA95177B1C15F54600A89CAD /* FBDiagnostic.m in Sources */,
 				AA95176C1C15F54600A89CAD /* FBSimulatorInteraction+Diagnostics.m in Sources */,
 				AA95179E1C15F54600A89CAD /* FBProcessQuery.m in Sources */,
+				AA8C49161C7D167500F9C996 /* FBIPCClient.m in Sources */,
 				AA9517981C15F54600A89CAD /* FBCoreSimulatorNotifier.m in Sources */,
 				AA4242FE1C529366008ABD80 /* FBFramebufferVideo.m in Sources */,
 				AA9517BD1C15F54600A89CAD /* NSRunLoop+SimulatorControlAdditions.m in Sources */,
@@ -2234,6 +2265,7 @@
 				AA9517A61C15F54600A89CAD /* FBTask.m in Sources */,
 				AA9517481C15F54600A89CAD /* FBProcessLaunchConfiguration+Helpers.m in Sources */,
 				AAB207C11C2099A9007C7908 /* FBSimulatorLoggingEventSink.m in Sources */,
+				AA8C49111C7D153E00F9C996 /* FBIPCServer.m in Sources */,
 				AA9517801C15F54600A89CAD /* FBSimulator.m in Sources */,
 				AA9517711C15F54600A89CAD /* FBSimulatorInteraction+Upload.m in Sources */,
 				AA9517A81C15F54600A89CAD /* FBTaskExecutor+Convenience.m in Sources */,

--- a/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration.h
@@ -17,7 +17,7 @@
  */
 typedef NS_OPTIONS(NSUInteger, FBSimulatorLaunchOptions) {
   FBSimulatorLaunchOptionsEnableDirectLaunch = 1 << 0, /** Launches Simulators directly with a Framebuffer instead of with Simulator.app */
-  FBSimulatorLaunchOptionsRecordVideo = 1 << 1, /** Records the Framebuffer to a video */
+  FBSimulatorLaunchOptionsRecordVideo = 1 << 1, /** Automatically starts the recording of video when the simulator is launched. */
   FBSimulatorLaunchOptionsShowDebugWindow = 1 << 2, /** Relays the Simulator Framebuffer to a window */
   FBSimulatorLaunchOptionsUseNSWorkspace = 1 << 4, /** Uses -[NSWorkspace launchApplicationAtURL:options:configuration::error:] to launch Simulator.app */
 };

--- a/FBSimulatorControl/FBSimulatorControl.h
+++ b/FBSimulatorControl/FBSimulatorControl.h
@@ -25,6 +25,9 @@
 #import <FBSimulatorControl/FBFramebufferDelegate.h>
 #import <FBSimulatorControl/FBFramebufferVideo.h>
 #import <FBSimulatorControl/FBInteraction.h>
+#import <FBSimulatorControl/FBIPCClient.h>
+#import <FBSimulatorControl/FBIPCManager.h>
+#import <FBSimulatorControl/FBIPCServer.h>
 #import <FBSimulatorControl/FBJSONSerializationDescribeable.h>
 #import <FBSimulatorControl/FBMutableSimulatorEventSink.h>
 #import <FBSimulatorControl/FBProcessInfo.h>

--- a/FBSimulatorControl/Framebuffer/FBFramebufferVideo.h
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferVideo.h
@@ -27,10 +27,25 @@
  Creates a new FBFramebufferVideo instance.
 
  @param diagnostic the log to base the video file from.
+ @param autorecord whether the the instance shoud start recording when it recieves it's first frame.
  @param logger the logger object to log events to, may be nil.
  @param eventSink an event sink to report video output to.
  @return a new FBFramebufferVideo instance.
  */
-+ (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic logger:(id<FBSimulatorLogger>)logger eventSink:(id<FBSimulatorEventSink>)eventSink;
++ (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic shouldAutorecord:(BOOL)autorecord logger:(id<FBSimulatorLogger>)logger eventSink:(id<FBSimulatorEventSink>)eventSink;
+
+/**
+ Starts Recording Video.
+ If the video is already recording, this call will do nothing.
+ Is asynchronous with the caller so the Event Sink will be notified when the video starts recording.
+ */
+- (void)startRecording;
+
+/**
+ Stops Recording Video.
+ If the video is not recording, this call will do nothing.
+ Is asynchronous with the caller so the Event Sink will be notified when the video starts recording.
+ */
+- (void)stopRecording;
 
 @end

--- a/FBSimulatorControl/Framebuffer/FBFramebufferVideo.m
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferVideo.m
@@ -22,8 +22,9 @@
 
 typedef NS_ENUM(NSInteger, FBFramebufferVideoState) {
   FBFramebufferVideoStateNotStarted = 0,
-  FBFramebufferVideoStateRunning = 1,
-  FBFramebufferVideoStateTerminating = 2,
+  FBFramebufferVideoStateWaitingForFirstFrame = 1,
+  FBFramebufferVideoStateRunning = 2,
+  FBFramebufferVideoStateTerminating = 3,
 };
 
 static const OSType FBFramebufferPixelFormat = kCVPixelFormatType_32ARGB;
@@ -54,13 +55,13 @@ static const CMTimeScale FBFramebufferVideoRoundingMode = kCMTimeRoundingMethod_
 
 #pragma mark Initializers
 
-+ (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic logger:(id<FBSimulatorLogger>)logger eventSink:(id<FBSimulatorEventSink>)eventSink
++ (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic shouldAutorecord:(BOOL)autorecord logger:(id<FBSimulatorLogger>)logger eventSink:(id<FBSimulatorEventSink>)eventSink
 {
   dispatch_queue_t queue = dispatch_queue_create("com.facebook.FBSimulatorControl.media", DISPATCH_QUEUE_SERIAL);
-  return [[self alloc] initWithDiagnostic:diagnostic onQueue:queue logger:[logger onQueue:queue] eventSink:eventSink];
+  return [[self alloc] initWithDiagnostic:diagnostic shouldAutorecord:autorecord onQueue:queue logger:[logger onQueue:queue] eventSink:eventSink];
 }
 
-- (instancetype)initWithDiagnostic:(FBDiagnostic *)diagnostic onQueue:(dispatch_queue_t)queue logger:(id<FBSimulatorLogger>)logger eventSink:(id<FBSimulatorEventSink>)eventSink
+- (instancetype)initWithDiagnostic:(FBDiagnostic *)diagnostic shouldAutorecord:(BOOL)autorecord onQueue:(dispatch_queue_t)queue logger:(id<FBSimulatorLogger>)logger eventSink:(id<FBSimulatorEventSink>)eventSink
 {
   self = [super init];
   if (!self) {
@@ -73,10 +74,44 @@ static const CMTimeScale FBFramebufferVideoRoundingMode = kCMTimeRoundingMethod_
 
   _mediaQueue = queue;
   _frameQueue = [FBCapacityQueue withCapacity:20];
-  _state = FBFramebufferVideoStateNotStarted;
+  _state = autorecord ? FBFramebufferVideoStateWaitingForFirstFrame : FBFramebufferVideoStateNotStarted;
   _timebase = NULL;
 
   return self;
+}
+
+#pragma mark Public Methods
+
+- (void)startRecording
+{
+  dispatch_async(self.mediaQueue, ^{
+    // Must be NotStarted to flick the First Frame wait switch.
+    if (self.state != FBFramebufferVideoStateNotStarted) {
+      [self.logger.info logFormat:@"Cannot start recording with state '%@'", [FBFramebufferVideo stateStringForState:self.state]];
+      return;
+    }
+    [self.logger.debug log:@"Manually starting recording"];
+    self.state = FBFramebufferVideoStateWaitingForFirstFrame;
+  });
+}
+
+- (void)stopRecording
+{
+  dispatch_group_t group = dispatch_group_create();
+  dispatch_async(self.mediaQueue, ^{
+    // No video has been recorded, so the recorder can just switch off.
+    if (self.state == FBFramebufferVideoStateWaitingForFirstFrame) {
+      self.state = FBFramebufferVideoStateNotStarted;
+      return;
+    }
+    // If not running, this is an invalid state to call from.
+    if (self.state != FBFramebufferVideoStateRunning) {
+      [self.logger.info logFormat:@"Cannot stop recording with state '%@'", [FBFramebufferVideo stateStringForState:self.state]];
+      return;
+    }
+    [self.logger.debug log:@"Manually stopping recording"];
+    [self teardownWriterWithGroup:group];
+  });
 }
 
 #pragma mark FBFramebufferDelegate Implementation
@@ -84,14 +119,7 @@ static const CMTimeScale FBFramebufferVideoRoundingMode = kCMTimeRoundingMethod_
 - (void)framebuffer:(FBSimulatorFramebuffer *)framebuffer didUpdate:(FBFramebufferFrame *)frame
 {
   dispatch_async(self.mediaQueue, ^{
-    // First frame means that the Video Session should be started.
-    // The Frame will be enqueued with the time of the session start time.
-    if (self.state == FBFramebufferVideoStateNotStarted) {
-      [self startRecordingWithFrame:frame error:nil];
-      return;
-    }
-
-    // Push the image at the current time.
+    // Push the image, converting to the new timebase.
     [self pushFrame:frame timebaseConversion:YES];
   });
 }
@@ -100,14 +128,6 @@ static const CMTimeScale FBFramebufferVideoRoundingMode = kCMTimeRoundingMethod_
 {
   dispatch_group_enter(teardownGroup);
   dispatch_barrier_async(self.mediaQueue, ^{
-    if (self.lastFrame) {
-      // Construct a time at the current timebase's time and push it to the queue.
-      // Timebase conversion does not need to apply.
-      CMTime time = CMTimebaseGetTime(self.timebase);
-      FBFramebufferFrame *finalFrame = [[FBFramebufferFrame alloc] initWithTime:time timebase:self.timebase image:self.lastFrame.image count:(self.lastFrame.count + 1) size:self.lastFrame.size];
-      [self.logger.info logFormat:@"Pushing last frame with new timing (%@) as this is the final frame", finalFrame];
-      [self pushFrame:finalFrame timebaseConversion:NO];
-    }
     [self teardownWriterWithGroup:teardownGroup];
     dispatch_group_leave(teardownGroup);
   });
@@ -133,19 +153,54 @@ static const CMTimeScale FBFramebufferVideoRoundingMode = kCMTimeRoundingMethod_
 
 - (void)pushFrame:(FBFramebufferFrame *)frame timebaseConversion:(BOOL)timebaseConversion
 {
-  frame = timebaseConversion ? [frame convertToTimebase:self.timebase timescale:FBFramebufferVideoTimescale roundingMethod:FBFramebufferVideoRoundingMode] : frame;
-  FBFramebufferFrame *evictedFrame = [self.frameQueue push:frame];
-  if (evictedFrame) {
-    [self.logger.debug logFormat:@"Evicted Frame (%@), frame dropped", evictedFrame];
+  // Discard frames when there's no reason to record them
+  if (self.state == FBFramebufferVideoStateNotStarted || self.state == FBFramebufferVideoStateTerminating) {
+    self.lastFrame = nil;
+    [self.frameQueue popAll];
+    return;
   }
+  // When waiting for first frame, start video recording.
+  if (self.state == FBFramebufferVideoStateWaitingForFirstFrame) {
+    self.lastFrame = nil;
+    [self.frameQueue popAll];
+    [self startRecordingWithFrame:frame error:nil];
+    return;
+  }
+
+  // Convert the timebase if required, then push the frame to the queue and drain.
+  frame = timebaseConversion ? [frame convertToTimebase:self.timebase timescale:FBFramebufferVideoTimescale roundingMethod:FBFramebufferVideoRoundingMode] : frame;
+  [self.frameQueue push:frame];
   [self drainQueue];
+}
+
+- (FBFramebufferFrame *)popFrame
+{
+  FBFramebufferFrame *frame = [self.frameQueue pop];
+  if (!frame) {
+    return nil;
+  }
+  // It's important that a number of conditions are met to ensure that this call is reliable as possible.
+  // Setting -[AVAssetWriter movieFragmentInterval] usually exacerbates any problems in the input.
+  // Much of the information here comes from the AVFoundation guru @rfistman.
+  //
+  // 1) The time used in -[AVAssetWriter startSessionAtSourceTime:] should have the same value as the first call to -[AVAssetWriterInputPixelBufferAdaptor appendPixelBuffer:withPresentationTime:]
+  // 2) The ordering of frames should always mean that each frame is sequential in it's presentation time. kCMTimeRoundingMethod_Default can result in strange values from rounding so kCMTimeRoundingMethod_RoundTowardNegativeInfinity is used.
+  //
+  // "The operation couldn't be completed. (OSStatus error -12633.)" is 'InvalidTimestamp': http://stackoverflow.com/a/23252239
+  // "An unknown error occurred (-16341)" is 'kMediaSampleTimingGeneratorError_InvalidTimeStamp': @rfistman
+  if (self.lastFrame && CMTimeCompare(frame.time, self.lastFrame.time) != 1) {
+    [self.logger.error logFormat:@"Dropping Frame (%@) as it's timestamp is not greater than a previous frame (%@)", frame, self.lastFrame];
+    return nil;
+  }
+  self.lastFrame = frame;
+  return frame;
 }
 
 - (void)drainQueue
 {
   NSInteger drainCount = 0;
   while (self.adaptor.assetWriterInput.readyForMoreMediaData) {
-    FBFramebufferFrame *frame = [self.frameQueue pop];
+    FBFramebufferFrame *frame = [self popFrame];
     if (!frame) {
       return;
     }
@@ -161,22 +216,10 @@ static const CMTimeScale FBFramebufferVideoRoundingMode = kCMTimeRoundingMethod_
       continue;
     }
 
-    // It's important that a number of conditions are met to ensure that this call is reliable as possible.
-    // Setting -[AVAssetWriter movieFragmentInterval] usually exacerbates any problems in the input.
-    // Much of the information here comes from the AVFoundation guru @rfistman.
-    //
-    // 1) The time used in -[AVAssetWriter startSessionAtSourceTime:] should have the same value as the first call to -[AVAssetWriterInputPixelBufferAdaptor appendPixelBuffer:withPresentationTime:]
-    // 2) The ordering of frames should always mean that each frame is sequential in it's presentation time. kCMTimeRoundingMethod_Default can result in strange values from rounding so kCMTimeRoundingMethod_RoundTowardNegativeInfinity is used.
-    //
-    // "The operation couldn't be completed. (OSStatus error -12633.)" is 'InvalidTimestamp': http://stackoverflow.com/a/23252239
-    // "An unknown error occurred (-16341)" is 'kMediaSampleTimingGeneratorError_InvalidTimeStamp': @rfistman
-
-    if (self.lastFrame && CMTimeCompare(frame.time, self.lastFrame.time) != 1) {
-      [self.logger.error logFormat:@"Dropping Frame (%@) as it's timestamp is not greater than a previous frame (%@)", frame, self.lastFrame];
-    } else if (![self.adaptor appendPixelBuffer:pixelBuffer withPresentationTime:frame.time]) {
+    // Append the PixelBuffer to the Adaptor.
+    if (![self.adaptor appendPixelBuffer:pixelBuffer withPresentationTime:frame.time]) {
       [self.logger.error logFormat:@"Failed to append pixel buffer of frame (%@) with error %@", frame, self.writer.error];
     }
-    self.lastFrame = frame;
     CVPixelBufferRelease(pixelBuffer);
   }
   if (drainCount == 0 && self.frameQueue.count > 0) {
@@ -188,7 +231,14 @@ static const CMTimeScale FBFramebufferVideoRoundingMode = kCMTimeRoundingMethod_
 
 - (BOOL)startRecordingWithFrame:(FBFramebufferFrame *)frame error:(NSError **)error
 {
-  // Create a Timebase based off frame's timebase, with a new base time.
+  // Bail out if we're in an invalid state
+  if (self.state == FBFramebufferVideoStateWaitingForFirstFrame) {
+    return [[FBSimulatorError
+      describeFormat:@"Cannot start recording from state '%@'", [FBFramebufferVideo stateStringForState:self.state]]
+      failBool:error];
+  }
+
+  // Create a Timebase to construct the time of the first frame.
   CMTimebaseRef timebase = NULL;
   CMTimebaseCreateWithMasterTimebase(
     kCFAllocatorDefault,
@@ -206,14 +256,15 @@ static const CMTimeScale FBFramebufferVideoRoundingMode = kCMTimeRoundingMethod_
   if (![self createAssetWriterAtPath:path fromFrame:frame error:error]) {
     return NO;
   }
+  // Mark as running.
+  self.state = FBFramebufferVideoStateRunning;
 
-  // Enqueue the first frame
+  // Enqueue the first frame, converting it to the timebase that has just been created.
   [self pushFrame:frame timebaseConversion:YES];
 
   // Report the availability of the video
   [self.eventSink diagnosticAvailable:[[logBuilder updatePath:path] build]];
 
-  self.state = FBFramebufferVideoStateRunning;
   return YES;
 }
 
@@ -289,14 +340,33 @@ static const CMTimeScale FBFramebufferVideoRoundingMode = kCMTimeRoundingMethod_
 
 - (void)teardownWriterWithGroup:(dispatch_group_t)teardownGroup
 {
+  // Invalid to teardown when not running.
   if (self.state != FBFramebufferVideoStateRunning) {
+    [self.logger.info logFormat:@"Cannot stop recording with state '%@'", [FBFramebufferVideo stateStringForState:self.state]];
     return;
   }
+
+  // Push last frame if one exists.
+  if (self.lastFrame) {
+    // Construct a time at the current timebase's time and push it to the queue.
+    // Timebase conversion does not need to apply.
+    CMTime time = CMTimebaseGetTimeWithTimeScale(self.timebase, FBFramebufferVideoTimescale, FBFramebufferVideoRoundingMode);
+    FBFramebufferFrame *finalFrame = [[FBFramebufferFrame alloc] initWithTime:time timebase:self.timebase image:self.lastFrame.image count:(self.lastFrame.count + 1) size:self.lastFrame.size];
+    [self.logger.info logFormat:@"Pushing last frame (%@) with new timing (%@) as this is the final frame", self.lastFrame, finalFrame];
+    [self pushFrame:finalFrame timebaseConversion:NO];
+  }
+
+  // Update state.
   self.state = FBFramebufferVideoStateTerminating;
   [self.logger.info logFormat:@"Marking video at '%@ as finished", self.writer.outputURL];
+
+  // Free Resources
+  CFRelease(self.timebase);
+  self.timebase = nil;
   [self.adaptor.assetWriterInput markAsFinished];
   [self.writer removeObserver:self forKeyPath:@"readyForMoreMediaData"];
 
+  // Finish writing, making sure to update state on the media queue.
   [self.logger.info logFormat:@"Finishing Writing '%@'", self.writer.outputURL];
   dispatch_group_enter(teardownGroup);
   [self.writer finishWritingWithCompletionHandler:^{
@@ -390,6 +460,24 @@ static const CMTimeScale FBFramebufferVideoRoundingMode = kCMTimeRoundingMethod_
   CVPixelBufferUnlockBaseAddress(pixelBuffer, 0);
 
   return pixelBuffer;
+}
+
+#pragma mark String Formatting
+
++ (NSString *)stateStringForState:(FBFramebufferVideoState)state
+{
+  switch (state) {
+    case FBFramebufferVideoStateNotStarted:
+      return @"Not Started";
+    case FBFramebufferVideoStateWaitingForFirstFrame:
+      return @"Waiting for First Frame";
+    case FBFramebufferVideoStateRunning:
+      return @"Running";
+    case FBFramebufferVideoStateTerminating:
+      return @"Terminating";
+    default:
+      return @"Unknown";
+  }
 }
 
 @end

--- a/FBSimulatorControl/Framebuffer/FBSimulatorFramebuffer.h
+++ b/FBSimulatorControl/Framebuffer/FBSimulatorFramebuffer.h
@@ -14,6 +14,7 @@
 @class FBSimulator;
 @class FBSimulatorLaunchConfiguration;
 @class SimDeviceFramebufferService;
+@class FBFramebufferVideo;
 @protocol FBFramebufferDelegate;
 
 /**
@@ -51,5 +52,10 @@
  @param teardownGroup the dispatch_group to append asynchronous operations to.
  */
 - (void)stopListeningWithTeardownGroup:(dispatch_group_t)teardownGroup;
+
+/**
+ The FBFramebufferVideo instance owned by the receiver.
+ */
+@property (nonatomic, strong, readonly) FBFramebufferVideo *video;
 
 @end

--- a/FBSimulatorControl/Framebuffer/FBSimulatorFramebuffer.m
+++ b/FBSimulatorControl/Framebuffer/FBSimulatorFramebuffer.m
@@ -72,20 +72,19 @@ static const CMTimeRoundingMethod FBSimulatorFramebufferRoundingMethod = kCMTime
     [sinks addObject:[FBFramebufferDebugWindow withName:@"Simulator"]];
   }
 
-  BOOL recordVideo = (launchConfiguration.options & FBSimulatorLaunchOptionsRecordVideo) == FBSimulatorLaunchOptionsRecordVideo;
-  if (recordVideo) {
-    [sinks addObject:[FBFramebufferVideo withDiagnostic:simulator.diagnostics.video logger:logger eventSink:simulator.eventSink]];
-  }
-  [sinks addObject:[FBFramebufferImage withDiagnostic:simulator.diagnostics.screenshot eventSink:simulator.eventSink]];
+  BOOL autorecord = (launchConfiguration.options & FBSimulatorLaunchOptionsRecordVideo) == FBSimulatorLaunchOptionsRecordVideo;
+  FBFramebufferVideo *video = [FBFramebufferVideo withDiagnostic:simulator.diagnostics.video shouldAutorecord:autorecord logger:logger eventSink:simulator.eventSink];
+  [sinks addObject:video];
 
+  [sinks addObject:[FBFramebufferImage withDiagnostic:simulator.diagnostics.screenshot eventSink:simulator.eventSink]];
 
   id<FBFramebufferDelegate> delegate = [FBFramebufferCompositeDelegate withDelegates:[sinks copy]];
   dispatch_queue_t queue = dispatch_queue_create("com.facebook.FBSimulatorControl.simulatorframebuffer", DISPATCH_QUEUE_SERIAL);
 
-  return [[self alloc] initWithFramebufferService:framebufferService onQueue:queue logger:[logger onQueue:queue] delegate:delegate];
+  return [[self alloc] initWithFramebufferService:framebufferService onQueue:queue video:video logger:[logger onQueue:queue] delegate:delegate];
 }
 
-- (instancetype)initWithFramebufferService:(SimDeviceFramebufferService *)framebufferService onQueue:(dispatch_queue_t)clientQueue logger:(id<FBSimulatorLogger>)logger delegate:(id<FBFramebufferDelegate>)delegate
+- (instancetype)initWithFramebufferService:(SimDeviceFramebufferService *)framebufferService onQueue:(dispatch_queue_t)clientQueue video:(FBFramebufferVideo *)video logger:(id<FBSimulatorLogger>)logger delegate:(id<FBFramebufferDelegate>)delegate
 {
   NSParameterAssert(framebufferService);
 
@@ -95,6 +94,7 @@ static const CMTimeRoundingMethod FBSimulatorFramebufferRoundingMethod = kCMTime
   }
 
   _framebufferService = framebufferService;
+  _video = video;
   _logger = logger;
   _delegate = delegate;
 

--- a/FBSimulatorControl/IPC/FBIPCClient.h
+++ b/FBSimulatorControl/IPC/FBIPCClient.h
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class FBSimulator;
+@class FBSimulatorSet;
+
+/**
+ The client for IPC.
+ */
+@interface FBIPCClient : NSObject
+
+/**
+ The Set that the IPC Client should send Remote Events for
+ */
+@property (nonatomic, strong, readonly) FBSimulatorSet *set;
+
+/**
+ Creates and retuns an IPC Client for the provided Simulator Set.
+ 
+ @param set the Simulator Set to use.
+ */
++ (instancetype)withSimulatorSet:(FBSimulatorSet *)set;
+
+/**
+ Notifies the FBSimulatorControl process that owns the Simulator's Framebuffer to start recording video.
+ 
+ @param simulator the Simulator to start recording video for.
+ */
+- (void)startRecordingVideo:(FBSimulator *)simulator;
+
+/**
+ Notifies the FBSimulatorControl process that owns the Simulator's Framebuffer to stop recording video.
+
+ @param simulator the Simulator to stop recording video for.
+ */
+- (void)stopRecordingVideo:(FBSimulator *)simulator;
+
+@end

--- a/FBSimulatorControl/IPC/FBIPCClient.m
+++ b/FBSimulatorControl/IPC/FBIPCClient.m
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBIPCClient.h"
+
+#import "FBSimulator.h"
+#import "FBSimulatorSet.h"
+#import "FBSimulatorFramebuffer.h"
+#import "FBSimulatorBridge.h"
+#import "FBFramebufferVideo.h"
+#import "FBSimulatorControlConfiguration.h"
+#import "FBIPCManager.h"
+
+@interface FBIPCClient ()
+
+
+@property (nonatomic, strong, readonly) NSDistributedNotificationCenter *notificationCenter;
+
+@end
+
+@implementation FBIPCClient
+
++ (instancetype)withSimulatorSet:(FBSimulatorSet *)set
+{
+  return [[self alloc] initWithSet:set];
+}
+
+- (instancetype)initWithSet:(FBSimulatorSet *)set
+{
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  _set = set;
+
+  return self;
+}
+
+#pragma mark Public Methods
+
+- (void)startRecordingVideo:(FBSimulator *)simulator
+{
+  if (simulator.set != self.set) {
+    return;
+  }
+  if (simulator.bridge) {
+    [simulator.bridge.framebuffer.video startRecording];
+  }
+  // TODO: IPC CALL
+}
+
+- (void)stopRecordingVideo:(FBSimulator *)simulator
+{
+  if (simulator.set != self.set) {
+    return;
+  }
+  if (simulator.bridge) {
+    [simulator.bridge.framebuffer.video stopRecording];
+  }
+  // TODO: IPC CALL
+}
+
+
+@end

--- a/FBSimulatorControl/IPC/FBIPCManager.h
+++ b/FBSimulatorControl/IPC/FBIPCManager.h
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class FBIPCClient;
+@class FBIPCServer;
+@class FBSimulatorSet;
+
+/**
+ Manages the IPC Client and Server.
+ */
+@interface FBIPCManager : NSObject
+
+/**
+ Creates an IPC Manager for the Provided Simulator Set.
+ */
++ (instancetype)withSimulatorSet:(FBSimulatorSet *)set;
+
+/**
+ The Client that messages can be sent to.
+ */
+@property (nonatomic, strong, readonly) FBIPCClient *client;
+
+/**
+ The Server that will recieve messages.
+ */
+@property (nonatomic, strong, readonly) FBIPCServer *server;
+
+@end

--- a/FBSimulatorControl/IPC/FBIPCManager.m
+++ b/FBSimulatorControl/IPC/FBIPCManager.m
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBIPCManager.h"
+
+#import "FBIPCClient.h"
+#import "FBIPCServer.h"
+
+NSString *const FBVideoStartDistributedNotificationName = @"FBSIMULATORCONTROL_VIDEO_START";
+NSString *const FBVideoStopDistributedNotificationName = @"FBSIMULATORCONTROL_VIDEO_STOP";
+NSString *const FBDistributedNotificationUDIDKey = @"udid";
+
+@implementation FBIPCManager
+
++ (instancetype)withSimulatorSet:(FBSimulatorSet *)set
+{
+  FBIPCClient *client = [FBIPCClient withSimulatorSet:set];
+  FBIPCServer *server = [FBIPCServer withSimulatorSet:set];
+  return [[self alloc] initWithClient:client server:server];
+}
+
+- (instancetype)initWithClient:(FBIPCClient *)client server:(FBIPCServer *)server
+{
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  _client = client;
+  _server = server;
+
+  return self;
+}
+
+@end

--- a/FBSimulatorControl/IPC/FBIPCServer.h
+++ b/FBSimulatorControl/IPC/FBIPCServer.h
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class FBSimulatorSet;
+
+/**
+ The IPC Server.
+ Recieves events and translates them into FBSimulatorControl API Calls.
+ */
+@interface FBIPCServer : NSObject
+
+/**
+ The Set that the IPC Client should respond to Remote Events for
+ */
+@property (nonatomic, strong, readonly) FBSimulatorSet *set;
+
+/**
+ Creates an IPC Server that manages the Simulator Set.
+ */
++ (instancetype)withSimulatorSet:(FBSimulatorSet *)set;
+
+@end

--- a/FBSimulatorControl/IPC/FBIPCServer.m
+++ b/FBSimulatorControl/IPC/FBIPCServer.m
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBIPCServer.h"
+
+#import "FBFramebufferVideo.h"
+#import "FBIPCManager.h"
+#import "FBSimulator.h"
+#import "FBSimulatorBridge.h"
+#import "FBSimulatorControlConfiguration.h"
+#import "FBSimulatorFramebuffer.h"
+#import "FBSimulatorSet.h"
+
+@implementation FBIPCServer
+
+#pragma mark Initializers
+
++ (instancetype)withSimulatorSet:(FBSimulatorSet *)set
+{
+  return [[self alloc] initWithSet:set];
+}
+
+- (instancetype)initWithSet:(FBSimulatorSet *)set
+{
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  _set = set;
+
+  return self;
+}
+
+// TODO: Respond to Remote Events.
+
+@end

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.h
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.h
@@ -67,4 +67,16 @@
  */
 - (instancetype)killProcess:(FBProcessInfo *)process;
 
+/**
+ Starts Recording video on the Simulator.
+ This call will always succeed, regardless whether the video is started correctly or not.
+ */
+- (instancetype)startRecordingVideo;
+
+/**
+ Stops Recording video on the Simulator.
+ This call will always succeed, regardless whether the video is stopped correctly or not.
+ */
+- (instancetype)stopRecordingVideo;
+
 @end

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.m
@@ -280,4 +280,32 @@
   return launchdSimProcess;
 }
 
+- (instancetype)startRecordingVideo
+{
+  return [self interactWithBootedSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
+    FBFramebufferVideo *video = simulator.bridge.framebuffer.video;
+    if (video) {
+      [video startRecording];
+      return YES;
+    }
+
+    [simulator.ipcClient startRecordingVideo:simulator];
+    return YES;
+  }];
+}
+
+- (instancetype)stopRecordingVideo
+{
+  return [self interactWithBootedSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
+    FBFramebufferVideo *video = simulator.bridge.framebuffer.video;
+    if (video) {
+      [video stopRecording];
+      return YES;
+    }
+
+    [simulator.ipcClient stopRecordingVideo:simulator];
+    return YES;
+  }];
+}
+
 @end

--- a/FBSimulatorControl/Management/FBSimulator+Helpers.h
+++ b/FBSimulatorControl/Management/FBSimulator+Helpers.h
@@ -9,6 +9,7 @@
 
 #import <FBSimulatorControl/FBSimulator.h>
 
+@class FBIPCClient;
 @class FBSimDeviceWrapper;
 @class FBSimulatorApplication;
 @class FBSimulatorInteraction;
@@ -40,6 +41,11 @@
  The DeviceSetPath of the Simulator.
  */
 @property (nonatomic, copy, readonly) NSString *deviceSetPath;
+
+/**
+ Fetches an FBIPCServer for the Simulator.
+ */
+@property (nonatomic, strong, readonly) FBIPCClient *ipcClient;
 
 /*
  Fetches an NSArray<FBProcessInfo *> of the subprocesses of the launchd_sim.

--- a/FBSimulatorControl/Management/FBSimulator+Helpers.m
+++ b/FBSimulatorControl/Management/FBSimulator+Helpers.m
@@ -19,6 +19,8 @@
 #import "FBSimDeviceWrapper.h"
 #import "FBSimulator+Private.h"
 #import "FBSimulatorApplication.h"
+#import "FBSimulatorControl.h"
+#import "FBIPCManager.h"
 #import "FBSimulatorControlGlobalConfiguration.h"
 #import "FBSimulatorError.h"
 #import "FBSimulatorHistory+Queries.h"
@@ -50,6 +52,11 @@
 - (NSString *)deviceSetPath
 {
   return self.set.deviceSet.setPath;
+}
+
+- (FBIPCClient *)ipcClient
+{
+  return self.set.control.ipcManager.client;
 }
 
 - (NSArray *)launchdSimSubprocesses

--- a/FBSimulatorControl/Management/FBSimulatorBridge.h
+++ b/FBSimulatorControl/Management/FBSimulatorBridge.h
@@ -54,4 +54,11 @@
  */
 - (void)setLocationWithLatitude:(double)latitude longitude:(double)longitude;
 
+#pragma mark Properties
+
+/**
+ The FBSimulatorFramebuffer Instance.
+ */
+@property (nonatomic, strong, readonly) FBSimulatorFramebuffer *framebuffer;
+
 @end

--- a/FBSimulatorControl/Management/FBSimulatorBridge.m
+++ b/FBSimulatorControl/Management/FBSimulatorBridge.m
@@ -27,7 +27,6 @@
 @property (nonatomic, strong, readonly) id<FBSimulatorEventSink> eventSink;
 @property (nonatomic, strong, readonly) dispatch_group_t teardownGroup;
 
-@property (nonatomic, strong, readwrite) FBSimulatorFramebuffer *framebuffer;
 @property (nonatomic, assign, readwrite) mach_port_t hidPort;
 @property (nonatomic, strong, readwrite) id<SimulatorBridge> bridge;
 

--- a/FBSimulatorControl/Management/FBSimulatorControl+PrincipalClass.h
+++ b/FBSimulatorControl/Management/FBSimulatorControl+PrincipalClass.h
@@ -11,6 +11,7 @@
 
 #import <FBSimulatorControl/FBSimulatorPool.h>
 
+@class FBIPCManager;
 @class FBSimulatorApplication;
 @class FBSimulatorConfiguration;
 @class FBSimulatorControlConfiguration;
@@ -73,6 +74,11 @@
  The Pool that the FBSimulatorControl instance uses.
  */
 @property (nonatomic, strong, readonly) FBSimulatorSet *set;
+
+/**
+ The IPC Manager.
+ */
+@property (nonatomic, strong, readonly) FBIPCManager *ipcManager;
 
 /**
  The Configuration that FBSimulatorControl uses.

--- a/FBSimulatorControl/Management/FBSimulatorControl+PrincipalClass.m
+++ b/FBSimulatorControl/Management/FBSimulatorControl+PrincipalClass.m
@@ -24,6 +24,7 @@
 #import "FBSimulatorControlGlobalConfiguration.h"
 #import "FBSimulatorError.h"
 #import "FBSimulatorHistory.h"
+#import "FBIPCManager.h"
 #import "FBSimulatorLogger.h"
 #import "FBSimulatorPool.h"
 #import "FBSimulatorSet.h"
@@ -60,6 +61,7 @@
   }
   _configuration = configuration;
   _pool = [FBSimulatorPool poolWithSet:_set logger:logger];
+  _ipcManager = [FBIPCManager withSimulatorSet:_set];
 
   return self;
 }

--- a/FBSimulatorControl/Management/FBSimulatorSet.h
+++ b/FBSimulatorControl/Management/FBSimulatorSet.h
@@ -82,6 +82,14 @@
 - (NSArray *)deleteAllWithError:(NSError **)error;
 
 /**
+ Fetches a Simulator from the Set with the Provided UDID.
+ 
+ @param udid the UDID of the Simulator to obtain.
+ @return A FBSimulator instance or nil if one could not be obtained.
+ */
+- (FBSimulator *)simulatorWithUDID:(NSString *)udid;
+
+/**
  The Logger to use.
  */
 @property (nonatomic, strong, readonly) id<FBSimulatorLogger> logger;

--- a/FBSimulatorControl/Management/FBSimulatorSet.m
+++ b/FBSimulatorControl/Management/FBSimulatorSet.m
@@ -19,6 +19,7 @@
 #import "FBSimulatorControl.h"
 #import "FBSimulatorControlConfiguration.h"
 #import "FBSimulatorLogger.h"
+#import "FBSimulatorPredicates.h"
 #import "FBSimulatorTerminationStrategy.h"
 
 @implementation FBSimulatorSet
@@ -267,6 +268,13 @@
 - (NSArray *)deleteAllWithError:(NSError **)error
 {
   return [self deleteSimulators:self.allSimulators withError:error];
+}
+
+- (FBSimulator *)simulatorWithUDID:(NSString *)udid
+{
+  return [[self.allSimulators
+    filteredArrayUsingPredicate:[FBSimulatorPredicates udid:udid]]
+    firstObject];
 }
 
 #pragma mark FBDebugDescribeable Protocol

--- a/FBSimulatorControl/Utility/FBCapacityQueue.h
+++ b/FBSimulatorControl/Utility/FBCapacityQueue.h
@@ -39,6 +39,13 @@
 - (id)pop;
 
 /**
+ Pops all items from the queue.
+
+ @return an Array of all the items popped from the queue.
+ */
+- (NSArray *)popAll;
+
+/**
  The count of the queue.
 
  @return the count of items in the queue

--- a/FBSimulatorControl/Utility/FBCapacityQueue.m
+++ b/FBSimulatorControl/Utility/FBCapacityQueue.m
@@ -63,6 +63,13 @@
   return item;
 }
 
+- (NSArray *)popAll
+{
+  NSArray *all = self.array.copy;
+  [self.array removeAllObjects];
+  return all;
+}
+
 - (NSUInteger)count
 {
   return self.array.count;

--- a/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
@@ -68,6 +68,7 @@ public enum Action {
   case Launch(FBProcessLaunchConfiguration)
   case List
   case Listen(Server)
+  case Record(Bool)
   case Relaunch(FBApplicationLaunchConfiguration)
   case Shutdown
   case Terminate(String)
@@ -107,6 +108,8 @@ public func == (left: Action, right: Action) -> Bool {
     return true
   case (.Listen(let leftServer), .Listen(let rightServer)):
     return leftServer == rightServer
+  case (.Record(let leftStart), .Record(let rightStart)):
+    return leftStart == rightStart
   case (.Relaunch(let leftLaunch), .Relaunch(let rightLaunch)):
     return leftLaunch == rightLaunch
   case (.Shutdown, .Shutdown):

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -244,6 +244,7 @@ extension Action : Parsable {
         self.launchParser,
         self.listenParser,
         self.listParser,
+        self.recordParser,
         self.relaunchParser,
         self.shutdownParser,
         self.terminateParser
@@ -304,6 +305,15 @@ extension Action : Parsable {
     return Parser
       .succeeded(EventName.Relaunch.rawValue, self.appLaunchParser)
       .fmap { Action.Relaunch($0 as! FBApplicationLaunchConfiguration) }
+  }}
+
+  static var recordParser: Parser<Action> { get {
+    return Parser
+      .succeeded(EventName.Record.rawValue, Parser.alternative([
+        Parser.ofString("start", true),
+        Parser.ofString("stop", false)
+      ]))
+      .fmap { Action.Record($0) }
   }}
 
   static var shutdownParser: Parser<Action> { get {

--- a/fbsimctl/FBSimulatorControlKit/Sources/Events.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Events.swift
@@ -27,6 +27,7 @@ public enum EventName : String {
   case List = "list"
   case Listen = "listen"
   case Query = "query"
+  case Record = "record"
   case Relaunch = "relaunch"
   case Shutdown = "shutdown"
   case Signalled = "signalled"

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -232,6 +232,8 @@ private struct SimulatorRunner : Runner {
           interaction.launchAgent(agentLaunch)
         }
       }
+    case .Record(let start):
+      assertionFailure()
     case .Relaunch(let appLaunch):
       try interactWithSimulator(translator, EventName.Relaunch, appLaunch) { interaction in
         interaction.launchOrRelaunchApplication(appLaunch)

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -233,7 +233,13 @@ private struct SimulatorRunner : Runner {
         }
       }
     case .Record(let start):
-      assertionFailure()
+      try interactWithSimulator(translator, EventName.Record, simulator) { interaction in
+        if (start) {
+          interaction.startRecordingVideo()
+        } else {
+          interaction.stopRecordingVideo()
+        }
+      }
     case .Relaunch(let appLaunch):
       try interactWithSimulator(translator, EventName.Relaunch, appLaunch) { interaction in
         interaction.launchOrRelaunchApplication(appLaunch)

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
@@ -355,6 +355,14 @@ class CommandParserTests : XCTestCase {
     self.assertWithDefaultAction(action, suffix: suffix)
   }
 
+  func testParsesRecordStart() {
+    self.assertWithDefaultAction(Action.Record(true), suffix: ["record", "start"])
+  }
+
+  func testParsesRecordStop() {
+    self.assertWithDefaultAction(Action.Record(false), suffix: ["record", "stop"])
+  }
+
   func testParsesRelaunchAppByBundleID() {
     let action = Action.Relaunch(FBApplicationLaunchConfiguration(bundleID: "com.foo.bar", bundleName: nil, arguments: [], environment: [:]))
     let suffix: [String] = ["relaunch", "com.foo.bar"]

--- a/fbsimctl/fbsimctl.xcodeproj/xcshareddata/xcschemes/fbsimctl.xcscheme
+++ b/fbsimctl/fbsimctl.xcodeproj/xcshareddata/xcschemes/fbsimctl.xcscheme
@@ -74,19 +74,7 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "--state=booted"
-            isEnabled = "YES">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "listen"
-            isEnabled = "YES">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "--http"
-            isEnabled = "YES">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "8090"
+            argument = "51895E05-73ED-4A98-8834-DC2F67B6BE41 boot --direct-launch listen"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>


### PR DESCRIPTION
Since a process that links `FBSimulatorControl` may contain the 'Framebuffer' for any given booted Simulator, a secondary process may wish to manipulate this Simulator. In this 'direct-launch' model a process needs to be kept alive to act as a semi-persistent that should stay alive as long as the Simulator must stay alive.

Terminating the process that owns a `SimDevice`'s `PurpleFBServer` will shutdown the Simulator. This can be seen in the `Simulator.app`. Since a process that contains the Simulator's Framebuffer can take the form of a `fbsimctl` process, it's possible to use one process to hold onto the booted Simulator's Framebuffer, and another to start the video recording:

- `fbsimctl UDID boot --direct-launch --wait` Will boot a Simulator and keep it alive in the `fbsimctl` process. Sending this process a `SIGTERM` will shutdown the Simulator gracefully. The Framebuffer will be connected to this Simulator, but recording will not start until recording is explicitly requested.
- `fbsimctl UDID record start` Will communicate to the above waiting process and start the video record. It will then terminate.

For example, this is useful when you wish to record the video of a Simulator, but want to start recording at a later date.