### PR TITLE
Export FBDeviceControl Schemes

### DIFF
--- a/FBSimulatorControl.xcodeproj/xcshareddata/xcschemes/FBDeviceControl.xcscheme
+++ b/FBSimulatorControl.xcodeproj/xcshareddata/xcschemes/FBDeviceControl.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AAC8B22A1CEC51120034A865"
+               BuildableName = "FBDeviceControl.framework"
+               BlueprintName = "FBDeviceControl"
+               ReferencedContainer = "container:FBSimulatorControl.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AAC8B2331CEC51120034A865"
+               BuildableName = "FBDeviceControlTests.xctest"
+               BlueprintName = "FBDeviceControlTests"
+               ReferencedContainer = "container:FBSimulatorControl.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AAC8B22A1CEC51120034A865"
+            BuildableName = "FBDeviceControl.framework"
+            BlueprintName = "FBDeviceControl"
+            ReferencedContainer = "container:FBSimulatorControl.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AAC8B22A1CEC51120034A865"
+            BuildableName = "FBDeviceControl.framework"
+            BlueprintName = "FBDeviceControl"
+            ReferencedContainer = "container:FBSimulatorControl.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AAC8B22A1CEC51120034A865"
+            BuildableName = "FBDeviceControl.framework"
+            BlueprintName = "FBDeviceControl"
+            ReferencedContainer = "container:FBSimulatorControl.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FBSimulatorControl.xcodeproj/xcshareddata/xcschemes/FBSimulatorControl.xcscheme
+++ b/FBSimulatorControl.xcodeproj/xcshareddata/xcschemes/FBSimulatorControl.xcscheme
@@ -38,26 +38,6 @@
                ReferencedContainer = "container:FBSimulatorControl.xcodeproj">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "EEBD60161C90628F00298A07"
-               BuildableName = "FBControlCoreTests.xctest"
-               BlueprintName = "FBControlCoreTests"
-               ReferencedContainer = "container:FBSimulatorControl.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "EE4F0D381C91B7DB00608E89"
-               BuildableName = "XCTestBootstrapTests.xctest"
-               BlueprintName = "XCTestBootstrapTests"
-               ReferencedContainer = "container:FBSimulatorControl.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference


### PR DESCRIPTION
This scheme was not previously exported and ignored by source control in my working copy. It's needed by the build scripts that test each of the frameworks in sequence.