### PR TITLE
DeviceControl: linker tests can be run in any order

### DIFF
--- a/FBDeviceControlTests/Tests/Integration/FBDeviceControlLinkerTests.m
+++ b/FBDeviceControlTests/Tests/Integration/FBDeviceControlLinkerTests.m
@@ -27,10 +27,7 @@
   if (!NSProcessInfo.processInfo.environment[FBControlCoreDebugLogging]) {
     setenv(FBControlCoreDebugLogging.UTF8String, "NO", 1);
   }
-}
 
-- (void)testLinksPrivateFrameworks
-{
   [FBDeviceControlFrameworkLoader initializeEssentialFrameworks];
   [FBDeviceControlFrameworkLoader initializeXCodeFrameworks];
 }


### PR DESCRIPTION
### Reproduce

* Xcode 8.3.3
* macOS Sierra
* At least on physical device attached via USB

    Run this test in FBDeviceControlTests/Tests/Integration/FBDeviceControlLinkerTests.m

```
- (void)testReadsFromMobileDevice
{
  NSArray<FBAMDevice *> *devices = [FBAMDevice allDevices];
  XCTAssertNotNil(devices);
}
```

### Expected

An array of the connected devices.

### Found

```
# EXEC_BAD_ACCESS code=1 address=0x0
FBAMDCreateDeviceList(); 

https://github.com/calabash/FBSimulatorControl/blob/master/FBDeviceControl/Management/FBAMDevice.m#L66
```

### Notes

The problem is that this method: `[FBAMDevice loadFBAMDeviceSymbols];` is never called when the test is run in isolation.

If you run _all_ the tests in this file, then this test passes because a previous test calls methods that load the AMDevice symbols.  If you change the name of the test to `testAAA`, then this test will run first and it will fail.

Moving the load methods out of a test and into the initialize method seems like an acceptable solution.

### Test

I cannot run any of the DeviceControl tests on facebook/FBSimulatorControl master because of Swift dylib loading problems. 
