### PR TITLE
Add output/ and .clang-format to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ Carthage/Checkouts
 fbsimctl/Carthage/Build
 fbsimctl/Carthage/Checkouts
 
+output/
+.clang-format


### PR DESCRIPTION
* `output/` is created by `build.sh`
* I'm using some `.clang-format` configuration to achieve a similar code formatting like the one the project has already in existing code. Do you guys maybe have such a configuration too that you could share, so it wouldn't just be "similar" but exactly the same?