### PR TITLE
Expose 'list_apps' on HTTP Server

### DIFF
--- a/fbsimctl/FBSimulatorControlKit/Sources/HttpRelay.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/HttpRelay.swift
@@ -396,6 +396,10 @@ class HttpRelay : Relay {
     return ActionRoute.getConstant(.list, action: Action.list)
   }}
 
+  fileprivate static var listAppsRoute: Route { get {
+    return ActionRoute.getConstant(.listApps, action: Action.listApps)
+  }}
+
   fileprivate static var openRoute: Route { get {
     return ActionRoute.post(.open) { json in
       let urlString = try json.getValue("url").getString()
@@ -485,6 +489,7 @@ class HttpRelay : Relay {
       self.installRoute,
       self.launchRoute,
       self.listRoute,
+      self.listAppsRoute,
       self.openRoute,
       self.recordRoute,
       self.relaunchRoute,


### PR DESCRIPTION
Summary: Exposes the 'list_apps' action on the HTTP Server so that it can be used remotely.