### PR TITLE
Add Xcode 8 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
-osx_image: xcode7.3
 before_install:
   brew install carthage python3
+osx_image: xcode8
 env:
 - TARGET=framework COMMAND=test FBSIMULATORCONTROL_DEVICE_SET=default FBSIMULATORCONTROL_LAUNCH_TYPE=simulator_app
 - TARGET=framework COMMAND=test FBSIMULATORCONTROL_DEVICE_SET=custom FBSIMULATORCONTROL_LAUNCH_TYPE=simulator_app


### PR DESCRIPTION
Starting by trying to build everything. I'll have to probably exclude certain variants from the build matrix so that we only run the builds that we know to be green. Swift Version and `xctool` may only permit certain builds to run on Xcode 8.