### PR TITLE
Add error code for startup timeout

### DIFF
--- a/XCTestBootstrap/TestManager/FBTestBundleConnection.m
+++ b/XCTestBootstrap/TestManager/FBTestBundleConnection.m
@@ -157,7 +157,9 @@ typedef NS_ENUM(NSUInteger, FBTestBundleConnectionState) {
   }];
 
   if (!waitSuccess) {
-    XCTestBootstrapError *error = [XCTestBootstrapError describe:@"Timeout establishing connection"];
+    XCTestBootstrapError *error = [[XCTestBootstrapError
+      describe:@"Timeout establishing connection"]
+      code:XCTestBootstrapErrorCodeStartupTimeout];
     return [self concludeWithResult:[FBTestBundleResult failedInError:error]];
   }
   if (self.state == FBTestBundleConnectionStateResultAvailable) {

--- a/XCTestBootstrap/TestManager/FBTestDaemonConnection.m
+++ b/XCTestBootstrap/TestManager/FBTestDaemonConnection.m
@@ -138,8 +138,9 @@ typedef NS_ENUM(NSUInteger, FBTestDaemonConnectionState) {
   }];
 
   if (!waitSuccess) {
-    XCTestBootstrapError *error = [XCTestBootstrapError
-      describeFormat:@"Timed out %f seconds waiting for daemon connection", timeout];
+    XCTestBootstrapError *error = [[XCTestBootstrapError
+      describeFormat:@"Timed out %f seconds waiting for daemon connection", timeout]
+      code:XCTestBootstrapErrorCodeStartupTimeout];
     return [self concludeWithResult:[FBTestDaemonResult failedInError:error]];
   }
   if (self.state != FBTestDaemonConnectionStateReadyToExecuteTestPlan) {

--- a/XCTestBootstrap/Utility/XCTestBootstrapError.h
+++ b/XCTestBootstrap/Utility/XCTestBootstrapError.h
@@ -21,6 +21,7 @@ extern NSString *const XCTestBootstrapErrorDomain;
  */
 extern const NSInteger XCTestBootstrapErrorCodeStartupFailure;
 extern const NSInteger XCTestBootstrapErrorCodeLostConnection;
+extern const NSInteger XCTestBootstrapErrorCodeStartupTimeout;
 
 /**
  XCTestBootstrap Errors construction.

--- a/XCTestBootstrap/Utility/XCTestBootstrapError.m
+++ b/XCTestBootstrap/Utility/XCTestBootstrapError.m
@@ -13,6 +13,7 @@ NSString *const XCTestBootstrapErrorDomain = @"com.facebook.XCTestBootstrap";
 
 const NSInteger XCTestBootstrapErrorCodeStartupFailure = 0x3;
 const NSInteger XCTestBootstrapErrorCodeLostConnection = 0x4;
+const NSInteger XCTestBootstrapErrorCodeStartupTimeout = 0x5;
 
 @implementation XCTestBootstrapError
 


### PR DESCRIPTION
This lets consumers react to a timeout that happened during test
startup.