### PR TITLE
Don't wait for 'medialibraryd' when booting iOS 8 devices

### DIFF
--- a/FBSimulatorControl/Strategies/FBSimulatorBootStrategy.m
+++ b/FBSimulatorControl/Strategies/FBSimulatorBootStrategy.m
@@ -421,8 +421,9 @@
 - (NSArray<NSString *> *)requiredLaunchdServicesToVerifyBooted
 {
   FBControlCoreProductFamily family = self.simulator.productFamily;
+  id<FBControlCoreGlobalConfiguration_OS> version = self.simulator.osConfiguration;
   if (family == FBControlCoreProductFamilyiPhone || family == FBControlCoreProductFamilyiPad) {
-    if (FBControlCoreGlobalConfiguration.isXcode8OrGreater) {
+    if (FBControlCoreGlobalConfiguration.isXcode8OrGreater && [[version versionNumber] doubleValue] >= 9.0) {
       return @[
         @"com.apple.backboardd",
         @"com.apple.medialibraryd",

--- a/FBSimulatorControlTests/Tests/Integration/FBSimulatorLaunchTests.m
+++ b/FBSimulatorControlTests/Tests/Integration/FBSimulatorLaunchTests.m
@@ -79,6 +79,13 @@
   [self testLaunchesSingleSimulator:FBSimulatorConfiguration.iPhone5.iOS_9_3];
 }
 
+- (void)testLaunchesiOSVersion8AndAwaitsServices
+{
+  FBSimulatorBootOptions options = self.simulatorLaunchConfiguration.options | FBSimulatorBootOptionsAwaitServices;
+  self.simulatorLaunchConfiguration = [self.simulatorLaunchConfiguration withOptions:options];
+  [self testLaunchesSingleSimulator:FBSimulatorConfiguration.iPhone5.iOS_8_3];
+}
+
 - (void)testLaunchesMultipleSimulators
 {
   // Simulator Pool management is single threaded since it relies on unsynchronised mutable state


### PR DESCRIPTION
Fixes issue #368.

I've added a test that checks iOS 8 can be booted successfully, but I'm not sure how you ensure which iOS versions are available in the test environment.