### PR TITLE
Make FBJSONTestReporter take a FBFileConsumer–conforming object for file writing

### DIFF
--- a/fbxctest/FBXCTestKit/Configuration/FBXCTestConfiguration.m
+++ b/fbxctest/FBXCTestKit/Configuration/FBXCTestConfiguration.m
@@ -153,7 +153,8 @@
     self.shims = shimConfiguration;
   }
   if (!self.reporter) {
-    self.reporter = [[FBJSONTestReporter new] initWithTestBundlePath:_testBundlePath testType:self.testType];
+    FBFileWriter *stdOutFileWriter = [FBFileWriter writerWithFileHandle:NSFileHandle.fileHandleWithStandardOutput blocking:YES];
+    self.reporter = [[FBJSONTestReporter new] initWithTestBundlePath:_testBundlePath testType:self.testType fileConsumer:stdOutFileWriter];
   }
   if (testFilter != nil) {
     NSString *expectedPrefix = [self.testBundlePath stringByAppendingString:@":"];
@@ -163,7 +164,8 @@
     self.testFilter = [testFilter substringFromIndex:expectedPrefix.length];
   }
   if (!self.reporter) {
-    self.reporter = [[FBJSONTestReporter new] initWithTestBundlePath:_testBundlePath testType:self.testType];
+    FBFileWriter *stdOutFileWriter = [FBFileWriter writerWithFileHandle:NSFileHandle.fileHandleWithStandardOutput blocking:YES];
+    self.reporter = [[FBJSONTestReporter new] initWithTestBundlePath:_testBundlePath testType:self.testType fileConsumer:stdOutFileWriter];
   }
 
   self.workingDirectory = workingDirectory;

--- a/fbxctest/FBXCTestKit/Reporters/FBJSONTestReporter.h
+++ b/fbxctest/FBXCTestKit/Reporters/FBJSONTestReporter.h
@@ -7,10 +7,11 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#import <FBControlCore/FBFileConsumer.h>
 #import "FBXCTestReporter.h"
 
 @interface FBJSONTestReporter : NSObject <FBXCTestReporter>
 
-- (instancetype)initWithTestBundlePath:(NSString *)testBundlePath testType:(NSString *)testType;
+- (instancetype)initWithTestBundlePath:(NSString *)testBundlePath testType:(NSString *)testType fileConsumer:(id <FBFileConsumer>)fileConsumer;
 
 @end


### PR DESCRIPTION
Addressing #397 in parts. First is to replace the direct writing to `[NSFileHandle fileHandleWithStandardOutput]` with an `FBFileWriter` which does the same, though on a serial queue.