### PR TITLE
Expose method to modify defaults

### DIFF
--- a/FBSimulatorControl/Interactions/FBSimulatorInteraction+Settings.m
+++ b/FBSimulatorControl/Interactions/FBSimulatorInteraction+Settings.m
@@ -37,7 +37,7 @@
   return [self interactWithShutdownSimulator:^ BOOL (NSError **error, FBSimulator *simulator) {
     return [[FBLocalizationDefaultsModificationStrategy
       strategyWithSimulator:simulator]
-      overideLocalization:localizationOverride error:error];
+      overrideLocalization:localizationOverride error:error];
   }];
 }
 

--- a/FBSimulatorControl/Strategies/FBDefaultsModificationStrategy.h
+++ b/FBSimulatorControl/Strategies/FBDefaultsModificationStrategy.h
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param error an error out for any error that occurs.
  @return YES if succesful, NO otherwise.
  */
-- (BOOL)overideLocalization:(FBLocalizationOverride *)localizationOverride error:(NSError **)error;
+- (BOOL)overrideLocalization:(FBLocalizationOverride *)localizationOverride error:(NSError **)error;
 
 @end
 

--- a/FBSimulatorControl/Strategies/FBDefaultsModificationStrategy.h
+++ b/FBSimulatorControl/Strategies/FBDefaultsModificationStrategy.h
@@ -27,6 +27,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (instancetype)strategyWithSimulator:(FBSimulator *)simulator;
 
+/**
+ Modifies the defaults in a given domain or path.
+
+ @param domainOrPath the domain or path to modify.
+ @param defaults key value pair of defaults to set.
+ @param error an error out for any error that occurs.
+ @return YES if succesful, NO otherwise.
+ */
+- (BOOL)modifyDefaultsInDomainOrPath:(nullable NSString *)domainOrPath defaults:(NSDictionary<NSString *, id> *)defaults error:(NSError **)error;
+
 @end
 
 /**

--- a/FBSimulatorControl/Strategies/FBDefaultsModificationStrategy.m
+++ b/FBSimulatorControl/Strategies/FBDefaultsModificationStrategy.m
@@ -128,7 +128,7 @@
 
 @implementation FBLocalizationDefaultsModificationStrategy
 
-- (BOOL)overideLocalization:(FBLocalizationOverride *)localizationOverride error:(NSError **)error
+- (BOOL)overrideLocalization:(FBLocalizationOverride *)localizationOverride error:(NSError **)error
 {
   return [self modifyDefaultsInDomainOrPath:nil defaults:localizationOverride.defaultsDictionary error:error];
 }


### PR DESCRIPTION
Expose `modifyDefaultsInDomainOrPath:defaults:error:` to allow subclassing FBDefaultsModificationStrategy.