### PR TITLE
Remove com.apple.cloudd from list of services

### DIFF
--- a/FBSimulatorControl/Strategies/FBSimulatorBootStrategy.m
+++ b/FBSimulatorControl/Strategies/FBSimulatorBootStrategy.m
@@ -429,7 +429,6 @@
         @"com.apple.mobile.installd",
         @"com.apple.SimulatorBridge",
         @"com.apple.SpringBoard",
-        @"com.apple.cloudd",
       ];
     }
     return @[

--- a/FBSimulatorControlTests/Tests/Integration/FBSimulatorLaunchTests.m
+++ b/FBSimulatorControlTests/Tests/Integration/FBSimulatorLaunchTests.m
@@ -72,6 +72,13 @@
   [self testLaunchesSingleSimulator:FBSimulatorConfiguration.appleTV1080p];
 }
 
+- (void)testLaunchesPreviousiOSVersionAndAwaitsServices
+{
+  FBSimulatorBootOptions options = self.simulatorLaunchConfiguration.options | FBSimulatorBootOptionsAwaitServices;
+  self.simulatorLaunchConfiguration = [self.simulatorLaunchConfiguration withOptions:options];
+  [self testLaunchesSingleSimulator:FBSimulatorConfiguration.iPhone5.iOS_9_3];
+}
+
 - (void)testLaunchesMultipleSimulators
 {
   // Simulator Pool management is single threaded since it relies on unsynchronised mutable state


### PR DESCRIPTION
This service is not being launched on an iOS 9.3 Simulator. When
enabling FBSimulatorBootOptionsAwaitServices it fails to boot,
waiting for this service to launch.

Fix #330.