### PR TITLE
Xcode 8.3 compatibility: load required swift dylibs before loading private frameworks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ fbsimctl/cli-tests/supports_metal
 
 output/
 .clang-format
+
+## AppCode
+.idea

--- a/FBControlCore/FBControlCore.h
+++ b/FBControlCore/FBControlCore.h
@@ -68,6 +68,7 @@
 #import <FBControlCore/FBTerminationHandle.h>
 #import <FBControlCore/FBTestLaunchConfiguration.h>
 #import <FBControlCore/FBVideoRecordingCommands.h>
+#import <FBControlCore/FBDependentDylib+ApplePrivateDylibs.h>
 #import <FBControlCore/FBDependentDylib.h>
 #import <FBControlCore/FBWeakFramework+ApplePrivateFrameworks.h>
 #import <FBControlCore/FBWeakFrameworkLoader.h>

--- a/FBControlCore/FBControlCore.h
+++ b/FBControlCore/FBControlCore.h
@@ -68,6 +68,7 @@
 #import <FBControlCore/FBTerminationHandle.h>
 #import <FBControlCore/FBTestLaunchConfiguration.h>
 #import <FBControlCore/FBVideoRecordingCommands.h>
+#import <FBControlCore/FBDependentDylib.h>
 #import <FBControlCore/FBWeakFramework+ApplePrivateFrameworks.h>
 #import <FBControlCore/FBWeakFrameworkLoader.h>
 #import <FBControlCore/FBXCTestCommands.h>

--- a/FBControlCore/Utility/FBDependentDylib+ApplePrivateDylibs.h
+++ b/FBControlCore/Utility/FBDependentDylib+ApplePrivateDylibs.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <FBControlCore/FBDependentDylib.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Creates FBDependentDylib that represents private Apple dylibs that are
+ required by ControlCore.
+ */
+@interface FBDependentDylib (ApplePrivateDylibs)
+
+/**
+ Swift dylibs required by some versions of Xcode.
+ */
++ (NSArray<FBDependentDylib *> *)SwiftDylibs;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FBControlCore/Utility/FBDependentDylib+ApplePrivateDylibs.m
+++ b/FBControlCore/Utility/FBDependentDylib+ApplePrivateDylibs.m
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBDependentDylib+ApplePrivateDylibs.h"
+#import "FBControlCoreGlobalConfiguration.h"
+
+@implementation FBDependentDylib (ApplePrivateDylibs)
+
++ (NSArray<FBDependentDylib *> *)SwiftDylibs
+{
+
+  // Starting in Xcode 8.3, IDEFoundation.framework requires Swift libraries to be loaded
+  // prior to loading the framework itself.
+  //
+  // You can inspect what libraries are loaded and in what order using:
+  //
+  // $ xcrun otool -l Xcode.app/Contents/Frameworks/IDEFoundation.framework
+  //
+  // The minimum macOS version for Xcode 8.3 is Sierra 10.12 so there is no need to
+  // branch on the macOS version.
+  //
+  // The order matters!  The first swift dylib loaded by IDEFoundation.framework is
+  // AppKit.  However, AppKit requires CoreImage and QuartzCore to be loaded first.
+
+  NSDecimalNumber *xcodeVersion = [FBControlCoreGlobalConfiguration xcodeVersionNumber];
+  NSDecimalNumber *xcode83 = [NSDecimalNumber decimalNumberWithString:@"8.3"];
+  BOOL atLeastXcode83 = [xcodeVersion compare:xcode83] != NSOrderedAscending;
+
+  if (atLeastXcode83) {
+    return @[
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCoreImage.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftQuartzCore.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftAppKit.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCore.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCoreData.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCoreGraphics.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftDarwin.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftDispatch.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftFoundation.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftIOKit.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftObjectiveC.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftXPC.dylib"]
+             ];
+  } else {
+    // No swift dylibs are required.
+    return @[];
+  }
+}
+
+@end

--- a/FBControlCore/Utility/FBDependentDylib+ApplePrivateDylibs.m
+++ b/FBControlCore/Utility/FBDependentDylib+ApplePrivateDylibs.m
@@ -34,18 +34,18 @@
 
   if (atLeastXcode83) {
     return @[
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCore.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftDarwin.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftObjectiveC.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftDispatch.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftIOKit.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCoreGraphics.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftFoundation.dylib"],
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftXPC.dylib"],
              [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCoreImage.dylib"],
              [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftQuartzCore.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftAppKit.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCore.dylib"],
              [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCoreData.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftCoreGraphics.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftDarwin.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftDispatch.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftFoundation.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftIOKit.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftObjectiveC.dylib"],
-             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftXPC.dylib"]
+             [FBDependentDylib dependentWithRelativePath:@"../Frameworks/libswiftAppKit.dylib"],
              ];
   } else {
     // No swift dylibs are required.

--- a/FBControlCore/Utility/FBDependentDylib.h
+++ b/FBControlCore/Utility/FBDependentDylib.h
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol FBControlCoreLogger;
+
+/**
+ Represents a dylib that FBControlCore is dependent on
+ */
+@interface FBDependentDylib : NSObject
+
+/**
+ Creates and returns FBDependentDylib with the given path.
+
+ @param relativePath a path relative to /path/to/Xcode.app/Contents
+ @return an FBDependentDylib instance
+ */
++ (instancetype)dependentWithRelativePath:(NSString *)relativePath;
+
+
+/**
+ Loads the framework using dlopen.
+
+ @param logger a logger for logging framework loading activities.
+ @param error an error out for any error that occurs.
+ @return YES if successful, NO otherwise.
+ */
+- (BOOL)loadWithLogger:(id<FBControlCoreLogger>)logger error:(NSError **)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FBControlCore/Utility/FBDependentDylib.m
+++ b/FBControlCore/Utility/FBDependentDylib.m
@@ -46,11 +46,12 @@
 {
   NSURL *url = [NSURL fileURLWithPath:self.path];
   const char *cFileSystemRep = [url fileSystemRepresentation];
-  void *handle = dlopen(cFileSystemRep, RTLD_LOCAL|RTLD_LAZY);
+  void *handle = dlopen(cFileSystemRep, RTLD_NOW|RTLD_GLOBAL);
   [logger.debug logFormat:@"Attempting to load: %s", cFileSystemRep];
   if (!handle) {
     NSString *message = [NSString stringWithFormat:@"Could not load dylib %@ with dlopen: %s",
                          self.path, dlerror()];
+    [logger.debug logFormat:@"%@", message];
     return [FBControlCoreError failBoolWithErrorMessage:message
                                                errorOut:error];
   } else {

--- a/FBControlCore/Utility/FBDependentDylib.m
+++ b/FBControlCore/Utility/FBDependentDylib.m
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBDependentDylib.h"
+#import "FBControlCoreError.h"
+#import "FBControlCoreGlobalConfiguration.h"
+#import "FBControlCoreLogger.h"
+#import <dlfcn.h>
+
+@interface FBDependentDylib ()
+
+@property (nonatomic, copy, readonly) NSString *path;
+
+@end
+
+@implementation FBDependentDylib
+
+
+#pragma mark Initializers
+
++ (instancetype)dependentWithRelativePath:(NSString *)relativePath
+{
+  return [[FBDependentDylib alloc] initWithRelativePath:relativePath];
+}
+
+- (instancetype)initWithRelativePath:(NSString *)relativePath
+{
+  self = [super init];
+  if (self) {
+    NSString *developerDirectory = FBControlCoreGlobalConfiguration.developerDirectory;
+    NSString *joined = [developerDirectory stringByAppendingPathComponent:relativePath];
+    _path = [joined stringByStandardizingPath];
+  }
+  return self;
+}
+
+#pragma mark Public
+
+- (BOOL)loadWithLogger:(id<FBControlCoreLogger>)logger error:(NSError **)error
+{
+  NSURL *url = [NSURL fileURLWithPath:self.path];
+  const char *cFileSystemRep = [url fileSystemRepresentation];
+  void *handle = dlopen(cFileSystemRep, RTLD_LOCAL|RTLD_LAZY);
+  [logger.debug logFormat:@"Attempting to load: %s", cFileSystemRep];
+  if (!handle) {
+    NSString *message = [NSString stringWithFormat:@"Could not load dylib %@ with dlopen: %s",
+                         self.path, dlerror()];
+    return [FBControlCoreError failBoolWithErrorMessage:message
+                                               errorOut:error];
+  } else {
+    [logger.debug logFormat:@"Loaded %@", [self.path lastPathComponent]];
+    return YES;
+  }
+}
+
+@end

--- a/FBDeviceControl/Utility/FBDeviceControlFrameworkLoader.m
+++ b/FBDeviceControl/Utility/FBDeviceControlFrameworkLoader.m
@@ -84,6 +84,12 @@ static BOOL hasLoadedXcodeFrameworks = NO;
     return YES;
   }
 
+  for (FBDependentDylib *dylib in FBDependentDylib.SwiftDylibs) {
+    if (![dylib loadWithLogger:logger error:error]) {
+      return NO;
+    }
+  }
+
   NSArray<FBWeakFramework *> *frameworks = FBDeviceControlFrameworkLoader.privateFrameworks;
 
   if (![FBWeakFrameworkLoader loadPrivateFrameworks:frameworks logger:logger error:error]) {

--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -1358,6 +1358,8 @@
 		EEBD60961C908FA200298A07 /* FBJSONConversion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBJSONConversion.h; sourceTree = "<group>"; };
 		EEF4497B1CE0A22200300C9F /* FBXCTestBootstrapFixtures.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBXCTestBootstrapFixtures.h; sourceTree = "<group>"; };
 		EEF4497C1CE0A22200300C9F /* FBXCTestBootstrapFixtures.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXCTestBootstrapFixtures.m; sourceTree = "<group>"; };
+		F550B5901E51D14F006C8CC5 /* FBDependentDylib+ApplePrivateDylibs.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.h; path = "FBDependentDylib+ApplePrivateDylibs.h"; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
+		F550B5911E51D14F006C8CC5 /* FBDependentDylib+ApplePrivateDylibs.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = "FBDependentDylib+ApplePrivateDylibs.m"; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
 		F5ACC7001E51ACD700975101 /* FBDependentDylib.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.h; path = FBDependentDylib.h; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
 		F5ACC7011E51ACD700975101 /* FBDependentDylib.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = FBDependentDylib.m; sourceTree = "<group>"; tabWidth = 2; };
 /* End PBXFileReference section */
@@ -2737,6 +2739,8 @@
 				AABBF31E1DAC0F9400E2B6AF /* FBTerminationHandle.m */,
 				F5ACC7001E51ACD700975101 /* FBDependentDylib.h */,
 				F5ACC7011E51ACD700975101 /* FBDependentDylib.m */,
+				F550B5901E51D14F006C8CC5 /* FBDependentDylib+ApplePrivateDylibs.h */,
+				F550B5911E51D14F006C8CC5 /* FBDependentDylib+ApplePrivateDylibs.m */,
 				EE2EC7AA1CAC3F97009A7BB1 /* FBWeakFramework.h */,
 				EE2EC7AB1CAC3F97009A7BB1 /* FBWeakFramework.m */,
 				EE2EC7AE1CAC5119009A7BB1 /* FBWeakFramework+ApplePrivateFrameworks.h */,
@@ -2983,8 +2987,8 @@
 				EE9E1E4B1D6CB2CC00860830 /* FBProcessLaunchConfiguration+Helpers.h in Headers */,
 				EEBD606A1C9062E900298A07 /* FBDebugDescribeable.h in Headers */,
 				AAF4C4DF1CDBA1A7004F4AF3 /* FBRunLoopSpinner.h in Headers */,
-				F5ACC7021E51ACD700975101 /* FBDependentDylib.h in Headers */,
 				F550B5921E51D14F006C8CC5 /* FBDependentDylib+ApplePrivateDylibs.h in Headers */,
+				F5ACC7021E51ACD700975101 /* FBDependentDylib.h in Headers */,
 				AAB123821DB4B16900F20555 /* FBDispatchSourceNotifier.h in Headers */,
 				AA7728AE1E5238A6008FCF7C /* FBFileWriter.h in Headers */,
 				AA58F8921D959593006F8D81 /* FBCodesignProvider.h in Headers */,
@@ -3560,6 +3564,7 @@
 				AA0080D81DB4CCFD009A25CB /* FBProcessTerminationStrategy.m in Sources */,
 				AA4394E51E731998003532B2 /* FBXCTestCommands.m in Sources */,
 				AABD72A71E64A5DF004D6EBE /* FBTestLaunchConfiguration.m in Sources */,
+				F550B5931E51D14F006C8CC5 /* FBDependentDylib+ApplePrivateDylibs.m in Sources */,
 				EEBD60771C9062E900298A07 /* FBBinaryParser.m in Sources */,
 				AA0F6F2B1CA3DCF700926518 /* FBWeakFrameworkLoader.m in Sources */,
 			);

--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -1150,7 +1150,7 @@
 		AAC8B24D1CEC51520034A865 /* FBDeviceControlError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBDeviceControlError.h; sourceTree = "<group>"; };
 		AAC8B24E1CEC51520034A865 /* FBDeviceControlError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBDeviceControlError.m; sourceTree = "<group>"; };
 		AAC8B24F1CEC51520034A865 /* FBDeviceControlFrameworkLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBDeviceControlFrameworkLoader.h; sourceTree = "<group>"; };
-		AAC8B2501CEC51520034A865 /* FBDeviceControlFrameworkLoader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBDeviceControlFrameworkLoader.m; sourceTree = "<group>"; };
+		AAC8B2501CEC51520034A865 /* FBDeviceControlFrameworkLoader.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = FBDeviceControlFrameworkLoader.m; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
 		AAC8B25B1CEC52540034A865 /* FBDeviceControl.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = FBDeviceControl.xcconfig; sourceTree = "<group>"; };
 		AAC8B2621CEC55370034A865 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		AACA2C351C2976B100979C45 /* FBAddVideoPolyfill.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBAddVideoPolyfill.h; sourceTree = "<group>"; };

--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -490,6 +490,10 @@
 		EEBD60951C908F8500298A07 /* FBCollectionInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = EEBD60931C908F8500298A07 /* FBCollectionInformation.m */; };
 		EEBD60971C908FA200298A07 /* FBJSONConversion.h in Headers */ = {isa = PBXBuildFile; fileRef = EEBD60961C908FA200298A07 /* FBJSONConversion.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EEF4497E1CE0A22200300C9F /* FBXCTestBootstrapFixtures.m in Sources */ = {isa = PBXBuildFile; fileRef = EEF4497C1CE0A22200300C9F /* FBXCTestBootstrapFixtures.m */; };
+		F550B5921E51D14F006C8CC5 /* FBDependentDylib+ApplePrivateDylibs.h in Headers */ = {isa = PBXBuildFile; fileRef = F550B5901E51D14F006C8CC5 /* FBDependentDylib+ApplePrivateDylibs.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F550B5931E51D14F006C8CC5 /* FBDependentDylib+ApplePrivateDylibs.m in Sources */ = {isa = PBXBuildFile; fileRef = F550B5911E51D14F006C8CC5 /* FBDependentDylib+ApplePrivateDylibs.m */; };
+		F5ACC7021E51ACD700975101 /* FBDependentDylib.h in Headers */ = {isa = PBXBuildFile; fileRef = F5ACC7001E51ACD700975101 /* FBDependentDylib.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F5ACC7031E51ACD700975101 /* FBDependentDylib.m in Sources */ = {isa = PBXBuildFile; fileRef = F5ACC7011E51ACD700975101 /* FBDependentDylib.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1354,6 +1358,8 @@
 		EEBD60961C908FA200298A07 /* FBJSONConversion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBJSONConversion.h; sourceTree = "<group>"; };
 		EEF4497B1CE0A22200300C9F /* FBXCTestBootstrapFixtures.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBXCTestBootstrapFixtures.h; sourceTree = "<group>"; };
 		EEF4497C1CE0A22200300C9F /* FBXCTestBootstrapFixtures.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXCTestBootstrapFixtures.m; sourceTree = "<group>"; };
+		F5ACC7001E51ACD700975101 /* FBDependentDylib.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.h; path = FBDependentDylib.h; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
+		F5ACC7011E51ACD700975101 /* FBDependentDylib.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = FBDependentDylib.m; sourceTree = "<group>"; tabWidth = 2; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2728,6 +2734,9 @@
 				AAD0DE011CEB064200C28B58 /* FBSubstringUtilities.h */,
 				AAD0DE021CEB064200C28B58 /* FBSubstringUtilities.m */,
 				AABBF31D1DAC0F9400E2B6AF /* FBTerminationHandle.h */,
+				AABBF31E1DAC0F9400E2B6AF /* FBTerminationHandle.m */,
+				F5ACC7001E51ACD700975101 /* FBDependentDylib.h */,
+				F5ACC7011E51ACD700975101 /* FBDependentDylib.m */,
 				EE2EC7AA1CAC3F97009A7BB1 /* FBWeakFramework.h */,
 				EE2EC7AB1CAC3F97009A7BB1 /* FBWeakFramework.m */,
 				EE2EC7AE1CAC5119009A7BB1 /* FBWeakFramework+ApplePrivateFrameworks.h */,
@@ -2974,6 +2983,8 @@
 				EE9E1E4B1D6CB2CC00860830 /* FBProcessLaunchConfiguration+Helpers.h in Headers */,
 				EEBD606A1C9062E900298A07 /* FBDebugDescribeable.h in Headers */,
 				AAF4C4DF1CDBA1A7004F4AF3 /* FBRunLoopSpinner.h in Headers */,
+				F5ACC7021E51ACD700975101 /* FBDependentDylib.h in Headers */,
+				F550B5921E51D14F006C8CC5 /* FBDependentDylib+ApplePrivateDylibs.h in Headers */,
 				AAB123821DB4B16900F20555 /* FBDispatchSourceNotifier.h in Headers */,
 				AA7728AE1E5238A6008FCF7C /* FBFileWriter.h in Headers */,
 				AA58F8921D959593006F8D81 /* FBCodesignProvider.h in Headers */,
@@ -3531,6 +3542,7 @@
 				EEBD60831C9062E900298A07 /* FBControlCoreLogger.m in Sources */,
 				AAE4D05D1D99972B0098A71E /* FBFileManager.m in Sources */,
 				EEBD60791C9062E900298A07 /* FBCapacityQueue.m in Sources */,
+				F5ACC7031E51ACD700975101 /* FBDependentDylib.m in Sources */,
 				AA6A3B0A1CC0C96E00E016C4 /* FBCollectionOperations.m in Sources */,
 				AA9AAAEC1DE4C3F60056B127 /* FBProcessOutputConfiguration.m in Sources */,
 				EEBD605E1C9062E900298A07 /* FBCrashLogInfo.m in Sources */,

--- a/build.sh
+++ b/build.sh
@@ -240,6 +240,9 @@ Supported Commands:
     Build the xctest exectutable. Optionally copies the executable and it's dependencies to <output-directory>
   fbxctest test
     Builds the FBXCTestKit.framework and runs the tests.
+  fbdevicectl test
+    Builds the FBDeviceControl.framework and runs the tests.
+
 EOF
 }
 
@@ -311,6 +314,14 @@ case $TARGET in
       test)
         build_test_deps
         cli_framework_test fbxctest;;
+      *)
+        echo "Unknown Command $COMMAND"
+        exit 1;;
+    esac;;
+  fbdevicectl)
+    case $COMMAND in
+      test)
+        device_framework_test;;
       *)
         echo "Unknown Command $COMMAND"
         exit 1;;


### PR DESCRIPTION
**FORCE PUSHED** Thu Apr 13 09:49 Central European time

### Motivation

* Resolves **Missing Framework libswiftAppKit.dylib in Xcode 8.3** #375
* adds new build.sh command: `fbdevicectl test`
* add `.idea` to git ignore

Tested against Xcode 8.3 and 8.3.1

### Tests

Without this patch:

- [x] Xcode 8.0
- [x] Xcode 8.1
- [x] Xcode 8.2.1
- [x] Xcode 8.3 **FAILED**
- [x] Xcode 8.3.1 **FAILED**

With this patch:

- [x] Xcode 8.0
- [x] Xcode 8.1
- [x] Xcode 8.2.1
- [x] Xcode 8.3
- [x] Xcode 8.3.1

```
$ DEVELOPER_DIR=/Xcode/8.0/Xcode.app/Contents/Developer build.sh fbdevicectl test
$ DEVELOPER_DIR=/Xcode/8.1/Xcode.app/Contents/Developer build.sh fbdevicectl test
$ DEVELOPER_DIR=/Xcode/8.2.1/Xcode.app/Contents/Developer build.sh fbdevicectl test
$ DEVELOPER_DIR=/Xcode/8.3/Xcode.app/Contents/Developer build.sh fbdevicectl test
$ DEVELOPER_DIR=/Xcode/8.3.1/Xcode.app/Contents/Developer build.sh fbdevicectl test
```
