### PR TITLE
Extend environment in LaunchXCTest Action

### DIFF
--- a/fbsimctl/FBSimulatorControlKit/Sources/Environment.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Environment.swift
@@ -49,6 +49,14 @@ public extension Action {
           Action.subprocessEnvironment(environment)
         )
       )
+    case .LaunchXCTest(let configuration, let bundle, let timeout):
+      return .LaunchXCTest(
+        configuration.withEnvironmentAdditions(
+          Action.subprocessEnvironment(environment)
+        ),
+        bundle,
+        timeout
+      )
     default:
       return self
     }

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/Unit/EnvironmentTests.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/Unit/EnvironmentTests.swift
@@ -20,10 +20,10 @@ class EnvironmentTests : XCTestCase {
     ]
     let launchConfig = FBApplicationLaunchConfiguration(application: Fixtures.application, arguments: [], environment: [:], options: FBProcessLaunchOptions())
     let actual = Action.LaunchApp(launchConfig).appendEnvironment(environment)
-    let expteced  = Action.LaunchApp(launchConfig.withEnvironmentAdditions([
+    let expected  = Action.LaunchApp(launchConfig.withEnvironmentAdditions([
       "FOO" : "BAR",
       "BING" : "BONG",
     ]))
-    XCTAssertEqual(expteced, actual)
+    XCTAssertEqual(expected, actual)
   }
 }

--- a/fbsimctl/FBSimulatorControlKitTests/Tests/Unit/EnvironmentTests.swift
+++ b/fbsimctl/FBSimulatorControlKitTests/Tests/Unit/EnvironmentTests.swift
@@ -12,18 +12,29 @@ import FBSimulatorControl
 @testable import FBSimulatorControlKit
 
 class EnvironmentTests : XCTestCase {
+  let testEnvironment = [
+    "FBSIMCTL_CHILD_FOO" : "BAR",
+    "PATH" : "IGNORE",
+    "FBSIMCTL_CHILD_BING" : "BONG",
+  ]
+
   func testAppendsEnvironmentToLaunchConfiguration() {
-    let environment = [
-      "FBSIMCTL_CHILD_FOO" : "BAR",
-      "PATH" : "IGNORE",
-      "FBSIMCTL_CHILD_BING" : "BONG",
-    ]
     let launchConfig = FBApplicationLaunchConfiguration(application: Fixtures.application, arguments: [], environment: [:], options: FBProcessLaunchOptions())
-    let actual = Action.LaunchApp(launchConfig).appendEnvironment(environment)
+    let actual = Action.LaunchApp(launchConfig).appendEnvironment(testEnvironment)
     let expected  = Action.LaunchApp(launchConfig.withEnvironmentAdditions([
       "FOO" : "BAR",
       "BING" : "BONG",
     ]))
+    XCTAssertEqual(expected, actual)
+  }
+
+  func testAppendsEnvironmentToXCTestLaunchConfiguration() {
+    let launchConfig = FBApplicationLaunchConfiguration(application: Fixtures.application, arguments: [], environment: [:], options: FBProcessLaunchOptions())
+    let actual = Action.LaunchXCTest(launchConfig, "com.example.App", nil).appendEnvironment(testEnvironment)
+    let expected  = Action.LaunchXCTest(launchConfig.withEnvironmentAdditions([
+      "FOO" : "BAR",
+      "BING" : "BONG",
+    ]), "com.example.App", nil)
     XCTAssertEqual(expected, actual)
   }
 }


### PR DESCRIPTION
This makes it possible to inject environment variables with the
`FBSIMCTL_CHILD` prefix into the `LaunchXCTest` action.

Example use case:

```
export FBSIMCTL_CHILD_FB_REFERENCE_IMAGE_DIR="/Users/plu//ios-client/UnitTests/ReferenceImages"
fbsimctl launch_xctest ...
```