### PR TITLE
Add CLI Tests to Travis and build.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,9 @@
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
-## Build generated
+## Build & Test Generated
 build/
+fbsimctl/cli-tests/executable-under-test
 DerivedData
 
 ## Filesystem
@@ -31,6 +32,9 @@ xcuserdata/
 *.hmap
 *.ipa
 
+## Python
+*.pyc
+
 # Carthage
 #
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
@@ -40,3 +44,4 @@ Carthage/Build
 Carthage/Checkouts
 fbsimctl/Carthage/Build
 fbsimctl/Carthage/Checkouts
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: objective-c
 osx_image: xcode7.3
 before_install:
-  brew install carthage
+  brew install carthage python3
 env:
 - TARGET=framework COMMAND=test FBSIMULATORCONTROL_DEVICE_SET=default FBSIMULATORCONTROL_LAUNCH_TYPE=simulator_app
 - TARGET=framework COMMAND=test FBSIMULATORCONTROL_DEVICE_SET=custom FBSIMULATORCONTROL_LAUNCH_TYPE=simulator_app
 - TARGET=framework COMMAND=test FBSIMULATORCONTROL_DEVICE_SET=custom FBSIMULATORCONTROL_LAUNCH_TYPE=direct
 - TARGET=cli COMMAND=build
 - TARGET=cli COMMAND=test
+- TARGET=cli COMMAND=e2e-test
 script: ./build.sh
 branches:
   only:

--- a/fbsimctl/cli-tests/tests.py
+++ b/fbsimctl/cli-tests/tests.py
@@ -1,9 +1,6 @@
-from util import (FBSimctl, Simulator)
+from util import (FBSimctl, Simulator, EXECUTABLE_PATH)
 import unittest
 import tempfile
-
-EXECUTABLE_PATH = 'fbsimctl'
-
 
 class FBSimctlTestCase(unittest.TestCase):
     def setUp(self):

--- a/fbsimctl/cli-tests/util.py
+++ b/fbsimctl/cli-tests/util.py
@@ -4,14 +4,23 @@ import io
 import json
 import subprocess
 import logging
-
-DEFAULT_TIMEOUT = 100
+import os
 
 # Setup the Logger
 logging.basicConfig(format='%(message)s')
 log = logging.getLogger()
 log.setLevel(logging.INFO)
 
+DEFAULT_TIMEOUT = 100
+
+# Use the built testable, otherwise assume it is on the PATH.
+TEST_EXCUTABLE = 'executable-under-test/fbsimctl'
+if os.path.exists(os.path.exists(TEST_EXCUTABLE)):
+    EXECUTABLE_PATH = os.path.realpath(TEST_EXCUTABLE)
+    log.info('Using fbsimctl test executable at {}'.format(EXECUTABLE_PATH))
+else:
+    EXECUTABLE_PATH = 'fbsimctl'
+    log.info('Using fbsimctl on PATH')
 
 class Events:
     def __init__(self, events):


### PR DESCRIPTION
- Add an entry to the Travis Build matrix for running the CLI tests. 
- Adds an entry to the `build.sh` for calling the test script. 
- Adds a convention for placing the `executable-under-test` to `fbsimctl/cli-tests/executable-under-test`. The tests will use the `executable-under-test` if it is present.
- Parameterizing the output directory of cli & framework builds in `build.sh`.