### PR TITLE
Add FBFramebufferVideoOptions

### DIFF
--- a/FBSimulatorControl/Configuration/FBFramebufferVideoConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBFramebufferVideoConfiguration.h
@@ -16,7 +16,17 @@
 @class FBDiagnostic;
 
 /**
+ Options for FBFramebufferVideo.
+ */
+typedef NS_OPTIONS(NSUInteger, FBFramebufferVideoOptions) {
+  FBFramebufferVideoOptionsAutorecord = 1 << 0, /** If Set, will automatically start recording when the first video frame is recieved. **/
+  FBFramebufferVideoOptionsImmediateFrameStart = 1 << 1, /** If Set, will start recording a video immediately, using the previously delivered frame **/
+  FBFramebufferVideoOptionsFinalFrame = 1 << 2, /** If Set, will repeat the last frame just before a video is stopped **/
+};
+
+/**
  A Configuration Value for FBFramebufferVideo.
+
  */
 @interface FBFramebufferVideoConfiguration : NSObject <NSCoding, NSCopying, FBJSONSerializationDescribeable, FBDebugDescribeable>
 
@@ -28,7 +38,7 @@
 /**
  YES if the Video Component should automatically record when the first frame comes in.
  */
-@property (nonatomic, assign, readonly) BOOL autorecord;
+@property (nonatomic, assign, readonly) FBFramebufferVideoOptions options;
 
 /**
  The Timescale used in Video Encoding.
@@ -63,23 +73,23 @@
  Creates and Returns a new FBFramebufferVideoConfiguration Value with the provided parameters.
 
  @param diagnostic The Diagnostic Value to determine the video path
- @param autorecord YES if the Video Component should automatically record when the first frame comes in.
+ @param options The Flags for FBFramebufferVideo.
  @param timescale The Timescale used in Video Encoding.
  @param roundingMethod The Rounding Method used for Video Frames.
  @param fileType The FileType of the Video.
  @return a FBFramebufferVideoConfiguration instance.
  */
-+ (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic autorecord:(BOOL)autorecord timescale:(CMTimeScale)timescale roundingMethod:(CMTimeRoundingMethod)roundingMethod fileType:(NSString *)fileType;
++ (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic options:(FBFramebufferVideoOptions)options timescale:(CMTimeScale)timescale roundingMethod:(CMTimeRoundingMethod)roundingMethod fileType:(NSString *)fileType;
 
 #pragma mark Diagnostics
 
 + (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic;
 - (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic;
 
-#pragma mark Autorecord
+#pragma mark Options
 
-- (instancetype)withAutorecord:(BOOL)autorecord;
-+ (instancetype)withAutorecord:(BOOL)autorecord;
+- (instancetype)withOptions:(FBFramebufferVideoOptions)options;
++ (instancetype)withOptions:(FBFramebufferVideoOptions)options;
 
 #pragma mark Timescale
 

--- a/FBSimulatorControl/Configuration/FBFramebufferVideoConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBFramebufferVideoConfiguration.h
@@ -83,26 +83,41 @@ typedef NS_OPTIONS(NSUInteger, FBFramebufferVideoOptions) {
 
 #pragma mark Diagnostics
 
+/**
+ Returns a new Configuration with the Diagnostic Applied.
+ */
 + (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic;
 - (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic;
 
 #pragma mark Options
 
+/**
+ Returns a new Configuration with the Options Applied.
+ */
 - (instancetype)withOptions:(FBFramebufferVideoOptions)options;
 + (instancetype)withOptions:(FBFramebufferVideoOptions)options;
 
 #pragma mark Timescale
 
+/**
+ Returns a new Configuration with the Timescale Applied.
+ */
 - (instancetype)withTimescale:(CMTimeScale)timescale;
 + (instancetype)withTimescale:(CMTimeScale)timescale;
 
 #pragma mark Rounding
 
+/**
+ Returns a new Configuration with the Rounding Method Applied.
+ */
 - (instancetype)withRoundingMethod:(CMTimeRoundingMethod)roundingMethod;
 + (instancetype)withRoundingMethod:(CMTimeRoundingMethod)roundingMethod;
 
 #pragma mark File Type
 
+/**
+ Returns a new Configuration with the File Type Applied.
+ */
 - (instancetype)withFileType:(NSString *)fileType;
 + (instancetype)withFileType:(NSString *)fileType;
 

--- a/FBSimulatorControl/Framebuffer/FBFramebufferVideo.h
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferVideo.h
@@ -35,16 +35,16 @@
 
 /**
  Starts Recording Video.
- If the video is already recording, this call will do nothing.
- Is asynchronous with the caller so the Event Sink will be notified when the video starts recording.
+ 
+ @param group the dispatch_group to put asynchronous work into. When the group's blocks have completed the recording has processed. If nil, an anonymous group will be created.
  */
-- (void)startRecording;
+- (void)startRecording:(dispatch_group_t)group;
 
 /**
  Stops Recording Video.
- If the video is not recording, this call will do nothing.
- Is asynchronous with the caller so the Event Sink will be notified when the video starts recording.
+ 
+ @param group the dispatch_group to put asynchronous work into. When the group's blocks have completed the recording has processed. If nil, an anonymous group will be created.
  */
-- (void)stopRecording;
+- (void)stopRecording:(dispatch_group_t)group;
 
 @end

--- a/FBSimulatorControl/Framebuffer/FBFramebufferVideo.h
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferVideo.h
@@ -35,14 +35,14 @@
 
 /**
  Starts Recording Video.
- 
+
  @param group the dispatch_group to put asynchronous work into. When the group's blocks have completed the recording has processed. If nil, an anonymous group will be created.
  */
 - (void)startRecording:(dispatch_group_t)group;
 
 /**
  Stops Recording Video.
- 
+
  @param group the dispatch_group to put asynchronous work into. When the group's blocks have completed the recording has processed. If nil, an anonymous group will be created.
  */
 - (void)stopRecording:(dispatch_group_t)group;

--- a/FBSimulatorControl/Framebuffer/FBFramebufferVideo.m
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferVideo.m
@@ -72,8 +72,10 @@ static const OSType FBFramebufferPixelFormat = kCVPixelFormatType_32ARGB;
 
   _mediaQueue = queue;
   _frameQueue = [FBCapacityQueue withCapacity:20];
-  _state = configuration.autorecord ? FBFramebufferVideoStateWaitingForFirstFrame : FBFramebufferVideoStateNotStarted;
   _timebase = NULL;
+
+  BOOL autorecord = (configuration.options & FBFramebufferVideoOptionsAutorecord) == FBFramebufferVideoOptionsAutorecord;
+  _state = autorecord ? FBFramebufferVideoStateWaitingForFirstFrame : FBFramebufferVideoStateNotStarted;
 
   return self;
 }

--- a/FBSimulatorControl/Framebuffer/FBFramebufferVideo.m
+++ b/FBSimulatorControl/Framebuffer/FBFramebufferVideo.m
@@ -350,8 +350,8 @@ static const OSType FBFramebufferPixelFormat = kCVPixelFormatType_32ARGB;
     return;
   }
 
-  // Push last frame if one exists.
-  if (self.lastFrame) {
+  // Push last frame if one exists and the flag is set.
+  if (self.pushFinalFrame && self.lastFrame) {
     // Construct a time at the current timebase's time and push it to the queue.
     // Timebase conversion does not need to apply.
     CMTime time = CMTimebaseGetTimeWithTimeScale(self.timebase, self.configuration.timescale, self.configuration.roundingMethod);
@@ -471,6 +471,11 @@ static const OSType FBFramebufferPixelFormat = kCVPixelFormatType_32ARGB;
 - (BOOL)immediateStart
 {
   return (self.configuration.options & FBFramebufferVideoOptionsImmediateFrameStart) == FBFramebufferVideoOptionsImmediateFrameStart;
+}
+
+- (BOOL)pushFinalFrame
+{
+  return (self.configuration.options & FBFramebufferVideoOptionsFinalFrame) == FBFramebufferVideoOptionsFinalFrame;
 }
 
 #pragma mark String Formatting

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.h
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.h
@@ -67,4 +67,18 @@
  */
 - (instancetype)killProcess:(FBProcessInfo *)process;
 
+/**
+ Starts Recording video on the Simulator.
+ The Interaction will always succeed if the Simulator has a FBFramebufferVideo instance.
+ The Interaction will always fail if the Simulator does not have a FBFramebufferVideo instance.
+ */
+- (instancetype)startRecordingVideo;
+
+/**
+ Stops Recording video on the Simulator.
+ The Interaction will always succeed if the Simulator has a FBFramebufferVideo instance.
+ The Interaction will always fail if the Simulator does not have a FBFramebufferVideo instance.
+ */
+- (instancetype)stopRecordingVideo;
+
 @end

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Lifecycle.m
@@ -136,6 +136,22 @@
   return [self signal:SIGKILL process:process];
 }
 
+- (instancetype)startRecordingVideo
+{
+  return [self interactWithVideo:^ BOOL (NSError **error, FBSimulator *simulator, FBFramebufferVideo *video) {
+    [video startRecording];
+    return YES;
+  }];
+}
+
+- (instancetype)stopRecordingVideo
+{
+  return [self interactWithVideo:^ BOOL (NSError **error, FBSimulator *simulator, FBFramebufferVideo *video) {
+    [video stopRecording];
+    return YES;
+  }];
+}
+
 #pragma mark Private
 
 + (BOOL)launchSimulatorDirectly:(FBSimulator *)simulator configuration:(FBSimulatorLaunchConfiguration *)configuration error:(NSError **)error
@@ -278,6 +294,20 @@
   }
 
   return launchdSimProcess;
+}
+
+- (instancetype)interactWithVideo:(BOOL (^)(NSError **error, FBSimulator *simulator, FBFramebufferVideo *video))block
+{
+  return [self interactWithBootedSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
+    FBFramebufferVideo *video = simulator.bridge.framebuffer.video;
+    if (!video) {
+      return [[[FBSimulatorError
+        describe:@"Simulator Does not have a FBFramebufferVideo instance"]
+        inSimulator:simulator]
+        failBool:error];
+    }
+    return block(error, simulator, video);
+  }];
 }
 
 @end

--- a/FBSimulatorControlTests/Tests/Unit/FBConfigurationTests.m
+++ b/FBSimulatorControlTests/Tests/Unit/FBConfigurationTests.m
@@ -33,8 +33,8 @@
 - (NSArray *)videoConfigurations
 {
   return @[
-    [[[FBFramebufferVideoConfiguration withAutorecord:YES] withRoundingMethod:kCMTimeRoundingMethod_RoundTowardZero] withFileType:@"foo"],
-    [[[FBFramebufferVideoConfiguration withAutorecord:NO] withRoundingMethod:kCMTimeRoundingMethod_RoundTowardNegativeInfinity] withFileType:@"bar"]
+    [[[FBFramebufferVideoConfiguration withOptions:FBFramebufferVideoOptionsAutorecord | FBFramebufferVideoOptionsFinalFrame ] withRoundingMethod:kCMTimeRoundingMethod_RoundTowardZero] withFileType:@"foo"],
+    [[[FBFramebufferVideoConfiguration withOptions:FBFramebufferVideoOptionsImmediateFrameStart] withRoundingMethod:kCMTimeRoundingMethod_RoundTowardNegativeInfinity] withFileType:@"bar"]
   ];
 }
 

--- a/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
+++ b/FBSimulatorControlTests/Utilities/FBSimulatorControlTestCase.m
@@ -114,9 +114,9 @@ static NSString *const DirectLaunchRecordVideoKey = @"FBSIMULATORCONTROL_RECORD_
 {
   NSString *value = NSProcessInfo.processInfo.environment[DirectLaunchRecordVideoKey];
   if (value && value.boolValue == NO) {
-    return [FBFramebufferVideoConfiguration withAutorecord:YES];
+    return [FBFramebufferVideoConfiguration withOptions:FBFramebufferVideoOptionsAutorecord | FBFramebufferVideoOptionsImmediateFrameStart | FBFramebufferVideoOptionsFinalFrame];
   }
-  return [FBFramebufferVideoConfiguration withAutorecord:NO];
+  return [FBFramebufferVideoConfiguration withOptions:FBFramebufferVideoOptionsImmediateFrameStart | FBFramebufferVideoOptionsFinalFrame];
 }
 
 + (NSString *)defaultDeviceSetPath

--- a/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Runners.swift
@@ -233,13 +233,12 @@ private struct SimulatorRunner : Runner {
         }
       }
     case .Record(let start):
-      guard let video = simulator.bridge?.framebuffer?.video else {
-        throw FBSimulatorError.describe("Simulator Does not have a Video Framebuffer").inSimulator(simulator).build()
-      }
-      if start {
-        video.startRecording()
-      } else {
-        video.stopRecording()
+      try interactWithSimulator(translator, EventName.Record, simulator) { interaction in
+        if (start) {
+          interaction.startRecordingVideo()
+        } else {
+          interaction.stopRecordingVideo()
+        }
       }
     case .Relaunch(let appLaunch):
       try interactWithSimulator(translator, EventName.Relaunch, appLaunch) { interaction in


### PR DESCRIPTION
There are a number of optional behaviours in `FBFramebufferVideo` that can be switched on and off independently, so they have been given an option Set.

- `FBFramebufferVideoOptionsAutorecord` takes the place of the `autorecord` BOOl on `FBFramebufferConfiguration`
- `FBFramebufferVideoOptionsImmediateFrameStart` will cause the prior frame event to be kept around so that the record can start 'immediately'. The reason for doing this is that if the Simulator is at the home screen the first frame that will be received after the 'waiting for frame' state is set will be changes to the clock (i.e. once per minute) since Springboard doesn't need to redraw until the clock changes.
- `FBFramebufferVideoOptionsFinalFrame` is like the above, but upon stopping the video. By re-pushing the last frame the video will show how long the Simulator sat at a particular 'still frame' for.