### PR TITLE
FBLogSearch & FBBatchLogSearch

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -24,6 +24,9 @@
 		AA2219921C3D868300371B01 /* FBProcessTerminationStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = AA2219901C3D868300371B01 /* FBProcessTerminationStrategy.m */; };
 		AA2219951C3E752800371B01 /* FBCoreSimulatorTerminationStrategy.h in Headers */ = {isa = PBXBuildFile; fileRef = AA2219931C3E752800371B01 /* FBCoreSimulatorTerminationStrategy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA2219961C3E752800371B01 /* FBCoreSimulatorTerminationStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = AA2219941C3E752800371B01 /* FBCoreSimulatorTerminationStrategy.m */; };
+		AA2DE4C61C901A6000F6B646 /* FBLogSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = AA2DE4C41C901A6000F6B646 /* FBLogSearch.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA2DE4C71C901A6000F6B646 /* FBLogSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = AA2DE4C51C901A6000F6B646 /* FBLogSearch.m */; };
+		AA2DE4C91C9030F200F6B646 /* FBLogSearcherTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA2DE4C81C9030F200F6B646 /* FBLogSearcherTests.m */; };
 		AA3230CB1BDA387700C5BA01 /* FBSimulatorControlAssertions.m in Sources */ = {isa = PBXBuildFile; fileRef = AA3230CA1BDA387700C5BA01 /* FBSimulatorControlAssertions.m */; };
 		AA3FD0331C872E26001093CA /* FBFramebufferVideoConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = AA3FD0311C872E26001093CA /* FBFramebufferVideoConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA3FD0341C872E26001093CA /* FBFramebufferVideoConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = AA3FD0321C872E26001093CA /* FBFramebufferVideoConfiguration.m */; };
@@ -267,6 +270,9 @@
 		AA2DDC371C284044000689C6 /* SimRuntime.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SimRuntime.h; sourceTree = "<group>"; };
 		AA2DDC381C284044000689C6 /* SimServiceContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SimServiceContext.h; sourceTree = "<group>"; };
 		AA2DDC391C284044000689C6 /* SimVerifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SimVerifier.h; sourceTree = "<group>"; };
+		AA2DE4C41C901A6000F6B646 /* FBLogSearch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBLogSearch.h; sourceTree = "<group>"; };
+		AA2DE4C51C901A6000F6B646 /* FBLogSearch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBLogSearch.m; sourceTree = "<group>"; };
+		AA2DE4C81C9030F200F6B646 /* FBLogSearcherTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBLogSearcherTests.m; sourceTree = "<group>"; };
 		AA3230C91BDA387700C5BA01 /* FBSimulatorControlAssertions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSimulatorControlAssertions.h; sourceTree = "<group>"; };
 		AA3230CA1BDA387700C5BA01 /* FBSimulatorControlAssertions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSimulatorControlAssertions.m; sourceTree = "<group>"; };
 		AA3FD0311C872E26001093CA /* FBFramebufferVideoConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBFramebufferVideoConfiguration.h; sourceTree = "<group>"; };
@@ -1067,6 +1073,7 @@
 			children = (
 				AA3FD05D1C882685001093CA /* FBConfigurationTests.m */,
 				AA3FD0411C876E4F001093CA /* FBDiagnosticTests.m */,
+				AA2DE4C81C9030F200F6B646 /* FBLogSearcherTests.m */,
 				AA3FD0441C876E4F001093CA /* FBSimulatorApplicationTests.m */,
 				AA3FD0471C876E4F001093CA /* FBSimulatorControlHistoryTests.m */,
 				AA3FD0481C876E4F001093CA /* FBSimulatorHistoryGeneratorTests.m */,
@@ -1845,6 +1852,8 @@
 				AA1D65411C21B38D0069F90D /* FBCrashLogInfo.m */,
 				AA9516F81C15F54600A89CAD /* FBDiagnostic.h */,
 				AA9516F91C15F54600A89CAD /* FBDiagnostic.m */,
+				AA2DE4C41C901A6000F6B646 /* FBLogSearch.h */,
+				AA2DE4C51C901A6000F6B646 /* FBLogSearch.m */,
 				AA9516F51C15F54600A89CAD /* FBSimulatorDiagnostics.h */,
 				AA9516F61C15F54600A89CAD /* FBSimulatorDiagnostics.m */,
 			);
@@ -2097,6 +2106,7 @@
 				AACA2C371C2976B100979C45 /* FBAddVideoPolyfill.h in Headers */,
 				AA9517A51C15F54600A89CAD /* FBTask.h in Headers */,
 				AA4243011C529393008ABD80 /* FBCapacityQueue.h in Headers */,
+				AA2DE4C61C901A6000F6B646 /* FBLogSearch.h in Headers */,
 				AAD4978A1C50F14B00ABC1A7 /* FBMutableSimulatorEventSink.h in Headers */,
 				AA1D65461C21CD2A0069F90D /* FBASLParser.h in Headers */,
 				AAF2D3561C33EA3100434516 /* FBSimulatorInteraction+Lifecycle.h in Headers */,
@@ -2267,6 +2277,7 @@
 				AA1D65471C21CD2A0069F90D /* FBASLParser.m in Sources */,
 				AA95178F1C15F54600A89CAD /* FBSimulatorApplication.m in Sources */,
 				AAF2D3571C33EA3100434516 /* FBSimulatorInteraction+Lifecycle.m in Sources */,
+				AA2DE4C71C901A6000F6B646 /* FBLogSearch.m in Sources */,
 				AA95174F1C15F54600A89CAD /* FBSimulatorConfiguration+CoreSimulator.m in Sources */,
 				AA9517B71C15F54600A89CAD /* FBSimDeviceWrapper.m in Sources */,
 				AA95176F1C15F54600A89CAD /* FBSimulatorInteraction+Setup.m in Sources */,
@@ -2292,6 +2303,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AA2DE4C91C9030F200F6B646 /* FBLogSearcherTests.m in Sources */,
 				AA111CCE1BBE7C5A0054AFDD /* CoreSimulatorDoubles.m in Sources */,
 				AAAA67C61BC4FED200075197 /* FBSimulatorControlFixtures.m in Sources */,
 				AA3FD0501C876E4F001093CA /* FBDiagnosticTests.m in Sources */,

--- a/FBSimulatorControl/Diagnostics/FBDiagnostic.m
+++ b/FBSimulatorControl/Diagnostics/FBDiagnostic.m
@@ -850,7 +850,12 @@
   }
   object_setClass(self.diagnostic, FBDiagnostic_Path.class);
   self.diagnostic.backingFilePath = path;
-  self.diagnostic.fileType = [path pathExtension];
+  if (!self.diagnostic.shortName) {
+    self.diagnostic.shortName = [[path lastPathComponent] stringByDeletingPathExtension];
+  }
+  if (!self.diagnostic.fileType) {
+    self.diagnostic.fileType = [path pathExtension];
+  }
   return self;
 }
 

--- a/FBSimulatorControl/Diagnostics/FBLogSearch.h
+++ b/FBSimulatorControl/Diagnostics/FBLogSearch.h
@@ -38,6 +38,39 @@
 
 @end
 
+/**
+ Defines a model for batch searching diagnostics.
+ This model is then used to concurrently search logs, returning the relevant matches.
+
+ Diagnostics are defined in terms of thier short_name.
+ Logs are defined in terms of Search Predicates.
+ */
+@interface FBBatchLogSearch : NSObject <NSCopying, NSCoding, FBJSONSerializable, FBJSONDeserializable, FBDebugDescribeable>
+
+/**
+ Constructs a Batch Log Search for the provided mapping of log names to predicates.
+ The provided mapping is an NSDictionary where:
+ - The keys are an NSArray of NSStrings of the names of the Logs to search.
+ - The values are an NSArray of FBLogSearchPredicates of the predicates to search the named logs with.
+
+ @param mapping the mapping to search with.
+ @param error an error out for any error in the mapping format.
+ @return an FBBatchLogSearch instance if the mapping is valid, nil otherwise.
+ */
++ (instancetype)withMapping:(NSDictionary *)mapping error:(NSError **)error;
+
+/**
+ Runs the Reciever over an array of Diagnostics.
+ The returned dictionary is a NSDictionary where:
+ - The keys are the log names. A log must have 1 or more matches to have a key.
+ - The values are an NSArrray of NSStrings for the lines that have been matched.
+
+ @param diagnostics an NSArray
+ @return an NSDictionary of valid search results.
+ */
+- (NSDictionary *)search:(NSArray *)diagnostics;
+
+@end
 
 /**
  Wraps FBDiagnostic with Log Searching Abilities.

--- a/FBSimulatorControl/Diagnostics/FBLogSearch.h
+++ b/FBSimulatorControl/Diagnostics/FBLogSearch.h
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <FBSimulatorControl/FBJSONConversion.h>
+#import <FBSimulatorControl/FBDebugDescribeable.h>
+
+@class FBDiagnostic;
+
+/**
+ A Predicate for finding substrings in text.
+ */
+@interface FBLogSearchPredicate : NSObject <NSCopying, NSCoding, FBJSONSerializable, FBJSONDeserializable, FBDebugDescribeable>
+
+/**
+ A predicate that will match a line containing one of the substrings.
+ Substrings cannot contain newline characters.
+ 
+ @param substrings the substrings to search for.
+ @return a Log Search Predicate.
+ */
++ (instancetype)substrings:(NSArray *)substrings;
+
+/**
+ A predicate that will match a line matching the regular expression.
+
+ @param regex a regex that will compile with NSRegularExpression
+ @return a Log Search Predicate.
+ */
++ (instancetype)regex:(NSString *)regex;
+
+@end
+
+
+/**
+ Wraps FBDiagnostic with Log Searching Abilities.
+ */
+@interface FBLogSearch : NSObject
+
+/**
+ Creates a Log Searcher for the given diagnostic.
+ 
+ @param diagnostic the diagnostic to search.
+ @param predicate the predicate to search with.
+ */
++ (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic predicate:(FBLogSearchPredicate *)predicate;
+
+/**
+ Searches the Diagnostic Log, returning the first match.
+ If the Diagnostic is not searchable as text, nil will be returned.
+
+ @return the first line matching the predicate in the diagnostic, nil if nothing was found.
+ */
+- (NSString *)firstMatchingLine;
+
+/**
+ The Diagnostic to Search.
+ */
+@property (nonatomic, copy, readonly) FBDiagnostic *diagnostic;
+
+/**
+ The Predicate to Search with.
+ */
+@property (nonatomic, copy, readonly) FBLogSearchPredicate *predicate;
+
+@end

--- a/FBSimulatorControl/Diagnostics/FBLogSearch.m
+++ b/FBSimulatorControl/Diagnostics/FBLogSearch.m
@@ -1,0 +1,374 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBLogSearch.h"
+
+#import "FBDiagnostic.h"
+#import "FBCollectionInformation.h"
+#import "FBConcurrentCollectionOperations.h"
+#import "FBSimulatorError.h"
+
+#pragma mark - FBLogSearchPredicate
+
+@interface FBLogSearchPredicate_Regex : FBLogSearchPredicate
+
+@property (nonatomic, copy, readonly) NSRegularExpression *regularExpression;
+
+@end
+
+@implementation FBLogSearchPredicate_Regex
+
+- (instancetype)initWithRegularExpression:(NSRegularExpression *)regularExpression
+{
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  _regularExpression = regularExpression;
+
+  return self;
+}
+
+- (BOOL)matchesLine:(NSString *)line
+{
+  if (!self.regularExpression) {
+    return NO;
+  }
+  NSRange range = line.length ? NSMakeRange(0, line.length - 1) : NSMakeRange(0, 0);
+  return [self.regularExpression numberOfMatchesInString:line options:0 range:range] > 0;
+}
+
+#pragma mark NSCoding
+
+- (instancetype)initWithCoder:(NSCoder *)coder
+{
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  _regularExpression = [coder decodeObjectForKey:NSStringFromSelector(@selector(regularExpression))];
+
+  return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder
+{
+  [coder encodeObject:self.regularExpression forKey:NSStringFromSelector(@selector(regularExpression))];
+}
+
+#pragma mark NSCopying
+
+- (instancetype)copyWithZone:(NSZone *)zone
+{
+  return [[FBLogSearchPredicate_Regex alloc] initWithRegularExpression:self.regularExpression];
+}
+
+#pragma mark FBJSONSerializationDescribeable Implementation
+
+- (id)jsonSerializableRepresentation
+{
+  return @{
+    @"regex" : self.regularExpression.pattern ?: NSNull.null
+  };
+}
+
+#pragma mark FBDebugDescribeable Implementation
+
+- (NSString *)shortDescription
+{
+  return [NSString stringWithFormat:@"Of Regex: %@", self.regularExpression.pattern];
+}
+
+#pragma mark NSObject
+
+- (BOOL)isEqual:(FBLogSearchPredicate_Regex *)object
+{
+  if (![object isKindOfClass:self.class]) {
+    return NO;
+  }
+
+  return [self.regularExpression isEqual:object.regularExpression];
+}
+
+- (NSUInteger)hash
+{
+  return self.regularExpression.hash;
+}
+
+@end
+
+@interface FBLogSearchPredicate_Substrings : FBLogSearchPredicate
+
+@property (nonatomic, copy, readonly) NSArray *substrings;
+
+@end
+
+@implementation FBLogSearchPredicate_Substrings
+
+- (instancetype)initWithSubstrings:(NSArray *)substrings
+{
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  _substrings = substrings;
+
+  return self;
+}
+
+- (BOOL)matchesLine:(NSString *)line
+{
+  for (NSString *needle in self.substrings) {
+    if ([line rangeOfString:needle].location == NSNotFound) {
+      continue;
+    }
+    return YES;
+  }
+  return NO;
+}
+
+#pragma mark NSCoding
+
+- (instancetype)initWithCoder:(NSCoder *)coder
+{
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  _substrings = [coder decodeObjectForKey:NSStringFromSelector(@selector(substrings))];
+
+  return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder
+{
+  [coder encodeObject:self.substrings forKey:NSStringFromSelector(@selector(substrings))];
+}
+
+#pragma mark NSCopying
+
+- (instancetype)copyWithZone:(NSZone *)zone
+{
+  return [[FBLogSearchPredicate_Substrings alloc] initWithSubstrings:self.substrings];
+}
+
+#pragma mark FBJSONSerializationDescribeable Implementation
+
+- (id)jsonSerializableRepresentation
+{
+  return @{
+    @"substrings" : self.substrings,
+  };
+}
+
+#pragma mark FBDebugDescribeable Implementation
+
+- (NSString *)shortDescription
+{
+  return [NSString stringWithFormat:@"Of Substrings: %@", [FBCollectionInformation oneLineDescriptionFromArray:self.substrings]];
+}
+
+#pragma mark NSObject
+
+- (BOOL)isEqual:(FBLogSearchPredicate_Substrings *)object
+{
+  if (![object isKindOfClass:self.class]) {
+    return NO;
+  }
+
+  return [self.substrings isEqualToArray:object.substrings];
+}
+
+- (NSUInteger)hash
+{
+  return self.substrings.hash;
+}
+
+@end
+
+@implementation FBLogSearchPredicate
+
+#pragma mark Initializers
+
++ (instancetype)substrings:(NSArray *)substrings
+{
+  return [[FBLogSearchPredicate_Substrings alloc] initWithSubstrings:substrings];
+}
+
++ (instancetype)regex:(NSString *)pattern
+{
+  NSRegularExpression *regex = [NSRegularExpression
+    regularExpressionWithPattern:pattern
+    options:0
+    error:nil];
+  return [[FBLogSearchPredicate_Regex alloc] initWithRegularExpression:regex];
+}
+
++ (instancetype)inflateFromJSON:(id)json error:(NSError **)error
+{
+  NSArray *substrings = json[@"substrings"];
+  if ([FBCollectionInformation isArrayHeterogeneous:substrings withClass:NSString.class]) {
+    return [self substrings:substrings];
+  }
+
+  NSString *regexPattern = json[@"regex"];
+  if ([regexPattern isKindOfClass:NSString.class]) {
+    return [self regex:regexPattern];
+  }
+
+  return [[FBSimulatorError describeFormat:@"%@ does not contain a valid predicate", json] fail:error];
+}
+
+#pragma mark Public API
+
+- (BOOL)matchesLine:(NSString *)line
+{
+  NSAssert(NO, @"-[%@ %@] is abstract and should be overridden", NSStringFromClass(self.class), NSStringFromSelector(_cmd));
+  return NO;
+}
+
+#pragma mark NSCoding
+
+- (instancetype)initWithCoder:(NSCoder *)coder
+{
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+  return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder
+{
+}
+
+#pragma mark NSCopying
+
+- (instancetype)copyWithZone:(NSZone *)zone
+{
+  NSAssert(NO, @"-[%@ %@] is abstract and should be overridden", NSStringFromClass(self.class), NSStringFromSelector(_cmd));
+  return nil;
+}
+
+#pragma mark FBJSONSerializationDescribeable Implementation
+
+- (id)jsonSerializableRepresentation
+{
+  NSAssert(NO, @"-[%@ %@] is abstract and should be overridden", NSStringFromClass(self.class), NSStringFromSelector(_cmd));
+  return nil;
+}
+
+#pragma mark FBDebugDescribeable Implementation
+
+- (NSString *)description
+{
+  return self.shortDescription;
+}
+
+- (NSString *)shortDescription
+{
+  NSAssert(NO, @"-[%@ %@] is abstract and should be overridden", NSStringFromClass(self.class), NSStringFromSelector(_cmd));
+  return nil;
+}
+
+- (NSString *)debugDescription
+{
+  return self.shortDescription;
+}
+
+@end
+
+#pragma mark - FBLogSearch
+
+@interface FBLogSearch ()
+
+- (instancetype)initWithDiagnostic:(FBDiagnostic *)diagnostic predicate:(FBLogSearchPredicate *)predicate;
+
+@end
+
+@interface FBLogSearch_Invalid : FBLogSearch
+
+@end
+
+@implementation FBLogSearch_Invalid
+
+@end
+
+@interface FBLogSearch_Linewise : FBLogSearch
+
+@property (nonatomic, copy, readonly) NSArray *lines;
+
+@end
+
+@implementation FBLogSearch_Linewise
+
+- (instancetype)initWithDiagnostic:(FBDiagnostic *)diagnostic predicate:(FBLogSearchPredicate *)predicate lines:(NSArray *)lines
+{
+  self = [super initWithDiagnostic:diagnostic predicate:predicate];
+  if (!self) {
+    return nil;
+  }
+
+  _lines = lines;
+
+  return self;
+}
+
+- (NSString *)firstMatchingLine
+{
+  FBLogSearchPredicate *logSearchPredicate = self.predicate;
+  NSPredicate *predicate = [NSPredicate predicateWithBlock:^ BOOL (NSString *line, NSDictionary *_) {
+    return [logSearchPredicate matchesLine:line];
+  }];
+
+  return [[FBConcurrentCollectionOperations
+    filter:self.lines predicate:predicate]
+    firstObject];
+}
+
+@end
+
+@implementation FBLogSearch
+
+#pragma mark Initializers
+
++ (instancetype)withDiagnostic:(FBDiagnostic *)diagnostic predicate:(FBLogSearchPredicate *)predicate
+{
+  if (!diagnostic.isSearchableAsText) {
+    return [FBLogSearch_Invalid new];
+  }
+  NSArray *lines = [diagnostic.asString componentsSeparatedByCharactersInSet:NSCharacterSet.newlineCharacterSet];
+  return [[FBLogSearch_Linewise alloc] initWithDiagnostic:diagnostic predicate:predicate lines:lines];
+}
+
+- (instancetype)initWithDiagnostic:(FBDiagnostic *)diagnostic predicate:(FBLogSearchPredicate *)predicate
+{
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  _diagnostic = diagnostic;
+  _predicate = predicate;
+
+  return self;
+}
+
+#pragma mark Public API
+
+- (NSString *)firstMatchingLine
+{
+  return nil;
+}
+
+@end

--- a/FBSimulatorControl/FBSimulatorControl.h
+++ b/FBSimulatorControl/FBSimulatorControl.h
@@ -28,6 +28,7 @@
 #import <FBSimulatorControl/FBFramebufferVideoConfiguration.h>
 #import <FBSimulatorControl/FBInteraction.h>
 #import <FBSimulatorControl/FBJSONConversion.h>
+#import <FBSimulatorControl/FBLogSearch.h>
 #import <FBSimulatorControl/FBMutableSimulatorEventSink.h>
 #import <FBSimulatorControl/FBProcessInfo.h>
 #import <FBSimulatorControl/FBProcessLaunchConfiguration+Helpers.h>

--- a/FBSimulatorControl/Utility/FBConcurrentCollectionOperations.h
+++ b/FBSimulatorControl/Utility/FBConcurrentCollectionOperations.h
@@ -62,4 +62,9 @@
  */
 + (NSArray *)filterMap:(NSArray *)array predicate:(NSPredicate *)predicate map:(id (^)(id))block;
 
+/**
+ An NSPredicate that will filter out null/NSNull values.
+ */
++ (NSPredicate *)notNullPredicate;
+
 @end

--- a/FBSimulatorControl/Utility/FBConcurrentCollectionOperations.h
+++ b/FBSimulatorControl/Utility/FBConcurrentCollectionOperations.h
@@ -10,7 +10,8 @@
 #import <Foundation/Foundation.h>
 
 /**
- Conveniences for concurent colection operations
+ Conveniences for concurent collection operations.
+ The Predicates and Blocks Passed to these functions must work in a thread-safe manner, inspecting immutable values is the way to go.
  */
 @interface FBConcurrentCollectionOperations : NSObject
 
@@ -19,6 +20,7 @@
 
  @param count the number of generations to execute
  @param block the block to generate objects from.
+ @return a Generated Array of Objects.
  */
 + (NSArray *)generate:(NSUInteger)count withBlock:( id(^)(NSUInteger index) )block;
 
@@ -27,8 +29,18 @@
 
  @param array the array to map.
  @param block the block to map objects with.
+ @return a Mapped Array of Objects.
  */
 + (NSArray *)map:(NSArray *)array withBlock:( id(^)(id object) )block;
+
+/**
+ Filter an array of objects concurrently.
+
+ @param array the array to map/filter.
+ @param predicate the predicate to filter the objects with, before they are mapped.
+ @return a Filter Array of Objects.
+ */
++ (NSArray *)filter:(NSArray *)array predicate:(NSPredicate *)predicate;
 
 /**
  Map and then filter an array of objects concurrently.
@@ -36,6 +48,7 @@
  @param array the array to map/filter.
  @param block the block to map objects with.
  @param predicate the predicate to filter the mapped objects with.
+ @return a Mapped then Filtered array of objects.
  */
 + (NSArray *)mapFilter:(NSArray *)array map:(id (^)(id))block predicate:(NSPredicate *)predicate;
 
@@ -45,6 +58,7 @@
  @param array the array to map/filter.
  @param predicate the predicate to filter the objects with, before they are mapped.
  @param block the block to map objects with.
+ @return a Filtered then Mapped array of objects.
  */
 + (NSArray *)filterMap:(NSArray *)array predicate:(NSPredicate *)predicate map:(id (^)(id))block;
 

--- a/FBSimulatorControl/Utility/FBConcurrentCollectionOperations.m
+++ b/FBSimulatorControl/Utility/FBConcurrentCollectionOperations.m
@@ -109,6 +109,11 @@
     filteredArrayUsingPredicate:self.nonTerminalPredicate];
 }
 
++ (NSPredicate *)notNullPredicate
+{
+  return [NSPredicate predicateWithFormat:@"self != nil"];
+}
+
 #pragma mark Private
 
 + (NSPredicate *)nonTerminalPredicate

--- a/FBSimulatorControl/Utility/FBConcurrentCollectionOperations.m
+++ b/FBSimulatorControl/Utility/FBConcurrentCollectionOperations.m
@@ -60,6 +60,13 @@
     }];
 }
 
++ (NSArray *)filter:(NSArray *)array predicate:(NSPredicate *)predicate
+{
+  return [self filterMap:array predicate:predicate map:^ id (id object) {
+    return object;
+  }];
+}
+
 + (NSArray *)mapFilter:(NSArray *)array map:(id (^)(id))block predicate:(NSPredicate *)predicate
 {
   NSMutableArray *output = [NSMutableArray array];

--- a/FBSimulatorControlTests/Tests/Unit/FBConfigurationTests.m
+++ b/FBSimulatorControlTests/Tests/Unit/FBConfigurationTests.m
@@ -22,17 +22,19 @@
 
 - (NSArray *)serializableConfigurations
 {
-  return [[[[[self.videoConfigurations
+  return [[[[[[self.videoConfigurations
     arrayByAddingObjectsFromArray:self.processLaunchConfigurations]
     arrayByAddingObjectsFromArray:self.simulatorConfigurations]
     arrayByAddingObjectsFromArray:self.controlConfigurations]
     arrayByAddingObjectsFromArray:self.launchConfigurations]
-    arrayByAddingObjectsFromArray:self.diagnostics];
+    arrayByAddingObjectsFromArray:self.diagnostics]
+    arrayByAddingObjectsFromArray:self.logSearchPredicates];
 }
 
 - (NSArray *)deserializableConfigurations
 {
-  return [self appLaunchConfigurations];
+  return [[self appLaunchConfigurations]
+    arrayByAddingObjectsFromArray:self.logSearchPredicates];
 }
 
 - (NSArray *)videoConfigurations
@@ -103,6 +105,14 @@
       updateShortName:@"BONG"]
       updateFileType:@"txt"]
       build],
+  ];
+}
+
+- (NSArray *)logSearchPredicates
+{
+  return @[
+    [FBLogSearchPredicate substrings:@[@"foo", @"bar", @"baz"]],
+    [FBLogSearchPredicate regex:@"(foo|bar|baz)"]
   ];
 }
 

--- a/FBSimulatorControlTests/Tests/Unit/FBConfigurationTests.m
+++ b/FBSimulatorControlTests/Tests/Unit/FBConfigurationTests.m
@@ -22,19 +22,21 @@
 
 - (NSArray *)serializableConfigurations
 {
-  return [[[[[[self.videoConfigurations
+  return [[[[[[[self.videoConfigurations
     arrayByAddingObjectsFromArray:self.processLaunchConfigurations]
     arrayByAddingObjectsFromArray:self.simulatorConfigurations]
     arrayByAddingObjectsFromArray:self.controlConfigurations]
     arrayByAddingObjectsFromArray:self.launchConfigurations]
     arrayByAddingObjectsFromArray:self.diagnostics]
-    arrayByAddingObjectsFromArray:self.logSearchPredicates];
+    arrayByAddingObjectsFromArray:self.logSearchPredicates]
+    arrayByAddingObject:self.batchLogSearch];
 }
 
 - (NSArray *)deserializableConfigurations
 {
-  return [[self appLaunchConfigurations]
-    arrayByAddingObjectsFromArray:self.logSearchPredicates];
+  return [[[self appLaunchConfigurations]
+    arrayByAddingObjectsFromArray:self.logSearchPredicates]
+    arrayByAddingObject:self.batchLogSearch];
 }
 
 - (NSArray *)videoConfigurations
@@ -114,6 +116,14 @@
     [FBLogSearchPredicate substrings:@[@"foo", @"bar", @"baz"]],
     [FBLogSearchPredicate regex:@"(foo|bar|baz)"]
   ];
+}
+
+- (FBBatchLogSearch *)batchLogSearch
+{
+  return [FBBatchLogSearch withMapping:@{
+    @[@"log1", @"log2"] : @[[FBLogSearchPredicate substrings:@[@"foo, bar, baz"]]],
+    @[@"log3"] : @[[FBLogSearchPredicate regex:@"(foo|bar|baz)"], [FBLogSearchPredicate substrings:@[@"blastoof"]]]
+  } error:nil];
 }
 
 - (void)testEqualityOfCopy

--- a/FBSimulatorControlTests/Tests/Unit/FBDiagnosticTests.m
+++ b/FBSimulatorControlTests/Tests/Unit/FBDiagnosticTests.m
@@ -137,6 +137,28 @@
   XCTAssertEqualObjects(writeOutString, logString);
 }
 
+- (void)testInitializesDefaultsWhenPopulatingFromFile
+{
+  FBDiagnostic *diagnostic = [[[FBDiagnosticBuilder builder]
+    updatePath:FBSimulatorControlFixtures.simulatorSystemLogPath]
+    build];
+
+  XCTAssertEqualObjects(diagnostic.shortName, @"simulator_system");
+  XCTAssertEqualObjects(diagnostic.fileType, @"log");
+}
+
+- (void)testDoesNotInitializeDefaultsWhenAlreadySpecified
+{
+  FBDiagnostic *diagnostic = [[[[[FBDiagnosticBuilder builder]
+    updateShortName:@"bibble"]
+    updateFileType:@"txt"]
+    updatePath:FBSimulatorControlFixtures.simulatorSystemLogPath]
+    build];
+
+  XCTAssertEqualObjects(diagnostic.shortName, @"bibble");
+  XCTAssertEqualObjects(diagnostic.fileType, @"txt");
+}
+
 - (void)testTextFileCoercions
 {
   FBDiagnostic *diagnostic = self.simulatorSystemLog;

--- a/FBSimulatorControlTests/Tests/Unit/FBLogSearcherTests.m
+++ b/FBSimulatorControlTests/Tests/Unit/FBLogSearcherTests.m
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <FBSimulatorControl/FBSimulatorControl.h>
+
+#import "FBSimulatorControlFixtures.h"
+
+@interface FBLogSearchTests : XCTestCase
+
+@end
+
+@implementation FBLogSearchTests
+
+- (void)testFindsFirstMatchingLineInFileDiagnostic
+{
+  FBLogSearch *searcher = [FBLogSearch withDiagnostic:self.simulatorSystemLog predicate:[FBLogSearchPredicate substrings:@[
+    @"LOLIDK",
+    @"Installed apps did change",
+    @"Couldn't find the digitizer HID service, this is probably bad"
+  ]]];
+  XCTAssertEqualObjects(searcher.firstMatchingLine, @"Mar  7 16:50:18 some-hostname SpringBoard[24911]: Installed apps did change.");
+}
+
+- (void)testFailsToFindAbsentSubstrings
+{
+  FBLogSearch *searcher = [FBLogSearch withDiagnostic:self.simulatorSystemLog predicate:[FBLogSearchPredicate substrings:@[
+    @"LOLIDK",
+    @"LOLIDK1",
+    @"LOLIDK2"
+  ]]];
+  XCTAssertNil(searcher.firstMatchingLine);
+}
+
+- (void)testFindsFirstMatchingLineInFileRegex
+{
+  FBLogSearch *searcher = [FBLogSearch withDiagnostic:self.simulatorSystemLog predicate:[FBLogSearchPredicate regex:
+    @"layer position \\d+ \\d+ bounds \\d+ \\d+ \\d+ \\d+"
+  ]];
+  XCTAssertEqualObjects(searcher.firstMatchingLine, @"Mar  7 16:50:18 some-hostname backboardd[24912]: layer position 375 667 bounds 0 0 750 1334");
+}
+
+- (void)testFailsToFindAbsentRegex
+{
+  FBLogSearch *searcher = [FBLogSearch withDiagnostic:self.simulatorSystemLog predicate:[FBLogSearchPredicate regex:
+    @"layer position \\D+ \\d+ bounds \\d+ \\d+ \\d+ \\d+"
+  ]];
+  XCTAssertNil(searcher.firstMatchingLine);
+}
+
+- (void)testDoesNotFindInBinaryDiagnostics
+{
+  FBLogSearch *searcher = [FBLogSearch withDiagnostic:self.photoDiagnostic predicate:[FBLogSearchPredicate substrings:@[
+    @"LOLIDK",
+    @"Installed apps did change",
+    @"Couldn't find the digitizer HID service, this is probably bad"
+  ]]];
+  XCTAssertNil(searcher.firstMatchingLine);
+}
+
+@end

--- a/FBSimulatorControlTests/Tests/Unit/FBLogSearcherTests.m
+++ b/FBSimulatorControlTests/Tests/Unit/FBLogSearcherTests.m
@@ -66,3 +66,43 @@
 }
 
 @end
+
+@interface FBBatchLogSearcherTests : XCTestCase
+
+@end
+
+@implementation FBBatchLogSearcherTests
+
+- (void)testBatchSearchFindsAcrossMultipleDiagnostics
+{
+  NSDictionary *mapping = @{
+    @[@"simulator_system", @"tree"] : @[
+      [FBLogSearchPredicate substrings:@[@"Springboard", @"IOHIDSession", @"rect"]],
+      [FBLogSearchPredicate regex:@"layer position \\d+ \\d+ bounds \\d+ \\d+ \\d+ \\d+"]
+    ],
+    @[@"simulator_system"] : @[
+      [FBLogSearchPredicate substrings:@[@"ADDING REMOTE com.apple.Maps"]],
+    ],
+    @[@"tree"] : @[
+      [FBLogSearchPredicate regex:@"(ANIMPOSSIBLE|REGEAAAAAAAAA)"],
+    ],
+    @[@"photo0"] : @[
+      [FBLogSearchPredicate substrings:@[@"111", @"222"]],
+    ]
+  };
+  NSError *error = nil;
+  FBBatchLogSearch *batchSearch = [FBBatchLogSearch withMapping:mapping error:&error];
+  XCTAssertNil(error);
+  XCTAssertNotNil(batchSearch);
+  NSDictionary *results = [batchSearch search:@[
+    self.simulatorSystemLog,
+    self.treeJSONDiagnostic,
+    self.photoDiagnostic
+  ]];
+  XCTAssertNotNil(results);
+  XCTAssertEqual([results[@"simulator_system"] count], 3u);
+  XCTAssertEqual([results[@"tree"] count], 1u);
+  XCTAssertEqual([results[@"photo0"] count], 0u);
+}
+
+@end


### PR DESCRIPTION
Adds a `FBLogSearch` which is a simple Log Searching class that can search through the text of text files. This is particularly practical if you wish to extract information from an app log in order to assert against particular conditions.

The implementation is pretty naiive, but relies on `FBConcurrentCollectionOperations` to be 'fast-enough'. By using a class cluster, it should be possible to do log searching directly via asl in the future.

In addition to the 1-diagnostic 1-predicate search of `FBLogSearch` there is a complementary class `FBBatchLogSearch` which builds upon `FBLogSearch` and will run multiple searches concurrently and bucket them by diagnostic name. This can be very handy when you wish to search for a bunch of strings in an app/system log, or there's an interesting string that you want to track down across a range of files.

Additionally, the searches are de/serializable over JSON, which makes it trivial to implement and endpoint to take care of log searching. In some occasions it can be useful to query a remote simulator for particular information in the logs. Batching this all together in one call can make the query more performant.