### PR TITLE
Rename FBSimulatorFramebuffer to FBFramebuffer

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -30,8 +30,8 @@
 		AA3FD0361C87594E001093CA /* FBFramebufferVideoConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA3FD0351C87594E001093CA /* FBFramebufferVideoConfigurationTests.m */; };
 		AA3FD0381C875A96001093CA /* FBSimulatorLaunchConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA3FD0371C875A96001093CA /* FBSimulatorLaunchConfigurationTests.m */; };
 		AA4242EA1C528338008ABD80 /* FBFramebufferDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4242DF1C528338008ABD80 /* FBFramebufferDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AA4242ED1C528338008ABD80 /* FBSimulatorFramebuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4242E21C528338008ABD80 /* FBSimulatorFramebuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AA4242EE1C528338008ABD80 /* FBSimulatorFramebuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = AA4242E31C528338008ABD80 /* FBSimulatorFramebuffer.m */; };
+		AA4242ED1C528338008ABD80 /* FBFramebuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4242E21C528338008ABD80 /* FBFramebuffer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA4242EE1C528338008ABD80 /* FBFramebuffer.m in Sources */ = {isa = PBXBuildFile; fileRef = AA4242E31C528338008ABD80 /* FBFramebuffer.m */; };
 		AA4242F11C529145008ABD80 /* FBFramebufferCompositeDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4242EF1C529145008ABD80 /* FBFramebufferCompositeDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA4242F21C529145008ABD80 /* FBFramebufferCompositeDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = AA4242F01C529145008ABD80 /* FBFramebufferCompositeDelegate.m */; };
 		AA4242F91C529280008ABD80 /* FBFramebufferDebugWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = AA4242F71C52927F008ABD80 /* FBFramebufferDebugWindow.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -276,8 +276,8 @@
 		AA3FD0351C87594E001093CA /* FBFramebufferVideoConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBFramebufferVideoConfigurationTests.m; sourceTree = "<group>"; };
 		AA3FD0371C875A96001093CA /* FBSimulatorLaunchConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorLaunchConfigurationTests.m; sourceTree = "<group>"; };
 		AA4242DF1C528338008ABD80 /* FBFramebufferDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBFramebufferDelegate.h; sourceTree = "<group>"; };
-		AA4242E21C528338008ABD80 /* FBSimulatorFramebuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorFramebuffer.h; sourceTree = "<group>"; };
-		AA4242E31C528338008ABD80 /* FBSimulatorFramebuffer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorFramebuffer.m; sourceTree = "<group>"; };
+		AA4242E21C528338008ABD80 /* FBFramebuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBFramebuffer.h; sourceTree = "<group>"; };
+		AA4242E31C528338008ABD80 /* FBFramebuffer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBFramebuffer.m; sourceTree = "<group>"; };
 		AA4242EF1C529145008ABD80 /* FBFramebufferCompositeDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBFramebufferCompositeDelegate.h; sourceTree = "<group>"; };
 		AA4242F01C529145008ABD80 /* FBFramebufferCompositeDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBFramebufferCompositeDelegate.m; sourceTree = "<group>"; };
 		AA4242F71C52927F008ABD80 /* FBFramebufferDebugWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBFramebufferDebugWindow.h; sourceTree = "<group>"; };
@@ -1056,6 +1056,8 @@
 		AA4242D81C528338008ABD80 /* Framebuffer */ = {
 			isa = PBXGroup;
 			children = (
+				AA4242E21C528338008ABD80 /* FBFramebuffer.h */,
+				AA4242E31C528338008ABD80 /* FBFramebuffer.m */,
 				AA4242EF1C529145008ABD80 /* FBFramebufferCompositeDelegate.h */,
 				AA4242F01C529145008ABD80 /* FBFramebufferCompositeDelegate.m */,
 				AA4242F71C52927F008ABD80 /* FBFramebufferDebugWindow.h */,
@@ -1067,8 +1069,6 @@
 				AABD8DF81C592DBA008527CD /* FBFramebufferImage.m */,
 				AA4242FB1C529366008ABD80 /* FBFramebufferVideo.h */,
 				AA4242FC1C529366008ABD80 /* FBFramebufferVideo.m */,
-				AA4242E21C528338008ABD80 /* FBSimulatorFramebuffer.h */,
-				AA4242E31C528338008ABD80 /* FBSimulatorFramebuffer.m */,
 			);
 			path = Framebuffer;
 			sourceTree = "<group>";
@@ -2062,7 +2062,7 @@
 				AA1D653E1C21A9690069F90D /* FBCollectionDescriptions.h in Headers */,
 				AA79A1CE1C7766ED00D5C685 /* FBSimulatorSet+Private.h in Headers */,
 				AA4242F11C529145008ABD80 /* FBFramebufferCompositeDelegate.h in Headers */,
-				AA4242ED1C528338008ABD80 /* FBSimulatorFramebuffer.h in Headers */,
+				AA4242ED1C528338008ABD80 /* FBFramebuffer.h in Headers */,
 				AA95177F1C15F54600A89CAD /* FBSimulator.h in Headers */,
 				AA9517551C15F54600A89CAD /* FBSimulatorControlGlobalConfiguration.h in Headers */,
 				AA9517B61C15F54600A89CAD /* FBSimDeviceWrapper.h in Headers */,
@@ -2208,7 +2208,7 @@
 			files = (
 				AA78DCDB1C5005D2006FAB41 /* FBSimulatorLaunchCtl.m in Sources */,
 				AA1D65431C21B38D0069F90D /* FBCrashLogInfo.m in Sources */,
-				AA4242EE1C528338008ABD80 /* FBSimulatorFramebuffer.m in Sources */,
+				AA4242EE1C528338008ABD80 /* FBFramebuffer.m in Sources */,
 				AA9517521C15F54600A89CAD /* FBSimulatorConfiguration.m in Sources */,
 				AA9517541C15F54600A89CAD /* FBSimulatorControlConfiguration.m in Sources */,
 				AA9517881C15F54600A89CAD /* FBSimulatorPredicates.m in Sources */,

--- a/FBSimulatorControl/FBSimulatorControl.h
+++ b/FBSimulatorControl/FBSimulatorControl.h
@@ -20,6 +20,7 @@
 #import <FBSimulatorControl/FBDebugDescribeable.h>
 #import <FBSimulatorControl/FBDiagnostic.h>
 #import <FBSimulatorControl/FBDispatchSourceNotifier.h>
+#import <FBSimulatorControl/FBFramebuffer.h>
 #import <FBSimulatorControl/FBFramebufferCompositeDelegate.h>
 #import <FBSimulatorControl/FBFramebufferDebugWindow.h>
 #import <FBSimulatorControl/FBFramebufferDelegate.h>
@@ -53,7 +54,6 @@
 #import <FBSimulatorControl/FBSimulatorError.h>
 #import <FBSimulatorControl/FBSimulatorEventRelay.h>
 #import <FBSimulatorControl/FBSimulatorEventSink.h>
-#import <FBSimulatorControl/FBSimulatorFramebuffer.h>
 #import <FBSimulatorControl/FBSimulatorHistory+Private.h>
 #import <FBSimulatorControl/FBSimulatorHistory+Queries.h>
 #import <FBSimulatorControl/FBSimulatorHistory.h>

--- a/FBSimulatorControl/Framebuffer/FBFramebuffer.h
+++ b/FBSimulatorControl/Framebuffer/FBFramebuffer.h
@@ -23,7 +23,7 @@
  The class itself doesn't perform much behaviour other than to manage the lifecycle.
  Implementors of FBFramebufferDelegate perform individual behaviours such as recording videos and images.
  */
-@interface FBSimulatorFramebuffer : NSObject <FBJSONSerializationDescribeable>
+@interface FBFramebuffer : NSObject <FBJSONSerializationDescribeable>
 
 /**
  Creates and returns a new FBSimulatorDirectLaunch object for the provided SimDeviceFramebufferService.

--- a/FBSimulatorControl/Framebuffer/FBFramebuffer.m
+++ b/FBSimulatorControl/Framebuffer/FBFramebuffer.m
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import "FBSimulatorFramebuffer.h"
+#import "FBFramebuffer.h"
 
 #import <mach/exc.h>
 #import <mach/mig.h>
@@ -46,7 +46,7 @@ static const NSInteger FBFramebufferLogFrameFrequency = 100;
 static const CMTimeScale FBSimulatorFramebufferTimescale = 10E8;
 static const CMTimeRoundingMethod FBSimulatorFramebufferRoundingMethod = kCMTimeRoundingMethod_Default;
 
-@interface FBSimulatorFramebuffer ()
+@interface FBFramebuffer ()
 
 @property (nonatomic, strong, readonly) SimDeviceFramebufferService *framebufferService;
 @property (nonatomic, strong, readonly) id<FBSimulatorLogger> logger;
@@ -60,7 +60,7 @@ static const CMTimeRoundingMethod FBSimulatorFramebufferRoundingMethod = kCMTime
 
 @end
 
-@implementation FBSimulatorFramebuffer
+@implementation FBFramebuffer
 
 #pragma mark Initializers
 
@@ -113,7 +113,7 @@ static const CMTimeRoundingMethod FBSimulatorFramebufferRoundingMethod = kCMTime
 {
   return [NSString stringWithFormat:
     @"%@ | Size %@ | Frame Count %ld",
-    [FBSimulatorFramebuffer stringFromFramebufferState:self.state],
+    [FBFramebuffer stringFromFramebufferState:self.state],
     NSStringFromSize(self.size),
     self.frameCount
   ];
@@ -153,7 +153,7 @@ static const CMTimeRoundingMethod FBSimulatorFramebufferRoundingMethod = kCMTime
   });
 }
 
-- (void)framebufferDidBecomeInvalid:(FBSimulatorFramebuffer *)framebuffer error:(NSError *)error
+- (void)framebufferDidBecomeInvalid:(FBFramebuffer *)framebuffer error:(NSError *)error
 {
   dispatch_group_t teardownGroup = dispatch_group_create();
   [self framebufferDidBecomeInvalid:framebuffer error:error teardownGroup:teardownGroup];
@@ -207,7 +207,7 @@ static const CMTimeRoundingMethod FBSimulatorFramebufferRoundingMethod = kCMTime
   [self.logger.info logFormat:@"Frame Count %lu", self.frameCount];
 }
 
-- (void)framebufferDidBecomeInvalid:(FBSimulatorFramebuffer *)framebuffer error:(NSError *)error teardownGroup:(dispatch_group_t)teardownGroup
+- (void)framebufferDidBecomeInvalid:(FBFramebuffer *)framebuffer error:(NSError *)error teardownGroup:(dispatch_group_t)teardownGroup
 {
   if (self.state != FBSimulatorFramebufferStateStarting && self.state != FBSimulatorFramebufferStateRunning) {
     return;

--- a/FBSimulatorControl/Framebuffer/FBFramebufferCompositeDelegate.m
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferCompositeDelegate.m
@@ -36,14 +36,14 @@
 
 #pragma mark FBFramebufferDelegate Implementation
 
-- (void)framebuffer:(FBSimulatorFramebuffer *)framebuffer didUpdate:(FBFramebufferFrame *)frame
+- (void)framebuffer:(FBFramebuffer *)framebuffer didUpdate:(FBFramebufferFrame *)frame
 {
   for (id<FBFramebufferDelegate> delegate in self.delegates) {
     [delegate framebuffer:framebuffer didUpdate:frame];
   }
 }
 
-- (void)framebuffer:(FBSimulatorFramebuffer *)framebuffer didBecomeInvalidWithError:(NSError *)error teardownGroup:(dispatch_group_t)teardownGroup
+- (void)framebuffer:(FBFramebuffer *)framebuffer didBecomeInvalidWithError:(NSError *)error teardownGroup:(dispatch_group_t)teardownGroup
 {
   for (id<FBFramebufferDelegate> delegate in self.delegates) {
     [delegate framebuffer:framebuffer didBecomeInvalidWithError:error teardownGroup:teardownGroup];

--- a/FBSimulatorControl/Framebuffer/FBFramebufferDebugWindow.m
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferDebugWindow.m
@@ -52,7 +52,7 @@
 
 #pragma mark FBFramebufferDelegate Implementation
 
-- (void)framebuffer:(FBSimulatorFramebuffer *)framebuffer didUpdate:(FBFramebufferFrame *)frame
+- (void)framebuffer:(FBFramebuffer *)framebuffer didUpdate:(FBFramebufferFrame *)frame
 {
   dispatch_async(dispatch_get_main_queue(), ^{
     if (frame.count == 0) {
@@ -62,7 +62,7 @@
   });
 }
 
-- (void)framebuffer:(FBSimulatorFramebuffer *)framebuffer didBecomeInvalidWithError:(NSError *)error teardownGroup:(dispatch_group_t)teardownGroup
+- (void)framebuffer:(FBFramebuffer *)framebuffer didBecomeInvalidWithError:(NSError *)error teardownGroup:(dispatch_group_t)teardownGroup
 {
   [self teardownWindow];
 }

--- a/FBSimulatorControl/Framebuffer/FBFramebufferDelegate.h
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferDelegate.h
@@ -12,7 +12,7 @@
 #import <Foundation/Foundation.h>
 
 @class FBFramebufferFrame;
-@class FBSimulatorFramebuffer;
+@class FBFramebuffer;
 
 /**
  A Delegate for updates from a Simulator's Framebuffer.
@@ -24,7 +24,7 @@
 
  @param frame the updated frame.
  */
-- (void)framebuffer:(FBSimulatorFramebuffer *)framebuffer didUpdate:(FBFramebufferFrame *)frame;
+- (void)framebuffer:(FBFramebuffer *)framebuffer didUpdate:(FBFramebufferFrame *)frame;
 
 /**
  Called when the framebuffer is no longer valid, typically when the Simulator shuts down.
@@ -33,6 +33,6 @@
  @param error an error, if any occured in the teardown of the simulator.
  @param teardownGroup a dispatch_group to add asynchronous tasks to that should be performed in the teardown of the Framebuffer.
  */
-- (void)framebuffer:(FBSimulatorFramebuffer *)framebuffer didBecomeInvalidWithError:(NSError *)error teardownGroup:(dispatch_group_t)teardownGroup;
+- (void)framebuffer:(FBFramebuffer *)framebuffer didBecomeInvalidWithError:(NSError *)error teardownGroup:(dispatch_group_t)teardownGroup;
 
 @end

--- a/FBSimulatorControl/Framebuffer/FBFramebufferImage.m
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferImage.m
@@ -69,12 +69,12 @@
 
 #pragma mark FBFramebufferCounterDelegate Implementation
 
-- (void)framebuffer:(FBSimulatorFramebuffer *)framebuffer didUpdate:(FBFramebufferFrame *)frame
+- (void)framebuffer:(FBFramebuffer *)framebuffer didUpdate:(FBFramebufferFrame *)frame
 {
   self.lastFrame = frame;
 }
 
-- (void)framebuffer:(FBSimulatorFramebuffer *)framebuffer didBecomeInvalidWithError:(NSError *)error teardownGroup:(dispatch_group_t)teardownGroup
+- (void)framebuffer:(FBFramebuffer *)framebuffer didBecomeInvalidWithError:(NSError *)error teardownGroup:(dispatch_group_t)teardownGroup
 {
   FBDiagnostic *diagnostic = [FBFramebufferImage appendImage:self.lastFrame.image toDiagnostic:self.diagnostic];
   id<FBSimulatorEventSink> eventSink = self.eventSink;

--- a/FBSimulatorControl/Framebuffer/FBFramebufferVideo.m
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferVideo.m
@@ -114,7 +114,7 @@ static const OSType FBFramebufferPixelFormat = kCVPixelFormatType_32ARGB;
 
 #pragma mark FBFramebufferDelegate Implementation
 
-- (void)framebuffer:(FBSimulatorFramebuffer *)framebuffer didUpdate:(FBFramebufferFrame *)frame
+- (void)framebuffer:(FBFramebuffer *)framebuffer didUpdate:(FBFramebufferFrame *)frame
 {
   dispatch_async(self.mediaQueue, ^{
     // Push the image, converting to the new timebase.
@@ -122,7 +122,7 @@ static const OSType FBFramebufferPixelFormat = kCVPixelFormatType_32ARGB;
   });
 }
 
-- (void)framebuffer:(FBSimulatorFramebuffer *)framebuffer didBecomeInvalidWithError:(NSError *)error teardownGroup:(dispatch_group_t)teardownGroup
+- (void)framebuffer:(FBFramebuffer *)framebuffer didBecomeInvalidWithError:(NSError *)error teardownGroup:(dispatch_group_t)teardownGroup
 {
   dispatch_group_enter(teardownGroup);
   dispatch_barrier_async(self.mediaQueue, ^{

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.m
@@ -34,7 +34,7 @@
 #import "FBSimulatorControlGlobalConfiguration.h"
 #import "FBSimulatorError.h"
 #import "FBSimulatorEventSink.h"
-#import "FBSimulatorFramebuffer.h"
+#import "FBFramebuffer.h"
 #import "FBSimulatorInteraction+Private.h"
 #import "FBSimulatorLaunchConfiguration+Helpers.h"
 #import "FBSimulatorLaunchConfiguration.h"

--- a/FBSimulatorControl/Management/FBSimulatorBridge.h
+++ b/FBSimulatorControl/Management/FBSimulatorBridge.h
@@ -12,7 +12,7 @@
 #import <FBSimulatorControl/FBJSONSerializationDescribeable.h>
 
 @class FBSimulator;
-@class FBSimulatorFramebuffer;
+@class FBFramebuffer;
 @class FBSimulatorLaunchConfiguration;
 
 /**
@@ -59,6 +59,6 @@
 /**
  The FBSimulatorFramebuffer Instance.
  */
-@property (nonatomic, strong, readonly) FBSimulatorFramebuffer *framebuffer;
+@property (nonatomic, strong, readonly) FBFramebuffer *framebuffer;
 
 @end

--- a/FBSimulatorControl/Management/FBSimulatorBridge.m
+++ b/FBSimulatorControl/Management/FBSimulatorBridge.m
@@ -19,7 +19,7 @@
 #import "FBSimulator.h"
 #import "FBSimulatorError.h"
 #import "FBSimulatorEventSink.h"
-#import "FBSimulatorFramebuffer.h"
+#import "FBFramebuffer.h"
 #import "FBSimulatorLaunchConfiguration.h"
 
 @interface FBSimulatorBridge ()
@@ -134,7 +134,7 @@
   // Create and start the consumer of the Framebuffer Service.
   // The launch configuration will define the way that the Framebuffer is consumed.
   // Then the simulator's event sink should be notified with the created framebuffer object.
-  FBSimulatorFramebuffer *framebuffer = [FBSimulatorFramebuffer withFramebufferService:framebufferService configuration:configuration simulator:simulator];
+  FBFramebuffer *framebuffer = [FBFramebuffer withFramebufferService:framebufferService configuration:configuration simulator:simulator];
   [framebuffer startListeningInBackground];
 
   // Create the bridge and broadcast the availability
@@ -144,7 +144,7 @@
   return bridge;
 }
 
-- (instancetype)initWithFramebuffer:(FBSimulatorFramebuffer *)framebuffer hidPort:(mach_port_t)hidPort bridge:(id<SimulatorBridge>)bridge eventSink:(id<FBSimulatorEventSink>)eventSink
+- (instancetype)initWithFramebuffer:(FBFramebuffer *)framebuffer hidPort:(mach_port_t)hidPort bridge:(id<SimulatorBridge>)bridge eventSink:(id<FBSimulatorEventSink>)eventSink
 {
   self = [super init];
   if (!self) {


### PR DESCRIPTION
All the the other Frambuffer classes (including the delegate) begin with `FBFramebuffer` so the container object should too.