### PR TITLE
Record Start/Stop of video with JSON Payload

### DIFF
--- a/fbsimctl/FBSimulatorControlKit/Sources/HttpRelay.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/HttpRelay.swift
@@ -56,12 +56,10 @@ class HttpRelay : Relay {
         let bundleID = try json.getValue("bundle_id").getString()
         return Action.Terminate(bundleID)
       }),
-      ("record_start", { json in
-        return Action.Record(true)
+      ("record", { json in
+        let start = try json.getValue("start").getBool()
+        return Action.Record(start)
       }),
-      ("record_stop", { json in
-        return Action.Record(false)
-      })
     ])
   }
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/JSON.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/JSON.swift
@@ -166,6 +166,15 @@ extension JSON {
     }
   }
 
+  func getBool() throws -> Bool {
+    switch self {
+    case .JNumber(let number):
+      return number.boolValue
+    default:
+      throw JSONError.Parse("\(self) is not a number/boolean")
+    }
+  }
+
   func getArrayOfStrings() throws -> [String] {
     return try self.getArray().map { try $0.getString() }
   }


### PR DESCRIPTION
Having separate endpoints for each action seems a little sad, so we can now parse numbers as bools and use this to flip the `Action.Record` action.

`NSJSONSerialization` represents Bools as `NSNumber` so all numbers can be interpreted as bools :/