### PR TITLE
Change FBXCTestRunStrategy startTestManager interface

### DIFF
--- a/FBSimulatorControl/Strategies/FBSimulatorTestRunStrategy.m
+++ b/FBSimulatorControl/Strategies/FBSimulatorTestRunStrategy.m
@@ -82,8 +82,7 @@
     logger:simulator.logger];
 
   FBTestManager *testManager = [testRunStrategy
-    startTestManagerWithAttributes:self.configuration.applicationLaunchConfiguration.arguments
-    environment:self.configuration.applicationLaunchConfiguration.environment
+    startTestManagerWithApplicationLaunchConfiguration:self.configuration.applicationLaunchConfiguration
     error:&innerError];
 
   if (!testManager) {

--- a/XCTestBootstrap/Strategies/FBXCTestRunStrategy.h
+++ b/XCTestBootstrap/Strategies/FBXCTestRunStrategy.h
@@ -11,6 +11,7 @@
 
 #import <FBControlCore/FBControlCoreLogger.h>
 
+@class FBApplicationLaunchConfiguration;
 @class FBTestManager;
 @protocol FBXCTestPreparationStrategy;
 @protocol FBiOSTarget;
@@ -37,12 +38,11 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Starts testing session
 
- @param attributes additional attributes used to start test runner
- @param environment additional environment used to start test runner
+ @param applicationLaunchConfiguration application launch configuration used to start test runner
  @param error If there is an error, upon return contains an NSError object that describes the problem.
  @return testManager if the operation succeeds, otherwise nil.
  */
-- (nullable FBTestManager *)startTestManagerWithAttributes:(NSArray<NSString *> *)attributes environment:(NSDictionary<NSString *, NSString *> *)environment error:(NSError **)error;
+- (nullable FBTestManager *)startTestManagerWithApplicationLaunchConfiguration:(FBApplicationLaunchConfiguration *)applicationLaunchConfiguration error:(NSError **)error;
 
 @end
 

--- a/XCTestBootstrapTests/Tests/FBXCTestRunStrategyTests.m
+++ b/XCTestBootstrapTests/Tests/FBXCTestRunStrategyTests.m
@@ -15,6 +15,7 @@
 
 @interface FBXCTestRunStrategyTests : XCTestCase
 
+@property (nonatomic, strong, readwrite) FBApplicationLaunchConfiguration *applicationLaunchConfiguration;
 @property (nonatomic, strong, readwrite) OCMockObject *testManagerMock;
 
 @end
@@ -25,6 +26,7 @@
 {
   [super setUp];
 
+  self.applicationLaunchConfiguration = [FBApplicationLaunchConfiguration configurationWithBundleID:@"com.foo.Bar" bundleName:@"Bar" arguments:@[] environment:@{} output:FBProcessOutputConfiguration.outputToDevNull];
   self.testManagerMock = [OCMockObject niceMockForClass:FBTestManager.class];
   [[[self.testManagerMock stub] andReturn:self.testManagerMock] testManagerWithContext:OCMArg.any iosTarget:OCMArg.any reporter:OCMArg.any logger:OCMArg.any];
   [[[[self.testManagerMock stub] ignoringNonObjectArgs] andReturn:nil] connectWithTimeout:0];
@@ -41,7 +43,7 @@
 {
   id prepareTestMock = [OCMockObject niceMockForProtocol:@protocol(FBXCTestPreparationStrategy)];
   FBXCTestRunStrategy *strategy = [FBXCTestRunStrategy strategyWithIOSTarget:[OCMockObject niceMockForProtocol:@protocol(FBiOSTarget)] testPrepareStrategy:prepareTestMock reporter:nil logger:nil];
-  XCTAssertNoThrow([strategy startTestManagerWithAttributes:@[] environment:@{} error:nil]);
+  XCTAssertNoThrow([strategy startTestManagerWithApplicationLaunchConfiguration:self.applicationLaunchConfiguration error:nil]);
 }
 
 - (void)testCallToTestPreparationStep
@@ -49,7 +51,7 @@
   OCMockObject<FBXCTestPreparationStrategy> *prepareTestMock = [OCMockObject mockForProtocol:@protocol(FBXCTestPreparationStrategy)];
   [[prepareTestMock expect] prepareTestWithIOSTarget:[OCMArg any] error:[OCMArg anyObjectRef]];
   FBXCTestRunStrategy *strategy = [FBXCTestRunStrategy strategyWithIOSTarget:[OCMockObject niceMockForProtocol:@protocol(FBiOSTarget)] testPrepareStrategy:prepareTestMock reporter:nil logger:nil];
-  XCTAssertNoThrow([strategy startTestManagerWithAttributes:@[] environment:@{} error:nil]);
+  XCTAssertNoThrow([strategy startTestManagerWithApplicationLaunchConfiguration:self.applicationLaunchConfiguration error:nil]);
   [prepareTestMock verify];
 }
 
@@ -81,7 +83,7 @@
   [[[prepareTestMock stub] andReturn:testConfigurationMock] prepareTestWithIOSTarget:[OCMArg any] error:[OCMArg anyObjectRef]];
 
   FBXCTestRunStrategy *strategy = [FBXCTestRunStrategy strategyWithIOSTarget:iosTargetMock testPrepareStrategy:prepareTestMock reporter:nil logger:nil];
-  XCTAssertTrue([strategy startTestManagerWithAttributes:@[] environment:@{@"A" : @"B"} error:nil]);
+  XCTAssertTrue([strategy startTestManagerWithApplicationLaunchConfiguration:[self.applicationLaunchConfiguration withEnvironment:@{@"A" : @"B"}] error:nil]);
   [iosTargetMock verify];
   [deviceOperatorMock verify];
 }
@@ -91,7 +93,7 @@
   OCMockObject<FBiOSTarget> *iosTargetMock = [OCMockObject niceMockForProtocol:@protocol(FBiOSTarget)];
   id prepareTestMock = [OCMockObject niceMockForProtocol:@protocol(FBXCTestPreparationStrategy)];
   FBXCTestRunStrategy *strategy = [FBXCTestRunStrategy strategyWithIOSTarget:iosTargetMock testPrepareStrategy:prepareTestMock reporter:nil logger:nil];
-  XCTAssertFalse([strategy startTestManagerWithAttributes:@[] environment:@{} error:nil]);
+  XCTAssertFalse([strategy startTestManagerWithApplicationLaunchConfiguration:self.applicationLaunchConfiguration error:nil]);
   [iosTargetMock verify];
 }
 


### PR DESCRIPTION
Change interface of `-[FBXCTestRunStrategy startTestManager...]` to take some `FBApplicationLaunchConfiguration` instead of some arguments array and environment dictionary. This fixes using the attached `FBProcessOutputConfiguration` instead of defaulting to `FBProcessOutputConfiguration.outputToDevNull`.