### PR TITLE
Expose code signing error

### DIFF
--- a/FBControlCore/Codesigning/FBCodesignProvider.m
+++ b/FBControlCore/Codesigning/FBCodesignProvider.m
@@ -47,10 +47,11 @@ static NSString *const CDHashPrefix = @"CDHash=";
 
 - (BOOL)signBundleAtPath:(NSString *)bundlePath error:(NSError **)error
 {
-  return [[[FBTaskBuilder
+  FBTask *task = [[FBTaskBuilder
     taskWithLaunchPath:@"/usr/bin/codesign" arguments:@[@"-s", self.identityName, @"-f", bundlePath]]
-    startSynchronouslyWithTimeout:FBControlCoreGlobalConfiguration.fastTimeout]
-    wasSuccessful];
+    startSynchronouslyWithTimeout:FBControlCoreGlobalConfiguration.fastTimeout];
+  *error = task.error;
+  return [task wasSuccessful];
 }
 
 - (nullable NSString *)cdHashForBundleAtPath:(NSString *)bundlePath error:(NSError **)error

--- a/FBControlCore/Codesigning/FBCodesignProvider.m
+++ b/FBControlCore/Codesigning/FBCodesignProvider.m
@@ -50,7 +50,9 @@ static NSString *const CDHashPrefix = @"CDHash=";
   FBTask *task = [[FBTaskBuilder
     taskWithLaunchPath:@"/usr/bin/codesign" arguments:@[@"-s", self.identityName, @"-f", bundlePath]]
     startSynchronouslyWithTimeout:FBControlCoreGlobalConfiguration.fastTimeout];
-  *error = task.error;
+  if (error) {
+    *error = task.error;
+  }
   return [task wasSuccessful];
 }
 


### PR DESCRIPTION
The `testInjectsApplicationTestIntoSafari` test was sometimes failing on Travis. The underlying error was not exposed, yet. Now we can actually see why it is failing (and work around it):

    Test Case '-[FBSimulatorTestInjection testInjectsApplicationTestIntoSafari]' started.
    /Users/travis/build/plu/FBSimulatorControl/FBSimulatorControlTests/Fixtures/FBSimulatorControlFixtures.m:177: error: -[FBSimulatorTestInjection testInjectsApplicationTestIntoSafari] : failed - Bundle at path /Users/travis/build/plu/FBSimulatorControl/build/Build/Products/Debug/FBSimulatorControlTests.xctest/Contents/Resources/iOSUnitTestFixture.xctest could not be codesigned: Error Domain=com.facebook.FBControlCore.task Code=0 "Launched process '<FBTaskProcess_NSTask: 0x7ff52ec911b0>' took longer than 10.000000 seconds to terminate" UserInfo={exitcode=15, stderr=, stdout=, NSLocalizedDescription=Launched process '<FBTaskProcess_NSTask: 0x7ff52ec911b0>' took longer than 10.000000 seconds to terminate}