### PR TITLE
Fix launchctl path

### DIFF
--- a/FBControlCore/Applications/FBBinaryDescriptor.h
+++ b/FBControlCore/Applications/FBBinaryDescriptor.h
@@ -66,14 +66,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (nullable instancetype)binaryWithPath:(NSString *)path error:(NSError **)error;
 
-/**
- Returns the launchctl for the current version of Xcode's of the Simulator Platform.
- Will assert if the FBBinaryDescriptor instance could not be constructed.
-
- @return a FBBinaryDescriptor instance launchctl.
- */
-+ (instancetype)launchCtl;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FBControlCore/Applications/FBBinaryDescriptor.m
+++ b/FBControlCore/Applications/FBBinaryDescriptor.m
@@ -165,21 +165,7 @@
     architectures:archs];
 }
 
-+ (instancetype)launchCtl
-{
-  NSError *error = nil;
-  FBBinaryDescriptor *binary = [FBBinaryDescriptor binaryWithPath:self.pathForiPhoneLaunchCtl error:&error];
-  NSAssert(binary, @"Failed to construct launchctl binary with error %@", error);
-  return binary;
-}
-
 #pragma mark Private
-
-+ (NSString *)pathForiPhoneLaunchCtl
-{
-  return [FBControlCoreGlobalConfiguration.developerDirectory
-    stringByAppendingPathComponent:@"/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/bin/launchctl"];
-}
 
 + (NSString *)binaryNameForBinaryPath:(NSString *)binaryPath
 {

--- a/FBSimulatorControl/Utility/FBSimulatorLaunchCtl.m
+++ b/FBSimulatorControl/Utility/FBSimulatorLaunchCtl.m
@@ -9,6 +9,9 @@
 
 #import "FBSimulatorLaunchCtl.h"
 
+#import <CoreSimulator/SimDevice.h>
+#import <CoreSimulator/SimRuntime.h>
+
 #import <FBControlCore/FBControlCore.h>
 
 #import "FBProcessLaunchConfiguration+Helpers.h"
@@ -17,6 +20,27 @@
 #import "FBSimulator+Helpers.h"
 #import "FBSimulator.h"
 #import "FBSimulatorError.h"
+
+@interface FBSimulator (FBSimulatorLaunchCtl)
+
+@property (nonatomic, copy, readonly) FBBinaryDescriptor *launchCtlBinary;
+
+@end
+
+@implementation FBSimulator (FBSimulatorLaunchCtl)
+
+- (FBBinaryDescriptor *)launchCtlBinary
+{
+  NSString *path = [[self.device.runtime.root
+    stringByAppendingPathComponent:@"bin"]
+    stringByAppendingPathComponent:@"launchctl"];
+  NSError *error = nil;
+  FBBinaryDescriptor *binary = [FBBinaryDescriptor binaryWithPath:path error:&error];
+  NSAssert(binary, @"Could not locate launchctl at expected location '%@', error %@", path, error);
+  return binary;
+}
+
+@end
 
 @interface FBSimulatorLaunchCtl ()
 
@@ -115,7 +139,7 @@
 {
   // Construct a Launch Configuration for launchctl we'll use the 'list' command.
   FBAgentLaunchConfiguration *launchConfiguration = [FBAgentLaunchConfiguration
-    configurationWithBinary:FBBinaryDescriptor.launchCtl
+    configurationWithBinary:self.simulator.launchCtlBinary
     arguments:arguments
     environment:@{}
     options:0];


### PR DESCRIPTION
The path of the `launchctl` was erroneously using a hardcoded path, relative to the root of the xcode install, rather than the `SimRuntime`'s root. This changes that, so that we can always fetch the appropriate path for the executable.