### PR TITLE
Use higher timeout for signBundleAtPath

### DIFF
--- a/FBControlCore/Codesigning/FBCodesignProvider.m
+++ b/FBControlCore/Codesigning/FBCodesignProvider.m
@@ -49,7 +49,7 @@ static NSString *const CDHashPrefix = @"CDHash=";
 {
   return [[[FBTaskBuilder
     taskWithLaunchPath:@"/usr/bin/codesign" arguments:@[@"-s", self.identityName, @"-f", bundlePath]]
-    startSynchronouslyWithTimeout:FBControlCoreGlobalConfiguration.fastTimeout]
+    startSynchronouslyWithTimeout:FBControlCoreGlobalConfiguration.regularTimeout]
     wasSuccessful];
 }
 


### PR DESCRIPTION
The `testInjectsApplicationTestIntoSafari` test was sometimes timing out on Travis:

    Test Case '-[FBSimulatorTestInjection testInjectsApplicationTestIntoSafari]' started.
    /Users/travis/build/plu/FBSimulatorControl/FBSimulatorControlTests/Fixtures/FBSimulatorControlFixtures.m:177: error: -[FBSimulatorTestInjection testInjectsApplicationTestIntoSafari] : failed - Bundle at path /Users/travis/build/plu/FBSimulatorControl/build/Build/Products/Debug/FBSimulatorControlTests.xctest/Contents/Resources/iOSUnitTestFixture.xctest could not be codesigned: Error Domain=com.facebook.FBControlCore.task Code=0 "Launched process '<FBTaskProcess_NSTask: 0x7ff52ec911b0>' took longer than 10.000000 seconds to terminate" UserInfo={exitcode=15, stderr=, stdout=, NSLocalizedDescription=Launched process '<FBTaskProcess_NSTask: 0x7ff52ec911b0>' took longer than 10.000000 seconds to terminate}