### PR TITLE
Extract FBTestManagerJUnitGenerator

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		05AC8AFB1D587A8B008B435E /* FBTestManagerTestReporterBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 05AC8AF91D587A8B008B435E /* FBTestManagerTestReporterBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		05AC8AFC1D587A8B008B435E /* FBTestManagerTestReporterBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 05AC8AFA1D587A8B008B435E /* FBTestManagerTestReporterBase.m */; };
 		05D3B5761D572EA100944680 /* junitResult0.xml in Resources */ = {isa = PBXBuildFile; fileRef = 05D3B5751D572EA100944680 /* junitResult0.xml */; };
+		05E1E34E1E3DBA87004F67B8 /* FBTestManagerJUnitGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 05E1E34C1E3DBA87004F67B8 /* FBTestManagerJUnitGenerator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		05E1E34F1E3DBA87004F67B8 /* FBTestManagerJUnitGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 05E1E34D1E3DBA87004F67B8 /* FBTestManagerJUnitGenerator.m */; };
 		05F1823F1D59B48600DBD35C /* junitResult1.xml in Resources */ = {isa = PBXBuildFile; fileRef = 05F1823E1D59B48600DBD35C /* junitResult1.xml */; };
 		1F7596B31DFF6B40006B9053 /* libShimulator.dylib in Resources */ = {isa = PBXBuildFile; fileRef = AA017F4C1BD7784700F45E9D /* libShimulator.dylib */; };
 		2ACC1E9C1CB7EE0000F9CE24 /* FBSimulatorInteraction+Keychain.m in Sources */ = {isa = PBXBuildFile; fileRef = 2ACC1E9A1CB7EE0000F9CE24 /* FBSimulatorInteraction+Keychain.m */; };
@@ -597,6 +599,8 @@
 		05AC8AF91D587A8B008B435E /* FBTestManagerTestReporterBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBTestManagerTestReporterBase.h; sourceTree = "<group>"; };
 		05AC8AFA1D587A8B008B435E /* FBTestManagerTestReporterBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBTestManagerTestReporterBase.m; sourceTree = "<group>"; };
 		05D3B5751D572EA100944680 /* junitResult0.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = junitResult0.xml; sourceTree = "<group>"; };
+		05E1E34C1E3DBA87004F67B8 /* FBTestManagerJUnitGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBTestManagerJUnitGenerator.h; sourceTree = "<group>"; };
+		05E1E34D1E3DBA87004F67B8 /* FBTestManagerJUnitGenerator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBTestManagerJUnitGenerator.m; sourceTree = "<group>"; };
 		05F1823E1D59B48600DBD35C /* junitResult1.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = junitResult1.xml; sourceTree = "<group>"; };
 		1DD70E291A4B50E500000000 /* FBSimulatorControl.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = FBSimulatorControl.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1DD70E291A4B50E500000001 /* FBSimulatorControl.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = FBSimulatorControl.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2229,6 +2233,8 @@
 				EE12775E1C9338D700DE52A1 /* FBTestManagerAPIMediator.m */,
 				AA46BF5E1D6DDC6A00C41DAF /* FBTestManagerContext.h */,
 				AA46BF5F1D6DDC6A00C41DAF /* FBTestManagerContext.m */,
+				05E1E34C1E3DBA87004F67B8 /* FBTestManagerJUnitGenerator.h */,
+				05E1E34D1E3DBA87004F67B8 /* FBTestManagerJUnitGenerator.m */,
 				AAEB9D951CD3585600151A9E /* FBTestManagerProcessInteractionDelegate.h */,
 				AA7FA7AC1CE0726900614A61 /* FBTestManagerProcessInteractionOperator.h */,
 				AA7FA7AD1CE0726900614A61 /* FBTestManagerProcessInteractionOperator.m */,
@@ -2703,6 +2709,7 @@
 				AA1F2C8A1CEA4176003E0BDE /* XCTestBootstrapFrameworkLoader.h in Headers */,
 				05AC8AFB1D587A8B008B435E /* FBTestManagerTestReporterBase.h in Headers */,
 				AA7414F01CE3102F00C9641D /* FBTestBundleConnection.h in Headers */,
+				05E1E34E1E3DBA87004F67B8 /* FBTestManagerJUnitGenerator.h in Headers */,
 				3E14994C1D4C5D49005A5C8F /* FBTestManagerTestReporterTestCaseFailure.h in Headers */,
 				AA46BF601D6DDC6A00C41DAF /* FBTestManagerContext.h in Headers */,
 				EE4F0D771C91B82700608E89 /* FBProductBundle.h in Headers */,
@@ -3277,6 +3284,7 @@
 				EE62DC611D6C82340031A457 /* FBTestLaunchConfiguration.m in Sources */,
 				EE4F0D7A1C91B82700608E89 /* FBTestBundle.m in Sources */,
 				AA0DC7571CE3A29F0037A8A7 /* FBTestDaemonConnection.m in Sources */,
+				05E1E34F1E3DBA87004F67B8 /* FBTestManagerJUnitGenerator.m in Sources */,
 				EE4F0D851C91B82700608E89 /* FBSimulatorTestPreparationStrategy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/XCTestBootstrap/TestManager/FBTestManagerJUnitGenerator.h
+++ b/XCTestBootstrap/TestManager/FBTestManagerJUnitGenerator.h
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class FBTestManagerTestReporterTestSuite;
+
+/**
+ Transforms a graph of FBTestManagerTestReporterTestSuite objects into
+ an NSXMLDocument representation of the JUnit format.
+ */
+@interface FBTestManagerJUnitGenerator : NSObject
+
+/**
+ Generates JUnit XML document for given test suite.
+
+ @param testSuite the test suite to transform.
+ @return an NSXMLDocument instance.
+ */
++ (NSXMLDocument *)documentForTestSuite:(FBTestManagerTestReporterTestSuite *)testSuite;
+
+/**
+ Generates JUnit XML document for given array of test suite elements.
+
+ @param testSuiteElements the test suite XML element.
+ @return an NSXMLDocument instance.
+ */
++ (NSXMLDocument *)documentForTestSuiteElements:(NSArray<NSXMLElement *> *)testSuiteElements;
+
+/**
+ Generates an XML node for the given Test Suite object and prefixes all Test Case names
+ with the given package prefix.
+
+ @param testSuite the test suite to transform.
+ @param packagePrefix the package prefix to prepend on each test case class name.
+ @return an NSXMLDocument instance.
+ */
++ (NSXMLElement *)elementForTestSuite:(FBTestManagerTestReporterTestSuite *)testSuite packagePrefix:(nullable NSString *)packagePrefix;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/XCTestBootstrap/TestManager/FBTestManagerJUnitGenerator.m
+++ b/XCTestBootstrap/TestManager/FBTestManagerJUnitGenerator.m
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBTestManagerJUnitGenerator.h"
+#import "FBTestManagerResultSummary.h"
+#import "FBTestManagerTestReporterTestCase.h"
+#import "FBTestManagerTestReporterTestCaseFailure.h"
+#import "FBTestManagerTestReporterTestSuite.h"
+
+@implementation FBTestManagerJUnitGenerator
+
+#pragma mark - JUnit XML Generator
+
++ (NSXMLDocument *)documentForTestSuite:(FBTestManagerTestReporterTestSuite *)testSuite
+{
+    return [self documentForTestSuiteElements:@[[self elementForTestSuite:testSuite packagePrefix:nil]]];
+}
+
++ (NSXMLDocument *)documentForTestSuiteElements:(NSArray<NSXMLElement *> *)testSuiteElements
+{
+  NSXMLElement *testSuitesElement = [NSXMLElement elementWithName:@"testsuites"];
+  for (NSXMLElement *testSuiteElement in testSuiteElements) {
+    [testSuitesElement addChild:testSuiteElement];
+  }
+  NSXMLDocument *document = [NSXMLDocument documentWithRootElement:testSuitesElement];
+  document.version = @"1.0";
+  document.standalone = YES;
+  document.characterEncoding = @"UTF-8";
+  return document;
+}
+
++ (NSXMLElement *)elementForTestSuite:(FBTestManagerTestReporterTestSuite *)testSuite packagePrefix:(NSString *)packagePrefix
+{
+  NSXMLElement *testSuiteElement = [NSXMLElement elementWithName:@"testsuite"];
+
+  NSString *runCount = @(testSuite.summary.runCount).stringValue;
+  NSString *failureCount = @(testSuite.summary.failureCount).stringValue;
+  NSString *errorCount = @(testSuite.summary.unexpected).stringValue;
+  NSString *duration = @(testSuite.summary.totalDuration).stringValue;
+
+  [testSuiteElement addAttribute:[NSXMLNode attributeWithName:@"tests" stringValue:runCount]];
+  [testSuiteElement addAttribute:[NSXMLNode attributeWithName:@"failures" stringValue:failureCount]];
+  [testSuiteElement addAttribute:[NSXMLNode attributeWithName:@"errors" stringValue:errorCount]];
+  [testSuiteElement addAttribute:[NSXMLNode attributeWithName:@"time" stringValue:duration]];
+  [testSuiteElement addAttribute:[NSXMLNode attributeWithName:@"name" stringValue:testSuite.name]];
+
+  for (FBTestManagerTestReporterTestCase *testCase in testSuite.testCases) {
+    [testSuiteElement addChild:[self elementForTestCase:testCase packagePrefix:packagePrefix]];
+  }
+
+  for (FBTestManagerTestReporterTestSuite *nestedTestSuite in testSuite.testSuites) {
+    [testSuiteElement addChild:[self elementForTestSuite:nestedTestSuite packagePrefix:packagePrefix]];
+  }
+
+  return testSuiteElement;
+}
+
+#pragma mark - Private
+
++ (NSString *)classNameForTestCase:(FBTestManagerTestReporterTestCase *)testCase packagePrefix:(NSString *)packagePrefix
+{
+  if (!packagePrefix.length) {
+    return testCase.testClass;
+  }
+  return [NSString stringWithFormat:@"%@.%@", packagePrefix, testCase.testClass];
+}
+
++ (NSXMLElement *)elementForTestCase:(FBTestManagerTestReporterTestCase *)testCase packagePrefix:(NSString *)packagePrefix
+{
+  NSXMLElement *testCaseElement = [NSXMLElement elementWithName:@"testcase"];
+  [testCaseElement addAttribute:[NSXMLNode attributeWithName:@"classname" stringValue:[self classNameForTestCase:testCase packagePrefix:packagePrefix]]];
+  [testCaseElement addAttribute:[NSXMLNode attributeWithName:@"name" stringValue:testCase.method]];
+  [testCaseElement addAttribute:[NSXMLNode attributeWithName:@"time" stringValue:@(testCase.duration).stringValue]];
+  for (FBTestManagerTestReporterTestCaseFailure *testCaseFailure in testCase.failures) {
+    [testCaseElement addChild:[self elementForTestCaseFailure:testCaseFailure]];
+  }
+  return testCaseElement;
+}
+
++ (NSXMLElement *)elementForTestCaseFailure:(FBTestManagerTestReporterTestCaseFailure *)testCaseFailure
+{
+  NSString *failure = [NSString stringWithFormat:@"%@:%zd", testCaseFailure.file, testCaseFailure.line];
+  NSXMLElement *testCaseFailureElement = [NSXMLElement elementWithName:@"failure" stringValue:failure];
+  [testCaseFailureElement addAttribute:[NSXMLNode attributeWithName:@"type" stringValue:@"Failure"]];
+  [testCaseFailureElement addAttribute:[NSXMLNode attributeWithName:@"message" stringValue:testCaseFailure.message]];
+  return testCaseFailureElement;
+}
+
+@end

--- a/XCTestBootstrap/TestManager/FBTestManagerTestReporterJUnit.m
+++ b/XCTestBootstrap/TestManager/FBTestManagerTestReporterJUnit.m
@@ -8,10 +8,7 @@
  */
 
 #import "FBTestManagerTestReporterJUnit.h"
-#import "FBTestManagerResultSummary.h"
-#import "FBTestManagerTestReporterTestCase.h"
-#import "FBTestManagerTestReporterTestCaseFailure.h"
-#import "FBTestManagerTestReporterTestSuite.h"
+#import "FBTestManagerJUnitGenerator.h"
 
 @interface FBTestManagerTestReporterJUnit ()
 
@@ -44,68 +41,8 @@
 {
   [super testManagerMediatorDidFinishExecutingTestPlan:mediator];
 
-  NSXMLDocument *document = [FBTestManagerTestReporterJUnit documentForTestSuite:self.testSuite];
+  NSXMLDocument *document = [FBTestManagerJUnitGenerator documentForTestSuite:self.testSuite];
   [[document XMLDataWithOptions:NSXMLNodePrettyPrint] writeToURL:self.outputFileURL atomically:YES];
-}
-
-#pragma mark - JUnit XML Generator
-
-+ (NSXMLDocument *)documentForTestSuite:(FBTestManagerTestReporterTestSuite *)testSuite
-{
-  NSXMLElement *testSuiteElement = [NSXMLElement elementWithName:@"testsuites"];
-  [testSuiteElement addChild:[self elementForTestSuite:testSuite]];
-  NSXMLDocument *document = [NSXMLDocument documentWithRootElement:testSuiteElement];
-  document.version = @"1.0";
-  document.standalone = YES;
-  document.characterEncoding = @"UTF-8";
-  return document;
-}
-
-+ (NSXMLElement *)elementForTestCase:(FBTestManagerTestReporterTestCase *)testCase
-{
-  NSXMLElement *testCaseElement = [NSXMLElement elementWithName:@"testcase"];
-  [testCaseElement addAttribute:[NSXMLNode attributeWithName:@"classname" stringValue:testCase.testClass]];
-  [testCaseElement addAttribute:[NSXMLNode attributeWithName:@"name" stringValue:testCase.method]];
-  [testCaseElement addAttribute:[NSXMLNode attributeWithName:@"time" stringValue:@(testCase.duration).stringValue]];
-  for (FBTestManagerTestReporterTestCaseFailure *testCaseFailure in testCase.failures) {
-    [testCaseElement addChild:[self elementForTestCaseFailure:testCaseFailure]];
-  }
-  return testCaseElement;
-}
-
-+ (NSXMLElement *)elementForTestCaseFailure:(FBTestManagerTestReporterTestCaseFailure *)testCaseFailure
-{
-  NSString *failure = [NSString stringWithFormat:@"%@:%zd", testCaseFailure.file, testCaseFailure.line];
-  NSXMLElement *testCaseFailureElement = [NSXMLElement elementWithName:@"failure" stringValue:failure];
-  [testCaseFailureElement addAttribute:[NSXMLNode attributeWithName:@"type" stringValue:@"Failure"]];
-  [testCaseFailureElement addAttribute:[NSXMLNode attributeWithName:@"message" stringValue:testCaseFailure.message]];
-  return testCaseFailureElement;
-}
-
-+ (NSXMLElement *)elementForTestSuite:(FBTestManagerTestReporterTestSuite *)testSuite
-{
-  NSXMLElement *testSuiteElement = [NSXMLElement elementWithName:@"testsuite"];
-
-  NSString *runCount = @(testSuite.summary.runCount).stringValue;
-  NSString *failureCount = @(testSuite.summary.failureCount).stringValue;
-  NSString *errorCount = @(testSuite.summary.unexpected).stringValue;
-  NSString *duration = @(testSuite.summary.totalDuration).stringValue;
-
-  [testSuiteElement addAttribute:[NSXMLNode attributeWithName:@"tests" stringValue:runCount]];
-  [testSuiteElement addAttribute:[NSXMLNode attributeWithName:@"failures" stringValue:failureCount]];
-  [testSuiteElement addAttribute:[NSXMLNode attributeWithName:@"errors" stringValue:errorCount]];
-  [testSuiteElement addAttribute:[NSXMLNode attributeWithName:@"time" stringValue:duration]];
-  [testSuiteElement addAttribute:[NSXMLNode attributeWithName:@"name" stringValue:testSuite.name]];
-
-  for (FBTestManagerTestReporterTestCase *testCase in testSuite.testCases) {
-    [testSuiteElement addChild:[self elementForTestCase:testCase]];
-  }
-
-  for (FBTestManagerTestReporterTestSuite *nestedTestSuite in testSuite.testSuites) {
-    [testSuiteElement addChild:[self elementForTestSuite:nestedTestSuite]];
-  }
-
-  return testSuiteElement;
 }
 
 @end

--- a/XCTestBootstrap/XCTestBootstrap.h
+++ b/XCTestBootstrap/XCTestBootstrap.h
@@ -17,6 +17,7 @@
 #import <XCTestBootstrap/FBTestLaunchConfiguration.h>
 #import <XCTestBootstrap/FBTestManager.h>
 #import <XCTestBootstrap/FBTestManagerAPIMediator.h>
+#import <XCTestBootstrap/FBTestManagerJUnitGenerator.h>
 #import <XCTestBootstrap/FBTestManagerProcessInteractionDelegate.h>
 #import <XCTestBootstrap/FBTestManagerResult.h>
 #import <XCTestBootstrap/FBTestManagerResultSummary.h>


### PR DESCRIPTION
Extracting the JUnit XML document generator into a separate method makes
it possible to merge together several test suites into one single graph
of test suites. It also adds the option to sort them into groups using a
package prefix. Unfortunately the JUnit parser on Jenkins does not
directly use the package attribute, instead the classname attribute must
have a Java-style package prefix (e.g. com.facebook.FBTestCase).