### PR TITLE
FBSimulatorBootStrategy: don't wait for medialibraryd on iOS < 9

### DIFF
--- a/FBSimulatorControl/Strategies/FBSimulatorBootStrategy.m
+++ b/FBSimulatorControl/Strategies/FBSimulatorBootStrategy.m
@@ -423,20 +423,23 @@
   FBControlCoreProductFamily family = self.simulator.productFamily;
   if (family == FBControlCoreProductFamilyiPhone || family == FBControlCoreProductFamilyiPad) {
     if (FBControlCoreGlobalConfiguration.isXcode8OrGreater) {
-      return @[
-        @"com.apple.backboardd",
-        @"com.apple.medialibraryd",
-        @"com.apple.mobile.installd",
-        @"com.apple.SimulatorBridge",
-        @"com.apple.SpringBoard",
-      ];
+        NSArray *xcode8Services = @[@"com.apple.backboardd",
+                                    @"com.apple.mobile.installd",
+                                    @"com.apple.SimulatorBridge",
+                                    @"com.apple.SpringBoard"];
+
+        NSDecimalNumber *simulatorVersion = self.simulator.osConfiguration.versionNumber;
+        NSDecimalNumber *iOS9 = [NSDecimalNumber decimalNumberWithString:@"9.0"];
+
+        // medialibraryd does not load on simulators < iOS 9.
+        if ([simulatorVersion isGreaterThanOrEqualTo:iOS9]) {
+            NSMutableArray *mutable = [NSMutableArray arrayWithArray:xcode8Services];
+            [mutable insertObject:@"com.apple.medialibraryd" atIndex:1];
+            xcode8Services = [NSArray arrayWithArray:mutable];
+        }
+
+        return xcode8Services;
     }
-    return @[
-      @"com.apple.backboardd",
-      @"com.apple.mobile.installd",
-      @"com.apple.SimulatorBridge",
-      @"com.apple.SpringBoard",
-    ];
   }
   if (family == FBControlCoreProductFamilyAppleWatch || family == FBControlCoreProductFamilyAppleTV) {
     if (FBControlCoreGlobalConfiguration.isXcode8OrGreater) {

--- a/FBSimulatorControlTests/Tests/Integration/FBSimulatorLaunchTests.m
+++ b/FBSimulatorControlTests/Tests/Integration/FBSimulatorLaunchTests.m
@@ -79,6 +79,13 @@
   [self testLaunchesSingleSimulator:FBSimulatorConfiguration.iPhone5.iOS_9_3];
 }
 
+- (void)testLaunchesiOSVersion8AndAwaitsServices
+{
+  FBSimulatorBootOptions options = self.simulatorLaunchConfiguration.options | FBSimulatorBootOptionsAwaitServices;
+  self.simulatorLaunchConfiguration = [self.simulatorLaunchConfiguration withOptions:options];
+  [self testLaunchesSingleSimulator:FBSimulatorConfiguration.iPhone5.iOS_8_3];
+}
+
 - (void)testLaunchesMultipleSimulators
 {
   // Simulator Pool management is single threaded since it relies on unsynchronised mutable state


### PR DESCRIPTION
### Motivation

medialibraryd never runs on iOS Simulator < 9.0

Based off work done by @dig412 in pull-request:

* Don't wait for 'medialibraryd' when booting iOS 8 devices #371

The original PR has been open for over a month with no response.
