### PR TITLE
Fix FBDeviceTestRunStrategyTest test case compile error

### DIFF
--- a/FBDeviceControlTests/Tests/Unit/FBDeviceTestRunStrategyTest.m
+++ b/FBDeviceControlTests/Tests/Unit/FBDeviceTestRunStrategyTest.m
@@ -26,7 +26,8 @@
     strategyWithDevice:device
     testHostPath:testHostPath
     testBundlePath:testBundlePath
-    withTimeout:0];
+    withTimeout:0
+    withArguments: @[]];
 
   NSDictionary *properties = [strategy buildXCTestRunProperties];
   NSDictionary *stubBundleProperties = properties[@"StubBundleId"];


### PR DESCRIPTION
The test wasn't compiling, so fixed it.