### PR TITLE
Add FBFramebufferVideoConfiguration

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		AA2219951C3E752800371B01 /* FBCoreSimulatorTerminationStrategy.h in Headers */ = {isa = PBXBuildFile; fileRef = AA2219931C3E752800371B01 /* FBCoreSimulatorTerminationStrategy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA2219961C3E752800371B01 /* FBCoreSimulatorTerminationStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = AA2219941C3E752800371B01 /* FBCoreSimulatorTerminationStrategy.m */; };
 		AA3230CB1BDA387700C5BA01 /* FBSimulatorControlAssertions.m in Sources */ = {isa = PBXBuildFile; fileRef = AA3230CA1BDA387700C5BA01 /* FBSimulatorControlAssertions.m */; };
+		AA3FD0331C872E26001093CA /* FBFramebufferVideoConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = AA3FD0311C872E26001093CA /* FBFramebufferVideoConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA3FD0341C872E26001093CA /* FBFramebufferVideoConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = AA3FD0321C872E26001093CA /* FBFramebufferVideoConfiguration.m */; };
 		AA4242EA1C528338008ABD80 /* FBFramebufferDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4242DF1C528338008ABD80 /* FBFramebufferDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA4242ED1C528338008ABD80 /* FBSimulatorFramebuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4242E21C528338008ABD80 /* FBSimulatorFramebuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA4242EE1C528338008ABD80 /* FBSimulatorFramebuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = AA4242E31C528338008ABD80 /* FBSimulatorFramebuffer.m */; };
@@ -267,6 +269,8 @@
 		AA2DDC391C284044000689C6 /* SimVerifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SimVerifier.h; sourceTree = "<group>"; };
 		AA3230C91BDA387700C5BA01 /* FBSimulatorControlAssertions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorControlAssertions.h; sourceTree = "<group>"; };
 		AA3230CA1BDA387700C5BA01 /* FBSimulatorControlAssertions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorControlAssertions.m; sourceTree = "<group>"; };
+		AA3FD0311C872E26001093CA /* FBFramebufferVideoConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBFramebufferVideoConfiguration.h; sourceTree = "<group>"; };
+		AA3FD0321C872E26001093CA /* FBFramebufferVideoConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBFramebufferVideoConfiguration.m; sourceTree = "<group>"; };
 		AA4242DF1C528338008ABD80 /* FBFramebufferDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBFramebufferDelegate.h; sourceTree = "<group>"; };
 		AA4242E21C528338008ABD80 /* FBSimulatorFramebuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorFramebuffer.h; sourceTree = "<group>"; };
 		AA4242E31C528338008ABD80 /* FBSimulatorFramebuffer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorFramebuffer.m; sourceTree = "<group>"; };
@@ -1747,6 +1751,8 @@
 		AA9516C11C15F54600A89CAD /* Configuration */ = {
 			isa = PBXGroup;
 			children = (
+				AA3FD0311C872E26001093CA /* FBFramebufferVideoConfiguration.h */,
+				AA3FD0321C872E26001093CA /* FBFramebufferVideoConfiguration.m */,
 				AA9516C51C15F54600A89CAD /* FBProcessLaunchConfiguration.h */,
 				AA9516C61C15F54600A89CAD /* FBProcessLaunchConfiguration.m */,
 				AA9516C21C15F54600A89CAD /* FBProcessLaunchConfiguration+Helpers.h */,
@@ -2066,6 +2072,7 @@
 				AA1D65421C21B38D0069F90D /* FBCrashLogInfo.h in Headers */,
 				AA95175E1C15F54600A89CAD /* FBSimulatorHistoryGenerator.h in Headers */,
 				AA9517701C15F54600A89CAD /* FBSimulatorInteraction+Upload.h in Headers */,
+				AA3FD0331C872E26001093CA /* FBFramebufferVideoConfiguration.h in Headers */,
 				AA9517AC1C15F54600A89CAD /* FBTerminationHandle.h in Headers */,
 				AAF8DA691C1AFFB1003B519E /* FBProcessInfo.h in Headers */,
 				AA9517911C15F54600A89CAD /* FBSimulatorHistory+Queries.h in Headers */,
@@ -2251,6 +2258,7 @@
 				AA59E2871C85AA9400C17ED3 /* FBFramebufferFrame.m in Sources */,
 				AA9517B51C15F54600A89CAD /* FBConcurrentCollectionOperations.m in Sources */,
 				AACA2C381C2976B100979C45 /* FBAddVideoPolyfill.m in Sources */,
+				AA3FD0341C872E26001093CA /* FBFramebufferVideoConfiguration.m in Sources */,
 				AA9517921C15F54600A89CAD /* FBSimulatorHistory+Queries.m in Sources */,
 				AA9517581C15F54600A89CAD /* FBSimulatorResourceManager.m in Sources */,
 				AA9517561C15F54600A89CAD /* FBSimulatorControlGlobalConfiguration.m in Sources */,

--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		AA3230CB1BDA387700C5BA01 /* FBSimulatorControlAssertions.m in Sources */ = {isa = PBXBuildFile; fileRef = AA3230CA1BDA387700C5BA01 /* FBSimulatorControlAssertions.m */; };
 		AA3FD0331C872E26001093CA /* FBFramebufferVideoConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = AA3FD0311C872E26001093CA /* FBFramebufferVideoConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA3FD0341C872E26001093CA /* FBFramebufferVideoConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = AA3FD0321C872E26001093CA /* FBFramebufferVideoConfiguration.m */; };
+		AA3FD0361C87594E001093CA /* FBFramebufferVideoConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA3FD0351C87594E001093CA /* FBFramebufferVideoConfigurationTests.m */; };
 		AA4242EA1C528338008ABD80 /* FBFramebufferDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4242DF1C528338008ABD80 /* FBFramebufferDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA4242ED1C528338008ABD80 /* FBSimulatorFramebuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4242E21C528338008ABD80 /* FBSimulatorFramebuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA4242EE1C528338008ABD80 /* FBSimulatorFramebuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = AA4242E31C528338008ABD80 /* FBSimulatorFramebuffer.m */; };
@@ -271,6 +272,7 @@
 		AA3230CA1BDA387700C5BA01 /* FBSimulatorControlAssertions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorControlAssertions.m; sourceTree = "<group>"; };
 		AA3FD0311C872E26001093CA /* FBFramebufferVideoConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBFramebufferVideoConfiguration.h; sourceTree = "<group>"; };
 		AA3FD0321C872E26001093CA /* FBFramebufferVideoConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBFramebufferVideoConfiguration.m; sourceTree = "<group>"; };
+		AA3FD0351C87594E001093CA /* FBFramebufferVideoConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBFramebufferVideoConfigurationTests.m; sourceTree = "<group>"; };
 		AA4242DF1C528338008ABD80 /* FBFramebufferDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBFramebufferDelegate.h; sourceTree = "<group>"; };
 		AA4242E21C528338008ABD80 /* FBSimulatorFramebuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorFramebuffer.h; sourceTree = "<group>"; };
 		AA4242E31C528338008ABD80 /* FBSimulatorFramebuffer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorFramebuffer.m; sourceTree = "<group>"; };
@@ -1675,6 +1677,7 @@
 			isa = PBXGroup;
 			children = (
 				AAF005241C43CA4600508E26 /* FBDiagnosticTests.m */,
+				AA3FD0351C87594E001093CA /* FBFramebufferVideoConfigurationTests.m */,
 				AAF005111C43CA4600508E26 /* FBProcessLaunchConfigurationTests.m */,
 				AAF005141C43CA4600508E26 /* FBSimulatorApplicationTests.m */,
 				AAF005151C43CA4600508E26 /* FBSimulatorAutomaticUpdatingTests.m */,
@@ -2290,6 +2293,7 @@
 				AAF0052D1C43CA4600508E26 /* FBSimulatorHistoryGeneratorTests.m in Sources */,
 				AAF005291C43CA4600508E26 /* FBSimulatorAutomaticUpdatingTests.m in Sources */,
 				AAF005251C43CA4600508E26 /* FBProcessLaunchConfigurationTests.m in Sources */,
+				AA3FD0361C87594E001093CA /* FBFramebufferVideoConfigurationTests.m in Sources */,
 				AAB4AC271BBBC6880046F6A1 /* FBSimulatorControlTestCase.m in Sources */,
 				AAF005331C43CA4600508E26 /* FBSimulatorSetTests.m in Sources */,
 			);

--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		AA3FD0331C872E26001093CA /* FBFramebufferVideoConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = AA3FD0311C872E26001093CA /* FBFramebufferVideoConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA3FD0341C872E26001093CA /* FBFramebufferVideoConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = AA3FD0321C872E26001093CA /* FBFramebufferVideoConfiguration.m */; };
 		AA3FD0361C87594E001093CA /* FBFramebufferVideoConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA3FD0351C87594E001093CA /* FBFramebufferVideoConfigurationTests.m */; };
+		AA3FD0381C875A96001093CA /* FBSimulatorLaunchConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA3FD0371C875A96001093CA /* FBSimulatorLaunchConfigurationTests.m */; };
 		AA4242EA1C528338008ABD80 /* FBFramebufferDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4242DF1C528338008ABD80 /* FBFramebufferDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA4242ED1C528338008ABD80 /* FBSimulatorFramebuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4242E21C528338008ABD80 /* FBSimulatorFramebuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA4242EE1C528338008ABD80 /* FBSimulatorFramebuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = AA4242E31C528338008ABD80 /* FBSimulatorFramebuffer.m */; };
@@ -273,6 +274,7 @@
 		AA3FD0311C872E26001093CA /* FBFramebufferVideoConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBFramebufferVideoConfiguration.h; sourceTree = "<group>"; };
 		AA3FD0321C872E26001093CA /* FBFramebufferVideoConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBFramebufferVideoConfiguration.m; sourceTree = "<group>"; };
 		AA3FD0351C87594E001093CA /* FBFramebufferVideoConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBFramebufferVideoConfigurationTests.m; sourceTree = "<group>"; };
+		AA3FD0371C875A96001093CA /* FBSimulatorLaunchConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorLaunchConfigurationTests.m; sourceTree = "<group>"; };
 		AA4242DF1C528338008ABD80 /* FBFramebufferDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBFramebufferDelegate.h; sourceTree = "<group>"; };
 		AA4242E21C528338008ABD80 /* FBSimulatorFramebuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorFramebuffer.h; sourceTree = "<group>"; };
 		AA4242E31C528338008ABD80 /* FBSimulatorFramebuffer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorFramebuffer.m; sourceTree = "<group>"; };
@@ -1687,6 +1689,7 @@
 				AAF0051D1C43CA4600508E26 /* FBSimulatorDiagnosticsTests.m */,
 				AAF005191C43CA4600508E26 /* FBSimulatorHistoryGeneratorTests.m */,
 				AAF0051A1C43CA4600508E26 /* FBSimulatorInteractionTests.m */,
+				AA3FD0371C875A96001093CA /* FBSimulatorLaunchConfigurationTests.m */,
 				AA6424FD1C44E99B00AA9BFB /* FBSimulatorLaunchTests.m */,
 				AAF0051E1C43CA4600508E26 /* FBSimulatorPoolTests.m */,
 				AAF0051F1C43CA4600508E26 /* FBSimulatorSetTests.m */,
@@ -2291,6 +2294,7 @@
 				AA6424FE1C44E99B00AA9BFB /* FBSimulatorLaunchTests.m in Sources */,
 				AA3230CB1BDA387700C5BA01 /* FBSimulatorControlAssertions.m in Sources */,
 				AAF0052D1C43CA4600508E26 /* FBSimulatorHistoryGeneratorTests.m in Sources */,
+				AA3FD0381C875A96001093CA /* FBSimulatorLaunchConfigurationTests.m in Sources */,
 				AAF005291C43CA4600508E26 /* FBSimulatorAutomaticUpdatingTests.m in Sources */,
 				AAF005251C43CA4600508E26 /* FBProcessLaunchConfigurationTests.m in Sources */,
 				AA3FD0361C87594E001093CA /* FBFramebufferVideoConfigurationTests.m in Sources */,

--- a/FBSimulatorControl/Configuration/FBFramebufferVideoConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBFramebufferVideoConfiguration.h
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <CoreMedia/CoreMedia.h>
+#import <Foundation/Foundation.h>
+
+#import <FBSimulatorControl/FBDebugDescribeable.h>
+#import <FBSimulatorControl/FBJSONSerializationDescribeable.h>
+
+@class FBDiagnostic;
+
+/**
+ A Configuration Value for FBFramebufferVideo.
+ */
+@interface FBFramebufferVideoConfiguration : NSObject <NSCoding, NSCopying, FBJSONSerializationDescribeable, FBDebugDescribeable>
+
+/**
+ The Diagnostic Value to determine the video path.
+ */
+@property (nonatomic, copy, readonly) FBDiagnostic *diagnostic;
+
+/**
+ YES if the Video Component should automatically record when the first frame comes in.
+ */
+@property (nonatomic, assign, readonly) BOOL autorecord;
+
+/**
+ The Timescale used in Video Encoding.
+ */
+@property (nonatomic, assign, readonly) CMTimeScale timescale;
+
+/**
+ The Rounding Method used for Video Frames.
+ */
+@property (nonatomic, assign, readonly) CMTimeRoundingMethod roundingMethod;
+
+/**
+ The FileType of the Video.
+ */
+@property (nonatomic, copy, readonly) NSString *fileType;
+
+#pragma mark Defaults & Initializers
+
+/**
+ The Default Value of FBFramebufferVideoConfiguration.
+ Uses Reasonable Defaults.
+ */
++ (instancetype)defaultConfiguration;
+
+/**
+ The Default Value of FBFramebufferVideoConfiguration.
+ Use this in preference to 'defaultConfiguration' if video encoding is problematic.
+ */
++ (instancetype)prudentConfiguration;
+
+/**
+ Creates and Returns a new FBFramebufferVideoConfiguration Value with the provided parameters.
+
+ @param diagnostic The Diagnostic Value to determine the video path
+ @param autorecord YES if the Video Component should automatically record when the first frame comes in.
+ @param timescale The Timescale used in Video Encoding.
+ @param roundingMethod The Rounding Method used for Video Frames.
+ @param fileType The FileType of the Video.
+ @return a FBFramebufferVideoConfiguration instance.
+ */
++ (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic autorecord:(BOOL)autorecord timescale:(CMTimeScale)timescale roundingMethod:(CMTimeRoundingMethod)roundingMethod fileType:(NSString *)fileType;
+
+#pragma mark Diagnostics
+
++ (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic;
+- (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic;
+
+#pragma mark Autorecord
+
+- (instancetype)withAutorecord:(BOOL)autorecord;
++ (instancetype)withAutorecord:(BOOL)autorecord;
+
+#pragma mark Timescale
+
+- (instancetype)withTimescale:(CMTimeScale)timescale;
++ (instancetype)withTimescale:(CMTimeScale)timescale;
+
+#pragma mark Rounding
+
+- (instancetype)withRoundingMethod:(CMTimeRoundingMethod)roundingMethod;
++ (instancetype)withRoundingMethod:(CMTimeRoundingMethod)roundingMethod;
+
+#pragma mark File Type
+
+- (instancetype)withFileType:(NSString *)fileType;
++ (instancetype)withFileType:(NSString *)fileType;
+
+@end

--- a/FBSimulatorControl/Configuration/FBFramebufferVideoConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBFramebufferVideoConfiguration.m
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBFramebufferVideoConfiguration.h"
+
+#import <AVFoundation/AVFoundation.h>
+
+#import "FBDiagnostic.h"
+
+@implementation FBFramebufferVideoConfiguration
+
++ (instancetype)defaultConfiguration
+{
+  return [FBFramebufferVideoConfiguration withDiagnostic:nil autorecord:NO timescale:1000 roundingMethod:kCMTimeRoundingMethod_RoundTowardZero fileType:AVFileTypeMPEG4];
+}
+
++ (instancetype)prudentConfiguration
+{
+  return [FBFramebufferVideoConfiguration withDiagnostic:nil autorecord:NO timescale:1000 roundingMethod:kCMTimeRoundingMethod_QuickTime fileType:AVFileTypeQuickTimeMovie];
+}
+
++ (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic autorecord:(BOOL)autorecord timescale:(CMTimeScale)timescale roundingMethod:(CMTimeRoundingMethod)roundingMethod fileType:(NSString *)fileType
+{
+  return [[FBFramebufferVideoConfiguration alloc] initWithDiagnostic:diagnostic autorecord:autorecord timescale:timescale roundingMethod:roundingMethod fileType:fileType];
+}
+
+- (instancetype)initWithDiagnostic:(FBDiagnostic *)diagnostic autorecord:(BOOL)autorecord timescale:(CMTimeScale)timescale roundingMethod:(CMTimeRoundingMethod)roundingMethod fileType:(NSString *)fileType
+{
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  _diagnostic = diagnostic;
+  _autorecord = autorecord;
+  _timescale = timescale;
+  _roundingMethod = roundingMethod;
+  _fileType = fileType;
+
+  return self;
+}
+
+#pragma mark NSCopying
+
+- (instancetype)copyWithZone:(NSZone *)zone
+{
+  return [[self.class alloc] initWithDiagnostic:self.diagnostic autorecord:self.autorecord timescale:self.timescale roundingMethod:self.roundingMethod fileType:self.fileType];
+}
+
+#pragma mark NSObject
+
+- (NSUInteger)hash
+{
+  return self.diagnostic.hash ^ (NSUInteger) self.autorecord ^ (NSUInteger) self.timescale ^ (NSUInteger) self.roundingMethod ^ self.fileType.hash;
+}
+
+- (BOOL)isEqual:(FBFramebufferVideoConfiguration *)configuration
+{
+  if (![configuration isKindOfClass:self.class]) {
+    return NO;
+  }
+
+  return (self.diagnostic == configuration.diagnostic || [self.diagnostic isEqual:configuration.diagnostic]) &&
+         (self.autorecord == configuration.autorecord) &&
+         (self.timescale == configuration.timescale) &&
+         (self.roundingMethod == configuration.roundingMethod) &&
+         (self.fileType == configuration.fileType || [self.fileType isEqual:configuration.fileType]);
+}
+
+#pragma mark NSCoding
+
+- (instancetype)initWithCoder:(NSCoder *)decoder
+{
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  _diagnostic = [decoder decodeObjectForKey:NSStringFromSelector(@selector(diagnostic))];
+  _autorecord = [decoder decodeBoolForKey:NSStringFromSelector(@selector(autorecord))];
+  _timescale = [decoder decodeInt32ForKey:NSStringFromSelector(@selector(timescale))];
+  _roundingMethod = [[decoder decodeObjectForKey:NSStringFromSelector(@selector(roundingMethod))] unsignedIntValue];
+  _fileType = [decoder decodeObjectForKey:NSStringFromSelector(@selector(fileType))];
+
+  return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder
+{
+  [coder encodeObject:self.diagnostic forKey:NSStringFromSelector(@selector(diagnostic))];
+  [coder encodeBool:self.autorecord forKey:NSStringFromSelector(@selector(autorecord))];
+  [coder encodeInt32:self.timescale forKey:NSStringFromSelector(@selector(timescale))];
+  [coder encodeObject:@(self.roundingMethod) forKey:NSStringFromSelector(@selector(roundingMethod))];
+  [coder encodeObject:self.fileType forKey:NSStringFromSelector(@selector(fileType))];
+}
+
+#pragma mark FBJSONSerializationDescribeable
+
+- (id)jsonSerializableRepresentation
+{
+  return @{
+    NSStringFromSelector(@selector(diagnostic)) : self.diagnostic.jsonSerializableRepresentation ?: NSNull.null,
+    NSStringFromSelector(@selector(autorecord)) : @(self.autorecord),
+    NSStringFromSelector(@selector(timescale)) : @(self.timescale),
+    NSStringFromSelector(@selector(roundingMethod)) : @(self.roundingMethod),
+    NSStringFromSelector(@selector(fileType)) : self.fileType ?: NSNull.null
+  };
+}
+
+#pragma mark FBDebugDescribeable
+
+- (NSString *)shortDescription
+{
+  return [NSString stringWithFormat:@"Autorecord %hhd | Timescale %d | Rounding Method %d", self.autorecord, self.timescale, self.roundingMethod];
+}
+
+- (NSString *)debugDescription
+{
+  return self.shortDescription;
+}
+
+- (NSString *)description
+{
+  return self.shortDescription;
+}
+
+#pragma mark Diagnostics
+
++ (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic
+{
+  return [self.defaultConfiguration withDiagnostic:diagnostic];
+}
+
+- (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic
+{
+  return [[self.class alloc] initWithDiagnostic:diagnostic autorecord:self.autorecord timescale:self.timescale roundingMethod:self.roundingMethod fileType:self.fileType];
+}
+
+#pragma mark Autorecord
+
++ (instancetype)withAutorecord:(BOOL)autorecord
+{
+  return [self.defaultConfiguration withAutorecord:autorecord];
+}
+
+- (instancetype)withAutorecord:(BOOL)autorecord
+{
+  return [[self.class alloc] initWithDiagnostic:self.diagnostic autorecord:autorecord timescale:self.timescale roundingMethod:self.roundingMethod fileType:self.fileType];
+}
+
+#pragma mark Timescale
+
++ (instancetype)withTimescale:(CMTimeScale)timescale
+{
+  return [self.defaultConfiguration withTimescale:timescale];
+}
+
+- (instancetype)withTimescale:(CMTimeScale)timescale
+{
+  return [[self.class alloc] initWithDiagnostic:self.diagnostic autorecord:self.autorecord timescale:timescale roundingMethod:self.roundingMethod fileType:self.fileType];
+}
+
+#pragma mark Rounding
+
++ (instancetype)withRoundingMethod:(CMTimeRoundingMethod)roundingMethod
+{
+  return [self.defaultConfiguration withRoundingMethod:roundingMethod];
+}
+
+- (instancetype)withRoundingMethod:(CMTimeRoundingMethod)roundingMethod
+{
+  return [[self.class alloc] initWithDiagnostic:self.diagnostic autorecord:self.autorecord timescale:self.timescale roundingMethod:roundingMethod fileType:self.fileType];
+}
+
+#pragma mark File Type
+
++ (instancetype)withFileType:(NSString *)fileType
+{
+  return [self withFileType:fileType];
+}
+
+- (instancetype)withFileType:(NSString *)fileType
+{
+  return [[self.class alloc] initWithDiagnostic:self.diagnostic autorecord:self.autorecord timescale:self.timescale roundingMethod:self.roundingMethod fileType:fileType];
+}
+
+@end

--- a/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorLaunchConfiguration.h
@@ -12,20 +12,26 @@
 #import <FBSimulatorControl/FBDebugDescribeable.h>
 #import <FBSimulatorControl/FBJSONSerializationDescribeable.h>
 
+@class FBFramebufferVideoConfiguration;
+
 /**
  An Option Set for Direct Launching.
  */
 typedef NS_OPTIONS(NSUInteger, FBSimulatorLaunchOptions) {
   FBSimulatorLaunchOptionsEnableDirectLaunch = 1 << 0, /** Launches Simulators directly with a Framebuffer instead of with Simulator.app */
-  FBSimulatorLaunchOptionsRecordVideo = 1 << 1, /** Automatically starts the recording of video when the simulator is launched. */
-  FBSimulatorLaunchOptionsShowDebugWindow = 1 << 2, /** Relays the Simulator Framebuffer to a window */
-  FBSimulatorLaunchOptionsUseNSWorkspace = 1 << 4, /** Uses -[NSWorkspace launchApplicationAtURL:options:configuration::error:] to launch Simulator.app */
+  FBSimulatorLaunchOptionsShowDebugWindow = 1 << 1, /** Relays the Simulator Framebuffer to a window */
+  FBSimulatorLaunchOptionsUseNSWorkspace = 1 << 2, /** Uses -[NSWorkspace launchApplicationAtURL:options:configuration::error:] to launch Simulator.app */
 };
 
 /**
  A Value Object for defining how to launch a Simulator.
  */
 @interface FBSimulatorLaunchConfiguration : NSObject <NSCoding, NSCopying, FBJSONSerializationDescribeable, FBDebugDescribeable>
+
+/**
+ Options for how the Simulator should be launched.
+ */
+@property (nonatomic, assign, readonly) FBSimulatorLaunchOptions options;
 
 /**
  The Locale in which to Simulate, may be nil.
@@ -38,13 +44,22 @@ typedef NS_OPTIONS(NSUInteger, FBSimulatorLaunchOptions) {
 @property (nonatomic, copy, readonly) NSString *scaleString;
 
 /**
- Options for how the Simulator should be launched.
+ Configuration for Framebuffer Video encoding.
+ Only applies if FBSimulatorLaunchOptionsEnableDirectLaunch is flagged.
  */
-@property (nonatomic, assign, readonly) FBSimulatorLaunchOptions options;
+@property (nonatomic, copy, readonly) FBFramebufferVideoConfiguration *video;
 
 #pragma mark Default Instance
 
 + (instancetype)defaultConfiguration;
+
+#pragma mark Launch Options
+
+/**
+ Set Direct Launch Options
+ */
++ (instancetype)withOptions:(FBSimulatorLaunchOptions)options;
+- (instancetype)withOptions:(FBSimulatorLaunchOptions)options;
 
 #pragma mark Device Scale
 
@@ -90,12 +105,12 @@ typedef NS_OPTIONS(NSUInteger, FBSimulatorLaunchOptions) {
 + (instancetype)withLocale:(NSLocale *)locale;
 - (instancetype)withLocale:(NSLocale *)locale;
 
-#pragma mark Launch Options
+#pragma mark Video
 
 /**
- Set Direct Launch Options
+ Set Video Configuration
  */
-+ (instancetype)withOptions:(FBSimulatorLaunchOptions)options;
-- (instancetype)withOptions:(FBSimulatorLaunchOptions)options;
++ (instancetype)withVideo:(FBFramebufferVideoConfiguration *)video;
+- (instancetype)withVideo:(FBFramebufferVideoConfiguration *)video;
 
 @end

--- a/FBSimulatorControl/FBSimulatorControl.h
+++ b/FBSimulatorControl/FBSimulatorControl.h
@@ -24,6 +24,7 @@
 #import <FBSimulatorControl/FBFramebufferDebugWindow.h>
 #import <FBSimulatorControl/FBFramebufferDelegate.h>
 #import <FBSimulatorControl/FBFramebufferVideo.h>
+#import <FBSimulatorControl/FBFramebufferVideoConfiguration.h>
 #import <FBSimulatorControl/FBInteraction.h>
 #import <FBSimulatorControl/FBJSONSerializationDescribeable.h>
 #import <FBSimulatorControl/FBMutableSimulatorEventSink.h>

--- a/FBSimulatorControl/Framebuffer/FBFramebufferVideo.h
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferVideo.h
@@ -11,7 +11,7 @@
 
 #import <FBSimulatorControl/FBFramebufferDelegate.h>
 
-@class FBDiagnostic;
+@class FBFramebufferVideoConfiguration;
 @protocol FBSimulatorLogger;
 @protocol FBSimulatorEventSink;
 
@@ -26,13 +26,12 @@
 /**
  Creates a new FBFramebufferVideo instance.
 
- @param diagnostic the log to base the video file from.
- @param autorecord whether the the instance shoud start recording when it recieves it's first frame.
+ @param configuration the configuration to use for encoding.
  @param logger the logger object to log events to, may be nil.
  @param eventSink an event sink to report video output to.
  @return a new FBFramebufferVideo instance.
  */
-+ (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic shouldAutorecord:(BOOL)autorecord logger:(id<FBSimulatorLogger>)logger eventSink:(id<FBSimulatorEventSink>)eventSink;
++ (instancetype)withConfiguration:(FBFramebufferVideoConfiguration *)configuration logger:(id<FBSimulatorLogger>)logger eventSink:(id<FBSimulatorEventSink>)eventSink;
 
 /**
  Starts Recording Video.

--- a/FBSimulatorControl/Framebuffer/FBSimulatorFramebuffer.m
+++ b/FBSimulatorControl/Framebuffer/FBSimulatorFramebuffer.m
@@ -21,9 +21,10 @@
 #import "FBFramebufferCompositeDelegate.h"
 #import "FBFramebufferDebugWindow.h"
 #import "FBFramebufferDelegate.h"
-#import "FBFramebufferImage.h"
 #import "FBFramebufferFrame.h"
+#import "FBFramebufferImage.h"
 #import "FBFramebufferVideo.h"
+#import "FBFramebufferVideoConfiguration.h"
 #import "FBSimulator.h"
 #import "FBSimulatorDiagnostics.h"
 #import "FBSimulatorEventSink.h"
@@ -72,8 +73,8 @@ static const CMTimeRoundingMethod FBSimulatorFramebufferRoundingMethod = kCMTime
     [sinks addObject:[FBFramebufferDebugWindow withName:@"Simulator"]];
   }
 
-  BOOL autorecord = (launchConfiguration.options & FBSimulatorLaunchOptionsRecordVideo) == FBSimulatorLaunchOptionsRecordVideo;
-  FBFramebufferVideo *video = [FBFramebufferVideo withDiagnostic:simulator.diagnostics.video shouldAutorecord:autorecord logger:logger eventSink:simulator.eventSink];
+  FBFramebufferVideoConfiguration *videoConfiguration = [launchConfiguration.video withDiagnostic:simulator.diagnostics.video];
+  FBFramebufferVideo *video = [FBFramebufferVideo withConfiguration:videoConfiguration logger:logger eventSink:simulator.eventSink];
   [sinks addObject:video];
 
   [sinks addObject:[FBFramebufferImage withDiagnostic:simulator.diagnostics.screenshot eventSink:simulator.eventSink]];

--- a/FBSimulatorControl/Management/FBSimulatorBridge.h
+++ b/FBSimulatorControl/Management/FBSimulatorBridge.h
@@ -54,4 +54,11 @@
  */
 - (void)setLocationWithLatitude:(double)latitude longitude:(double)longitude;
 
+#pragma mark Properties
+
+/**
+ The FBSimulatorFramebuffer Instance.
+ */
+@property (nonatomic, strong, readonly) FBSimulatorFramebuffer *framebuffer;
+
 @end

--- a/FBSimulatorControl/Management/FBSimulatorBridge.m
+++ b/FBSimulatorControl/Management/FBSimulatorBridge.m
@@ -27,7 +27,6 @@
 @property (nonatomic, strong, readonly) id<FBSimulatorEventSink> eventSink;
 @property (nonatomic, strong, readonly) dispatch_group_t teardownGroup;
 
-@property (nonatomic, strong, readwrite) FBSimulatorFramebuffer *framebuffer;
 @property (nonatomic, assign, readwrite) mach_port_t hidPort;
 @property (nonatomic, strong, readwrite) id<SimulatorBridge> bridge;
 

--- a/FBSimulatorControlTests/Tests/FBFramebufferVideoConfigurationTests.m
+++ b/FBSimulatorControlTests/Tests/FBFramebufferVideoConfigurationTests.m
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <FBSimulatorControl/FBSimulatorControl.h>
+
+@interface FBFramebufferVideoConfigurationTests : XCTestCase
+
+@end
+
+@implementation FBFramebufferVideoConfigurationTests
+
+- (void)testEqualityOfCopy
+{
+  FBFramebufferVideoConfiguration *config = [[[FBFramebufferVideoConfiguration withAutorecord:YES] withRoundingMethod:kCMTimeRoundingMethod_RoundTowardZero] withFileType:@"foo"];
+  FBFramebufferVideoConfiguration *configCopy = [config copy];
+
+  XCTAssertEqualObjects(config, configCopy);
+}
+
+- (void)testUnarchiving
+{
+  FBFramebufferVideoConfiguration *config = [[[FBFramebufferVideoConfiguration withAutorecord:NO] withRoundingMethod:kCMTimeRoundingMethod_RoundTowardNegativeInfinity] withFileType:@"bar"];
+  NSData *configData = [NSKeyedArchiver archivedDataWithRootObject:config];
+  FBFramebufferVideoConfiguration *configUnarchived = [NSKeyedUnarchiver unarchiveObjectWithData:configData];
+
+  XCTAssertEqualObjects(config, configUnarchived);
+}
+
+@end

--- a/FBSimulatorControlTests/Tests/FBSimulatorLaunchConfigurationTests.m
+++ b/FBSimulatorControlTests/Tests/FBSimulatorLaunchConfigurationTests.m
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <FBSimulatorControl/FBSimulatorControl.h>
+
+@interface FBSimulatorLaunchConfigurationTests : XCTestCase
+
+@end
+
+@implementation FBSimulatorLaunchConfigurationTests
+
+- (FBSimulatorLaunchConfiguration *)configuration
+{
+  return [[[FBSimulatorLaunchConfiguration
+    withLocaleNamed:@"en_US"]
+    withOptions:FBSimulatorLaunchOptionsShowDebugWindow]
+    scale75Percent];
+}
+
+- (void)testEqualityOfCopy
+{
+  FBSimulatorLaunchConfiguration *config = self.configuration;
+  FBSimulatorLaunchConfiguration *configCopy = [config copy];
+
+  XCTAssertEqual(config.options, configCopy.options);
+  XCTAssertEqualObjects(config, configCopy);
+}
+
+- (void)testUnarchiving
+{
+  FBSimulatorLaunchConfiguration *config = self.configuration;
+  NSData *configData = [NSKeyedArchiver archivedDataWithRootObject:config];
+  FBSimulatorLaunchConfiguration *configUnarchived = [NSKeyedUnarchiver unarchiveObjectWithData:configData];
+
+  XCTAssertEqual(config.options, configUnarchived.options);
+  XCTAssertEqualObjects(config, configUnarchived);
+}
+
+@end

--- a/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
@@ -110,13 +110,13 @@ static NSString *const DirectLaunchRecordVideoKey = @"FBSIMULATORCONTROL_RECORD_
   return YES;
 }
 
-+ (BOOL)recordVideo
++ (FBFramebufferVideoConfiguration *)defaultVideoConfiguration
 {
   NSString *value = NSProcessInfo.processInfo.environment[DirectLaunchRecordVideoKey];
   if (value && value.boolValue == NO) {
-    return NO;
+    return [FBFramebufferVideoConfiguration withAutorecord:YES];
   }
-  return YES;
+  return [FBFramebufferVideoConfiguration withAutorecord:NO];
 }
 
 + (NSString *)defaultDeviceSetPath
@@ -132,10 +132,7 @@ static NSString *const DirectLaunchRecordVideoKey = @"FBSIMULATORCONTROL_RECORD_
 {
   if (self.useDirectLaunching) {
     FBSimulatorLaunchOptions options = FBSimulatorLaunchOptionsEnableDirectLaunch;
-    if (self.recordVideo) {
-      options = (options | FBSimulatorLaunchOptionsRecordVideo);
-    }
-    return [FBSimulatorLaunchConfiguration withOptions:options];
+    return [[FBSimulatorLaunchConfiguration withOptions:options] withVideo:self.defaultVideoConfiguration];
   }
   return FBSimulatorLaunchConfiguration.defaultConfiguration;
 }

--- a/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
@@ -68,6 +68,7 @@ public enum Action {
   case Launch(FBProcessLaunchConfiguration)
   case List
   case Listen(Server)
+  case Record(Bool)
   case Relaunch(FBApplicationLaunchConfiguration)
   case Shutdown
   case Terminate(String)
@@ -107,6 +108,8 @@ public func == (left: Action, right: Action) -> Bool {
     return true
   case (.Listen(let leftServer), .Listen(let rightServer)):
     return leftServer == rightServer
+  case (.Record(let leftStart), .Record(let rightStart)):
+    return leftStart == rightStart
   case (.Relaunch(let leftLaunch), .Relaunch(let rightLaunch)):
     return leftLaunch == rightLaunch
   case (.Shutdown, .Shutdown):

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -244,6 +244,7 @@ extension Action : Parsable {
         self.launchParser,
         self.listenParser,
         self.listParser,
+        self.recordParser,
         self.relaunchParser,
         self.shutdownParser,
         self.terminateParser
@@ -304,6 +305,15 @@ extension Action : Parsable {
     return Parser
       .succeeded(EventName.Relaunch.rawValue, self.appLaunchParser)
       .fmap { Action.Relaunch($0 as! FBApplicationLaunchConfiguration) }
+  }}
+
+  static var recordParser: Parser<Action> { get {
+    return Parser
+      .succeeded(EventName.Record.rawValue, Parser.alternative([
+        Parser.ofString("start", true),
+        Parser.ofString("stop", false)
+      ]))
+      .fmap { Action.Record($0) }
   }}
 
   static var shutdownParser: Parser<Action> { get {

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -472,7 +472,7 @@ struct FBSimulatorConfigurationParser {
 
 /**
  A separate struct for FBSimulatorLaunchConfigurationParser is needed as Parsable protcol conformance cannot be
- applied to FBSimulatorLaunchConfigurationParser as it is a non-final.
+ applied to FBSimulatorLaunchConfiguration as it is a non-final class.
  */
 struct FBSimulatorLaunchConfigurationParser {
   static var parser: Parser<FBSimulatorLaunchConfiguration> { get {
@@ -518,7 +518,6 @@ struct FBSimulatorLaunchConfigurationParser {
     return Parser<FBSimulatorLaunchOptions>
       .unionOptions(1, [
         Parser.ofString("--direct-launch", FBSimulatorLaunchOptions.EnableDirectLaunch),
-        Parser.ofString("--record-video", FBSimulatorLaunchOptions.RecordVideo),
         Parser.ofString("--debug-window", FBSimulatorLaunchOptions.ShowDebugWindow)
       ])
   }}

--- a/fbsimctl/FBSimulatorControlKit/Sources/Events.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Events.swift
@@ -27,6 +27,7 @@ public enum EventName : String {
   case List = "list"
   case Listen = "listen"
   case Query = "query"
+  case Record = "record"
   case Relaunch = "relaunch"
   case Shutdown = "shutdown"
   case Signalled = "signalled"

--- a/fbsimctl/FBSimulatorControlKit/Sources/HttpRelay.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/HttpRelay.swift
@@ -55,6 +55,12 @@ class HttpRelay : Relay {
       ("terminate", { json in
         let bundleID = try json.getValue("bundle_id").getString()
         return Action.Terminate(bundleID)
+      }),
+      ("record_start", { json in
+        return Action.Record(true)
+      }),
+      ("record_stop", { json in
+        return Action.Record(false)
       })
     ])
   }

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -232,6 +232,15 @@ private struct SimulatorRunner : Runner {
           interaction.launchAgent(agentLaunch)
         }
       }
+    case .Record(let start):
+      guard let video = simulator.bridge?.framebuffer?.video else {
+        throw FBSimulatorError.describe("Simulator Does not have a Video Framebuffer").inSimulator(simulator).build()
+      }
+      if start {
+        video.startRecording()
+      } else {
+        video.stopRecording()
+      }
     case .Relaunch(let appLaunch):
       try interactWithSimulator(translator, EventName.Relaunch, appLaunch) { interaction in
         interaction.launchOrRelaunchApplication(appLaunch)

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
@@ -355,6 +355,14 @@ class CommandParserTests : XCTestCase {
     self.assertWithDefaultAction(action, suffix: suffix)
   }
 
+  func testParsesRecordStart() {
+    self.assertWithDefaultAction(Action.Record(true), suffix: ["record", "start"])
+  }
+
+  func testParsesRecordStop() {
+    self.assertWithDefaultAction(Action.Record(false), suffix: ["record", "stop"])
+  }
+
   func testParsesRelaunchAppByBundleID() {
     let action = Action.Relaunch(FBApplicationLaunchConfiguration(bundleID: "com.foo.bar", bundleName: nil, arguments: [], environment: [:]))
     let suffix: [String] = ["relaunch", "com.foo.bar"]

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/CommandParsersTests.swift
@@ -154,8 +154,8 @@ class FBSimulatorLaunchConfigurationTests : XCTestCase {
   func testParsesOptions() {
     self.assertParses(
       FBSimulatorLaunchConfigurationParser.parser,
-      ["--record-video", "--direct-launch"],
-      FBSimulatorLaunchConfiguration.defaultConfiguration().withOptions(FBSimulatorLaunchOptions.RecordVideo.union(FBSimulatorLaunchOptions.EnableDirectLaunch))
+      ["--direct-launch"],
+      FBSimulatorLaunchConfiguration.defaultConfiguration().withOptions(FBSimulatorLaunchOptions.EnableDirectLaunch)
     )
   }
 
@@ -163,7 +163,7 @@ class FBSimulatorLaunchConfigurationTests : XCTestCase {
     self.assertParses(
       FBSimulatorLaunchConfigurationParser.parser,
       ["--locale", "en_GB", "--scale=75", "--direct-launch","--record-video"],
-      FBSimulatorLaunchConfiguration.defaultConfiguration().withLocaleNamed("en_GB").scale75Percent().withOptions(FBSimulatorLaunchOptions.RecordVideo.union(FBSimulatorLaunchOptions.EnableDirectLaunch))
+      FBSimulatorLaunchConfiguration.defaultConfiguration().withLocaleNamed("en_GB").scale75Percent().withOptions(FBSimulatorLaunchOptions.EnableDirectLaunch)
     )
   }
 }
@@ -382,10 +382,10 @@ class CommandParserTests : XCTestCase {
   }
 
   func testParsesListBootListenShutdownDiagnose() {
-    let launchConfiguration = FBSimulatorLaunchConfiguration.withOptions(FBSimulatorLaunchOptions.EnableDirectLaunch.union(FBSimulatorLaunchOptions.RecordVideo))
+    let launchConfiguration = FBSimulatorLaunchConfiguration.withOptions(FBSimulatorLaunchOptions.EnableDirectLaunch)
     let simulatorConfiguration = FBSimulatorConfiguration.iPhone5()
     let actions: [Action] = [Action.List, Action.Create(simulatorConfiguration), Action.Boot(launchConfiguration), Action.Listen(Server.Http(8090)), Action.Shutdown, Action.Diagnose]
-    let suffix: [String] = ["list", "create", "iPhone 5", "boot", "--direct-launch", "--record-video", "listen", "--http", "8090", "shutdown", "diagnose"]
+    let suffix: [String] = ["list", "create", "iPhone 5", "boot", "--direct-launch", "listen", "--http", "8090", "shutdown", "diagnose"]
     self.assertWithDefaultActions(actions, suffix: suffix)
   }
 


### PR DESCRIPTION
Sadly, it looks like there are still issues with encoding when using `AVFileTypeMPEG4`. Instead of messing around with this in master until we find the sweet spot, it makes more sense to be able to manipulate the configuration of video encoding in clients that care about this. `FBFramebufferVideoConfiguration` takes on this role.

Additionally the `--record-video` flag disappears and can be replaced with `record start` by chaining interactions in `fbsimctl`.