### PR TITLE
Fix Segmentation Fault in listApps over HTTP

### DIFF
--- a/FBControlCore/Applications/FBInstalledApplication.h
+++ b/FBControlCore/Applications/FBInstalledApplication.h
@@ -85,7 +85,7 @@ extern FBApplicationInstallInfoKey const FBApplicationInstallInfoKeyBundleIdenti
 /**
  The data container path of the Application.
  */
-@property (nonatomic, assign, nullable, readonly) NSString *dataContainer;
+@property (nonatomic, copy, nullable, readonly) NSString *dataContainer;
 
 #pragma mark Install Type
 


### PR DESCRIPTION
Summary: Calling `listApps` over HTTP was failing with segfaul due to `dataContainer` being defined as `assign` property.