### PR TITLE
Avoid over releasing property

### DIFF
--- a/FBSimulatorControl/Framebuffer/FBFramebuffer.m
+++ b/FBSimulatorControl/Framebuffer/FBFramebuffer.m
@@ -221,7 +221,9 @@ static const CMTimeRoundingMethod FBSimulatorFramebufferRoundingMethod = kCMTime
   self.state = FBSimulatorFramebufferStateTerminated;
   [self.framebufferService unregisterClient:self];
   [self.framebufferService suspend];
-  CFRelease(self.timebase);
+  if (self.timebase) {
+    CFRelease(self.timebase);
+  }
   self.timebase = nil;
 
   [self.delegate framebuffer:self didBecomeInvalidWithError:error teardownGroup:teardownGroup];


### PR DESCRIPTION
When running the tests locally I sometimes saw a crash happening when over releasing the `timebase` property in `FBFramebuffer` during `[XCTestCase tearDown]`.