### PR TITLE
Expose editPropertyListFileRelativeFromRootPath

### DIFF
--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Setup.h
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Setup.h
@@ -72,6 +72,19 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)setupKeyboard;
 
+/**
+ Edit a property list file of the Simulator by manipulating the content of the dictionary in the block.
+
+ The path must be relative to the Simulator's data directory, example: `Library/Preferences/com.apple.Preferences.plist`
+ All changes made to the dictionary will be written back to the property list file.
+
+ @param relativePath The relative path from the Simulator's data path to the property list file.
+ @param block A block that receives the content of the property list file as a mutable dictionary.
+
+ @return the reciever, for chaining.
+ */
+- (instancetype)editPropertyListFileRelativeFromRootPath:(NSString *)relativePath amendWithBlock:( void(^)(NSMutableDictionary *) )block;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Setup.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Setup.m
@@ -97,16 +97,23 @@
 
 - (instancetype)setupKeyboard
 {
-  return [self interactWithShutdownSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
-    return [FBSimulatorInteraction
-      forSimulator:simulator
-      relativeFromRootPath:@"Library/Preferences/com.apple.Preferences.plist"
-      error:error
+  return [self
+      editPropertyListFileRelativeFromRootPath:@"Library/Preferences/com.apple.Preferences.plist"
       amendWithBlock:^(NSMutableDictionary *dictionary) {
         dictionary[@"KeyboardCapsLock"] = @NO;
         dictionary[@"KeyboardAutocapitalization"] = @NO;
         dictionary[@"KeyboardAutocorrection"] = @NO;
       }];
+}
+
+- (instancetype)editPropertyListFileRelativeFromRootPath:(NSString *)relativePath amendWithBlock:( void(^)(NSMutableDictionary *) )block
+{
+  return [self interactWithShutdownSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
+    return [FBSimulatorInteraction
+      forSimulator:simulator
+      relativeFromRootPath:relativePath
+      error:error
+      amendWithBlock:block];
   }];
 }
 


### PR DESCRIPTION
Edit a property list file of the Simulator by manipulating the content of the dictionary in the block.

The `setupKeyboard` method is changing a few of the keyboard settings, but not all of them. With this new method consumers of the Framework have full control of editing property list files that belong to the Simulator. Without the need of FBSimulatorControl having to know what property list files exist and what options they support.