### PR TITLE
Fix setting up test connection on iOS 8 simulators

### DIFF
--- a/FBSimulatorControlTests/Tests/Integration/FBSimulatorTestInjectionTests.m
+++ b/FBSimulatorControlTests/Tests/Integration/FBSimulatorTestInjectionTests.m
@@ -51,6 +51,18 @@
 
 }
 
+- (void)testInjectsApplicationTestIntoSampleAppOnIOS81Simulator
+{
+  self.simulatorConfiguration = FBSimulatorConfiguration.iPhone5.iOS_8_1;
+  FBSimulator *simulator = [self obtainBootedSimulator];
+  id<FBInteraction> interaction = [[simulator.interact
+    installApplication:self.tableSearchApplication]
+    startTestRunnerLaunchConfiguration:self.tableSearchAppLaunch testBundlePath:self.applicationTestBundlePath reporter:self];
+
+  [self assertInteractionSuccessful:interaction];
+  [self assertPassed:@[@"testIsRunningOnIOS"] failed:@[@"testIsRunningOnMacOSX", @"testIsSafari"]];
+}
+
 - (void)testInjectsApplicationTestIntoSafari
 {
   FBSimulator *simulator = [self obtainBootedSimulator];

--- a/XCTestBootstrap/TestManager/FBTestDaemonConnection.m
+++ b/XCTestBootstrap/TestManager/FBTestDaemonConnection.m
@@ -186,10 +186,10 @@
   [receipt handleCompletion:^(NSNumber *version, NSError *error) {
     if (error) {
       [self.logger logFormat:@"Error in whitelisting response from testmanagerd: %@ (%@), ignoring for now.", error.localizedDescription, error.localizedRecoverySuggestion];
-      return;
+    } else {
+      self.daemonProtocolVersion = version.integerValue;
+      [self.logger logFormat:@"Got legacy whitelisting response, daemon protocol version is 14"];
     }
-    self.daemonProtocolVersion = version.integerValue;
-    [self.logger logFormat:@"Got legacy whitelisting response, daemon protocol version is 14"];
     self.state = FBTestDaemonConnectionStateReadyToExecuteTestPlan;
   }];
   return receipt;


### PR DESCRIPTION
Fix #263

Please let me know if I can improve something. Please see also my comments in #263 about the retrying strategy of Xcode. Once you "listen" to the `XPC` communication, you'll notice that Xcode is also just trying different methods and ignoring errors.